### PR TITLE
Fix link URLs in kubernetes.md

### DIFF
--- a/installation/kubernetes.md
+++ b/installation/kubernetes.md
@@ -68,8 +68,8 @@ $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernet
 The default configuration of Fluent Bit makes sure of the following:
 
 * Consume all containers logs from the running Node.
-* The [Tail input plugin](http://fluentbit.io/documentation/0.14/input/tail.html) will not append more than **5MB**  into the engine until they are flushed to the Elasticsearch backend. This limit aims to provide a workaround for [backpressure](http://fluentbit.io/documentation/0.14/configuration/backpressure.html) scenarios.
+* The [Tail input plugin](https://docs.fluentbit.io/manual/v/1.0/input/tail) will not append more than **5MB**  into the engine until they are flushed to the Elasticsearch backend. This limit aims to provide a workaround for [backpressure](https://docs.fluentbit.io/manual/v/1.0/configuration/backpressure) scenarios.
 * The Kubernetes filter will enrich the logs with Kubernetes metadata, specifically _labels_ and _annotations_. The filter only goes to the API Server when it cannot find the cached info, otherwise it uses the cache.
-* The default backend in the configuration is Elasticsearch set by the [Elasticsearch Ouput Plugin](http://fluentbit.io/documentation/0.14/output/elasticsearch.html). It uses the Logstash format to ingest the logs. If you need a different Index and Type, please refer to the plugin option and do your own adjustments.
+* The default backend in the configuration is Elasticsearch set by the [Elasticsearch Ouput Plugin](https://docs.fluentbit.io/manual/v/1.0/output/elasticsearch). It uses the Logstash format to ingest the logs. If you need a different Index and Type, please refer to the plugin option and do your own adjustments.
 * There is an option called **Retry\_Limit** set to False, that means if Fluent Bit cannot flush the records to Elasticsearch it will re-try indefinitely until it succeed.
 


### PR DESCRIPTION
Point to https://docs.fluentbit.io with the correct version number.