### PR TITLE
Remove instruction to create build directory

### DIFF
--- a/installation/build_install.md
+++ b/installation/build_install.md
@@ -6,10 +6,9 @@
 
 > In the following steps you can find exact commands to build and install the project with the default options. If you already know how CMake works you can skip this part and look at the build options available.
 
-Create a temporary _build/_ directory inside the Fluent Bit sources:
+Change to the _build/_ directory inside the Fluent Bit sources:
 
 ```bash
-$ mkdir build
 $ cd build/
 ```
 


### PR DESCRIPTION
In the build and install instructions, there is no longer the need to
create the "build" directory, since this is already included in the
fluent-bit source.