### PR TITLE
parser: regular_expression: Add warning about special characters

### DIFF
--- a/parser/regular_expression.md
+++ b/parser/regular_expression.md
@@ -44,5 +44,9 @@ The above content do not provide a defined structure for Fluent Bit, but enablin
 ]
 ```
 
+A common pitfall is that you cannot use characters other than alphabets, numbers
+and underscore in group names. For example, a group name like `(?<user-name>.*)`
+will cause an error due to containing an invalid character (`-`).
+
 In order to understand, learn and test regular expressions like the example above, we suggest you try the following Ruby Regular Expression Editor: [http://rubular.com/r/X7BH0M4Ivm](http://rubular.com/r/X7BH0M4Ivm)
 


### PR DESCRIPTION
This is a limitation of Onigumo, who throws an initialization error
if a group name contains characters other than alphanumeric.

Let's document the limitation in the manual page clearly so that
users do not get confused about it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>