### PR TITLE
input: add title of in_random to README.md of input

### DIFF
--- a/input/README.md
+++ b/input/README.md
@@ -11,7 +11,7 @@ The _input plugins_ defines the source from where [Fluent Bit](http://fluentbit.
 | [kmsg](kmsg.md)       | Kernel Log Buffer | read the Linux Kernel log buffer messages.|
 | [mem](mem.md)         | Memory Usage | measure the total amount of memory used on the system.|
 | [mqtt](mqtt.md)       | MQTT | start a MQTT server and receive publish messages. |
-| [random](random.md)   | Generate Random samples. |
+| [random](random.md)   | Random |Generate Random samples. |
 | [serial](serial.md)   | Serial Interface | read data information from the serial interface.|
 | [stdin](stdin.md)     | Standard Input | read data from the standard input. |
 | [xbee](xbee.md)       | XBee Radio | read data through an XBee Radio device. |


### PR DESCRIPTION
I fixed table of Input plugins.
The title of in_random was blanked.

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>