### PR TITLE
filter: parser: Reserve_Data should be activated in FILTER

### DIFF
--- a/filter/parser.md
+++ b/filter/parser.md
@@ -71,14 +71,72 @@ You can see the record `{"data":"100 0.5 true This is example"}` are parsed.
 
 By default, the parser plugin only keeps the parsed fields in its output.
 
-If you enable `Preserve_Key`, the original key field is preserved:
+If you enable `Reserve_Data`, all other fields are preserved:
 
 ```python
 [PARSER]
     Name dummy_test
-    Preserve_Key On
     Format regex
     Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
+```
+
+```python
+[SERVICE]
+    Parsers_File /path/to/parsers.conf
+
+[INPUT]
+    Name dummy
+    Tag  dummy.data
+    Dummy {"data":"100 0.5 true This is example", "key1":"value1", "key2":"value2"}
+
+[FILTER]
+    Name parser
+    Match dummy.*
+    Key_Name data
+    Parser dummy_test
+    Reserve_Data On
+```
+
+This will produce the output:
+
+```text
+$ fluent-bit -c dummy.conf
+Fluent-Bit v0.12.0
+Copyright (C) Treasure Data
+
+[2017/07/06 22:33:12] [ info] [engine] started
+[0] dummy.data: [1499347993.001371317, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
+[1] dummy.data: [1499347994.001303118, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
+[2] dummy.data: [1499347995.001296133, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
+[3] dummy.data: [1499347996.001320284, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
+```
+
+If you enable `Reserved_Data` and `Preserve_Key`, the original key field will be
+preserved as well:
+
+```python
+[PARSER]
+    Name dummy_test
+    Format regex
+    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
+```
+
+```python
+[SERVICE]
+    Parsers_File /path/to/parsers.conf
+
+[INPUT]
+    Name dummy
+    Tag  dummy.data
+    Dummy {"data":"100 0.5 true This is example", "key1":"value1", "key2":"value2"}
+
+[FILTER]
+    Name parser
+    Match dummy.*
+    Key_Name data
+    Parser dummy_test
+    Reserve_Data On
+    Preserve_Key On
 ```
 
 This will produce the output:
@@ -95,36 +153,3 @@ Copyright (C) Treasure Data
 [3] dummy.data: [1499347996.001320284, {"data":"100 0.5 true This is example", "INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
 ```
 
-If you enable `Reserve_Data`, all other fields are preserved:
-
-```python
-[PARSER]
-    Name dummy_test
-    Reserve_Data On
-    Format regex
-    Regex ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
-```
-
-```python
-[SERVICE]
-    Parsers_File /path/to/parsers.conf
-
-[INPUT]
-    Name dummy
-    Tag  dummy.data
-    Dummy {"data":"100 0.5 true This is example", "key1":"value1", "key2":"value2"}
-```
-
-This will produce the output:
-
-```text
-$ fluent-bit -c dummy.conf
-Fluent-Bit v0.12.0
-Copyright (C) Treasure Data
-
-[2017/07/06 22:33:12] [ info] [engine] started
-[0] dummy.data: [1499347993.001371317, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
-[1] dummy.data: [1499347994.001303118, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
-[2] dummy.data: [1499347995.001296133, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
-[3] dummy.data: [1499347996.001320284, {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}, "key1":"value1", "key2":"value2"]
-```


### PR DESCRIPTION
As noted by #151, the documentation is incorrect.
Reserved_Data and Preserved_Key should be activated in the [FILTER] block instead of the [PARSER] block.

Also, Preserved_Key only works when Reserved_Data is On.
This is why I've swap the block in the documentation.

Relevant part in the code: https://github.com/fluent/fluent-bit/blob/master/plugins/filter_parser/filter_parser.c
```
                            if (ctx->reserve_data) {
                                if (!ctx->preserve_key) {
                                    append_arr_i--;
                                    append_arr_len--;
                                    append_arr[append_arr_i] = NULL;
                                }
                            }
                            else {
                                continue_parsing = FLB_FALSE;
                                break;
                            }
```

I don't actually know what the code do, but I couldn't get the documentation's example working and preserve_key seems to be only invoked here.