### PR TITLE
in_proc: add 'mem' and 'fd' options and update sample output

### DIFF
--- a/input/proc.md
+++ b/input/proc.md
@@ -12,6 +12,8 @@ The plugin supports the following configuration parameters:
 | Interval\_Sec| Interval in seconds between the service checks. Default value is _1_. |
 | Internal\_Nsec| Specify a nanoseconds interval for service checks, it works in conjuntion with the Interval\_Sec configuration key. Default value is _0_.|
 | Alert        | If enabled, it will only generate messages if the target process is down. By default this option is disabled.|
+| Fd           | If enabled, a number of fd is appended to each records. Default value is true.|
+| Mem          | If enabled, memory usage of the process is appended to each records. Default value is true.|
 
 ## Getting Started
 
@@ -33,6 +35,8 @@ In your main configuration file append the following _Input_ & _Output_ sections
     Proc_Name     crond
     Interval_Sec  1
     Interval_NSec 0
+    Fd            true
+    Mem           true
 
 [OUTPUT]
     Name   stdout
@@ -44,13 +48,13 @@ In your main configuration file append the following _Input_ & _Output_ sections
 Once Fluent Bit is running, you will see the health of process:
 
 ```bash
-$ fluent-bit -i proc -p proc_name=crond -o stdout
-Fluent-Bit v0.10.0
+$ fluent-bit -i proc -p proc_name=fluent-bit -o stdout
+Fluent-Bit v0.11.0
 Copyright (C) Treasure Data
 
-[2016/12/04 19:14:52] [ info] [engine] started
-[0] proc.0: [1480846493, {"alive"=>true, "proc_name"=>"crond", "pid"=>2425}]
-[1] proc.0: [1480846494, {"alive"=>true, "proc_name"=>"crond", "pid"=>2425}]
-[2] proc.0: [1480846495, {"alive"=>true, "proc_name"=>"crond", "pid"=>2425}]
-[3] proc.0: [1480846496, {"alive"=>true, "proc_name"=>"crond", "pid"=>2425}]
+[2017/01/30 21:44:56] [ info] [engine] started
+[0] proc.0: [1485780297, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>10964, "mem.VmPeak"=>14740000, "mem.VmSize"=>14740000, "mem.VmLck"=>0, "mem.VmHWM"=>1120000, "mem.VmRSS"=>1120000, "mem.VmData"=>2276000, "mem.VmStk"=>88000, "mem.VmExe"=>1768000, "mem.VmLib"=>2328000, "mem.VmPTE"=>68000, "mem.VmSwap"=>0, "fd"=>18}]
+[1] proc.0: [1485780298, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>10964, "mem.VmPeak"=>14740000, "mem.VmSize"=>14740000, "mem.VmLck"=>0, "mem.VmHWM"=>1148000, "mem.VmRSS"=>1148000, "mem.VmData"=>2276000, "mem.VmStk"=>88000, "mem.VmExe"=>1768000, "mem.VmLib"=>2328000, "mem.VmPTE"=>68000, "mem.VmSwap"=>0, "fd"=>18}]
+[2] proc.0: [1485780299, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>10964, "mem.VmPeak"=>14740000, "mem.VmSize"=>14740000, "mem.VmLck"=>0, "mem.VmHWM"=>1152000, "mem.VmRSS"=>1148000, "mem.VmData"=>2276000, "mem.VmStk"=>88000, "mem.VmExe"=>1768000, "mem.VmLib"=>2328000, "mem.VmPTE"=>68000, "mem.VmSwap"=>0, "fd"=>18}]
+[3] proc.0: [1485780300, {"alive"=>true, "proc_name"=>"fluent-bit", "pid"=>10964, "mem.VmPeak"=>14740000, "mem.VmSize"=>14740000, "mem.VmLck"=>0, "mem.VmHWM"=>1152000, "mem.VmRSS"=>1148000, "mem.VmData"=>2276000, "mem.VmStk"=>88000, "mem.VmExe"=>1768000, "mem.VmLib"=>2328000, "mem.VmPTE"=>68000, "mem.VmSwap"=>0, "fd"=>18}]
 ```


### PR DESCRIPTION
I updated a documentation about in_proc.

* update sample output.
* add description about "fd" and "mem" options.

