### PR TITLE
Fix tls links

### DIFF
--- a/output/influxdb.md
+++ b/output/influxdb.md
@@ -17,7 +17,7 @@ The **influxdb** output plugin, allows to flush your records into a [InfluxDB](h
 
 ### TLS / SSL
 
-InfluxDB output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](https://github.com/fluent/fluent-bit-docs/tree/ad9d80e5490bd5d79c86955c5689db1cb4cf89db/getting_started/tls_ssl.md) section.
+InfluxDB output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../configuration/tls_ssl.md) section.
 
 ## Getting Started
 

--- a/output/kafka-rest-proxy.md
+++ b/output/kafka-rest-proxy.md
@@ -18,7 +18,7 @@ The **kafka-rest** output plugin, allows to flush your records into a [Kafka RES
 
 ### TLS / SSL
 
-Kafka REST Proxy output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](https://github.com/fluent/fluent-bit-docs/tree/ad9d80e5490bd5d79c86955c5689db1cb4cf89db/getting_started/tls_ssl.md) section.
+Kafka REST Proxy output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../configuration/tls_ssl.md) section.
 
 ## Getting Started
 

--- a/output/splunk.md
+++ b/output/splunk.md
@@ -17,7 +17,7 @@ To get more details about how to setup the HEC in Splunk please refer to the fol
 
 ### TLS / SSL
 
-Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](https://docs.fluentbit.io/manual/configuration/tls_ssl) section.
+Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../configuration/tls_ssl.md) section.
 
 ## Getting Started
 


### PR DESCRIPTION
Noticed some TLS/SSL links in the output plugins were outdated or inconsistent.