### PR TITLE
configuration: file: Document the risk of too small Coro_Stack_Size

### DIFF
--- a/configuration/file.md
+++ b/configuration/file.md
@@ -31,7 +31,7 @@ The _Service_ section defines global properties of the service, the keys availab
 | HTTP\_Server | Enable built-in HTTP Server | Off |
 | HTTP\_Listen | Set listening interface for HTTP Server when it's enabled | 0.0.0.0 |
 | HTTP\_Port | Set TCP Port for the HTTP Server | 2020 |
-| Coro_Stack_Size | Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. | 24576 |
+| Coro_Stack_Size | Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer. | 24576 |
 
 ### Example
 


### PR DESCRIPTION
libco assumes that Coro_Stack_Size is large enough to hold the coroutine
thread's call stack.

Setting too small value to this configuration item can break the implicit
assumption, and can lead to obnoxious errors due to memory corruptions.
Let's document this issue clearly.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>