### PR TITLE
[out_http] Add gelf format to docs

### DIFF
--- a/output/http.md
+++ b/output/http.md
@@ -12,11 +12,16 @@ The **http** output plugin allows to flush your records into a HTTP endpoint. Fo
 | Port        | TCP port of the target HTTP Server | 80 |
 | Proxy       | Specify an HTTP Proxy. The expected format of this value is _http://host:port_. Note that _https_ is __not__ supported yet. ||
 | URI         | Specify an optional HTTP URI for the target web server, e.g: /something  | / |
-| Format      | Specify the data format to be used in the HTTP request body, by default it uses _msgpack_. Other supported formats are _json_, _json_stream_ and _json_lines_. | msgpack |
+| Format      | Specify the data format to be used in the HTTP request body, by default it uses _msgpack_. Other supported formats are _json_, _json_stream_ and _json_lines_ and _gelf_. | msgpack |
 | header_tag | Specify an optional HTTP header field for the original message tag. |         |
 | Header     | Add a HTTP header key/value pair. Multiple headers can be set. |         |
 | json_date_key | Specify the name of the date field in output | date |
 | json_date_format | Specify the format of the date. Supported formats are _double_ and _iso8601_ (eg: _2018-05-30T09:39:52.000681Z_)| double |
+| gelf_timestamp_key | Specify the key to use for `timestamp` in _gelf_ format | |
+| gelf_host_key | Specify the key to use for the `host` in _gelf_ format | |
+| gelf_short_messge_key | Specify the key to use as the `short` message in _gelf_ format | |
+| gelf_full_message_key | Specify the key to use for the `full` message in _gelf_ format | |
+| gelf_level_key | Specify the key to use for the `level` in _gelf_ format | |
 
 ### TLS / SSL
 


### PR DESCRIPTION
This was added to the code in
(4ce354ec3)[https://github.com/fluent/fluent-bit/commit/4ce354ec3]
but does not seem to have been added to the docs.

Signed-off-by: Don Bowman <db@donbowman.ca>