### PR TITLE
Explain how to encrypt connections using TLS (for fluentd v1.x)

### DIFF
--- a/output/forward.md
+++ b/output/forward.md
@@ -164,6 +164,27 @@ Paste this content in a file called _fld.conf_:
 </match>
 ```
 
+If you're using Fluentd v1, set up it as below:
+
+```text
+<source>
+  @type forward
+  <transport tls>
+    cert_path /etc/td-agent/certs/fluentd.crt
+    private_key_path /etc/td-agent/certs/fluentd.key
+    private_key_passphrase password
+  </transport>
+  <security>
+    self_hostname myserver.local
+    shared_key secret
+  </security>
+</source>
+
+<match **>
+ @type stdout
+</match>
+```
+
 ### Test Communication
 
 Start Fluentd:


### PR DESCRIPTION
Recent Fluentd versions support SSL/TLS forward out of the box.
This patch adds a minimum example to enable the support.

This should close #52.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>