### PR TITLE
Proposed better regex for Tag_Regex

### DIFF
--- a/input/tail.md
+++ b/input/tail.md
@@ -33,7 +33,7 @@ The plugin supports the following configuration parameters:
 | Parser | Specify the name of a parser to interpret the entry as a structured message. |  |
 | Key | When a message is unstructured \(no parser applied\), it's appended as a string under the key name _log_. This option allows to define an alternative name for that key. | log |
 | Tag | Set a tag (with regex-extract fields) that will be placed on lines read. E.g. `kube.<namespace_name>.<pod_name>.<container_name>` | |
-| Tag_Regex | Set a regex to exctract fields from the file. E.g. `(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-` | |
+| Tag_Regex | Set a regex to exctract fields from the file. E.g. `[a-z0-9\.]*(?>[-a-z0-9]*[a-z0-9])?(?>\.(?<pod_name>[a-z0-9](?>[-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-.*` | |
 
 Note that if the database parameter _db_ is **not** specified, by default the plugin will start reading each target file from the beginning.
 


### PR DESCRIPTION
Taking this log file from kubernetes pod container: `kube.var.log.containers.fluentd-64d9cbc9cc-s4gkl_monitoring_fluentd-c55ffe43b2842eb4079c4033ab51bb712bec16b2d40b12a630658765b949c0af.log`

It extract like this:

```
Group `pod_name`	24-48	fluentd-64d9cbc9cc-s4gkl
Group `namespace_name`	49-59	monitoring
Group `container_name`	60-67	fluentd
```

Example here: https://regex101.com/r/iwZQcg/1