### PR TITLE
out_http: Fix the command-line configuration example

### DIFF
--- a/output/http.md
+++ b/output/http.md
@@ -37,7 +37,7 @@ http://host:port/something
 Using the format specified, you could start Fluent Bit through:
 
 ```text
-$ fluent-bit -i cpu -t cpu -o http://192.168.2.3:80/something -o stdout -m '*'
+$ fluent-bit -i cpu -t cpu -o http://192.168.2.3:80/something -m '*'
 ```
 
 ### Configuration File


### PR DESCRIPTION
I think `-o stdout` is misplaced here, because running the current
version results in the following warning.

    [ warn] [router] NO match for http.0 output instance

I confirmed in my console that removing `-o stdout` fixes the issue.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>