### PR TITLE
Additional information regarding Topic_Key

### DIFF
--- a/output/kafka.md
+++ b/output/kafka.md
@@ -11,7 +11,7 @@ Kafka output plugin allows to ingest your records into an [Apache Kafka](https:/
 | Timestamp_Key | Set the key to store the record timestamp                    | @timestamp |
 | Brokers       | Single of multiple list of Kafka Brokers, e.g: 192.168.1.3:9092, 192.168.1.4:9092. |            |
 | Topics        | Single entry or list of topics separated by comma (,) that Fluent Bit will use to send messages to Kafka. If only one topic is set, that one will be used for all records. Instead if multiple topics exists, the one set in the record by Topic_Key will be used. | fluent-bit |
-| Topic_Key     | If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use. E.g: if Topic_Key is _router_ and the record is {"key1": 123, "router": "route_2"}, Fluent Bit will use topic _route_2_. Note that the topic __must__ be registered in the Topics list. |            |
+| Topic_Key     | If multiple Topics exists, the value of Topic_Key in the record will indicate the topic to use. E.g: if Topic_Key is _router_ and the record is {"key1": 123, "router": "route_2"}, Fluent Bit will use topic _route_2_. Note that if the value of Topic_Key is not present in Topics, then by default the first topic in the Topics list will indicate the topic to be used. |            |
 
 ## Getting Started
 


### PR DESCRIPTION
The `tested` behaviour for the Topic_Key is that: if the value of Topic_Key doesn't matches with any of the values in the Topics list, a default value (i.e. the first topic) in the list is returned. The snippet of code that shows this behavioru is:
```
/* Get first topic of the list (default topic) */
struct flb_kafka_topic *flb_kafka_topic_default(struct flb_kafka *ctx)
struct flb_kafka_topic *flb_kafka_topic_lookup(char *name,int name_len,struct flb_kafka *ctx)
  [...]                      /* No matches, return the default topic */
    return flb_kafka_topic_default(ctx);

}
```
Signed-off-by: Akash Kumar Dutta <adutta@tower-research.com>
Thanks :)