### PR TITLE
in_head: add description about add_path

### DIFF
--- a/input/head.md
+++ b/input/head.md
@@ -12,6 +12,7 @@ The plugin supports the following configuration parameters:
 | Buf_Size      | Buffer size to read the file. |
 | Interval_Sec  | Polling interval (seconds). |
 | Interval_NSec | Polling interval (nanosecond). |
+| Add_Path      | If enabled, filepath is appended to each records. Default value is _false_. |
 
 ## Getting Started
 


### PR DESCRIPTION
I added explanation of `add_path` which I committed https://github.com/fluent/fluent-bit/pull/140

Signed-off-by: Takahiro YAMASHITA <nokute78@gmail.com>