### PR TITLE
unit_test: fix option name

### DIFF
--- a/installation/unit_tests.md
+++ b/installation/unit_tests.md
@@ -25,7 +25,7 @@ By default [Fluent Bit](http://fluentbit.io) have the tests disabled, you need t
 
 ```bash
 $ cd build/
-$ cmake -DENABLE_TESTS=ON ../
+$ cmake -DFLB_TESTS=ON ../
 ```
 
 ## Running Tests


### PR DESCRIPTION
I fixed unit_test.md to support new option format "FLB_TESTS".

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>