### PR TITLE
Adding a documentation page for Datadog

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -86,6 +86,7 @@
   * [Azure](output/azure.md)
   * [BigQuery](output/bigquery.md)
   * [Counter](output/counter.md)
+  * [Datadog](output/datadog.md)
   * [Elasticsearch](output/elasticsearch.md)
   * [File](output/file.md)
   * [FlowCounter](output/flowcounter.md)

--- a/output/README.md
+++ b/output/README.md
@@ -7,6 +7,7 @@ The _output plugins_ defines where [Fluent Bit](http://fluentbit.io) should flus
 | [azure](azure.md) | Azure Log Analytics | Ingest records into Azure Log Analytics |
 | [bigquery](bigquery.md) | BigQuery | Ingest records into Google BigQuery |
 | [counter](counter.md) | Count Records | Simple records counter. |
+| [datadog](datadog.md) | Datadog | Ingest logs into Datadog. |
 | [es](elasticsearch.md) | Elasticsearch | flush records to a Elasticsearch server. |
 | [file](file.md) | File | Flush records to a file. |
 | [flowcounter](flowcounter.md) | FlowCounter | Count records. |

--- a/output/datadog.md
+++ b/output/datadog.md
@@ -1,0 +1,36 @@
+# Datadog
+
+The Datadog output plugin allows to ingest your Logs into [Datadog](https://docs.datadoghq.com/).
+
+Before you begin, you need a [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/).
+
+## Configuration Parameters
+
+| Key | Description | Default |
+|------------|---------------------------------------------------------------------------------------------|----------------------------------|
+| Host | The Datadog server where you are sending your logs.  | `http-intake.logs.datadoghq.com` |
+| TLS | End-to-end security communications security protocol. Datadog recommends leaving this `on`. | `on` |
+| apikey | )Your [Datadog API key](https://app.datadoghq.com/account/settings#api). |  |
+| dd_service | The name of your applications service. |  |
+| dd_source | The name of your application source. |  |
+| dd_tags | )The [tags](https://docs.datadoghq.com/tagging/) you want to assign to your logs in Datadog. |  |
+
+### Configuration File
+
+Get started quickly with this configuration file:
+
+```text
+[OUTPUT]
+    Name        datadog
+    Match       *
+    Host        http-intake.logs.datadoghq.com
+    TLS         on
+    apikey      <my-datadog-api-key>
+    dd_service  my-app-service
+    dd_source   my-app
+    dd_tags     team:logs,foo:bar
+```
+
+## Troubleshooting
+
+Anything we want to add here yet?

--- a/output/datadog.md
+++ b/output/datadog.md
@@ -1,19 +1,19 @@
 # Datadog
 
-The Datadog output plugin allows to ingest your Logs into [Datadog](https://docs.datadoghq.com/).
+The Datadog output plugin allows to ingest your logs into [Datadog](https://app.datadoghq.com/signup).
 
-Before you begin, you need a [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/).
+Before you begin, you need a [Datadog account](https://app.datadoghq.com/signup), a [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/), and you need to [activate Datadog Logs Management](https://app.datadoghq.com/logs/activation). 
 
 ## Configuration Parameters
 
 | Key | Description | Default |
 |------------|---------------------------------------------------------------------------------------------|----------------------------------|
-| Host | The Datadog server where you are sending your logs.  | `http-intake.logs.datadoghq.com` |
-| TLS | End-to-end security communications security protocol. Datadog recommends leaving this `on`. | `on` |
-| apikey | )Your [Datadog API key](https://app.datadoghq.com/account/settings#api). |  |
-| dd_service | The name of your applications service. |  |
-| dd_source | The name of your application source. |  |
-| dd_tags | )The [tags](https://docs.datadoghq.com/tagging/) you want to assign to your logs in Datadog. |  |
+| Host | _Required_ - The Datadog server where you are sending your logs.  | `http-intake.logs.datadoghq.com` |
+| TLS | _Required_ - End-to-end security communications security protocol. Datadog recommends leaving this `on`. | `on` |
+| apikey | _Required_ - Your [Datadog API key](https://app.datadoghq.com/account/settings#api). |  |
+| dd_service | _Recommended_ - the human readable name for your service generating the logs - the name of your application or database. |  |
+| dd_source | _Recommended_ - a human readable name for the underlying technology of your service. For example, `postgres` or `nginx`. |  |
+| dd_tags | _Optional_ - The [tags](https://docs.datadoghq.com/tagging/) you want to assign to your logs in Datadog. |  |
 
 ### Configuration File
 
@@ -26,11 +26,13 @@ Get started quickly with this configuration file:
     Host        http-intake.logs.datadoghq.com
     TLS         on
     apikey      <my-datadog-api-key>
-    dd_service  my-app-service
-    dd_source   my-app
+    dd_service  <my-app-service>
+    dd_source   <my-app-source>
     dd_tags     team:logs,foo:bar
 ```
 
 ## Troubleshooting
 
-Anything we want to add here yet?
+### 403 Forbidden
+
+If you get a `403 Forbidden` error response, double check that you have a valid [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/) and that you have [activated Datadog Logs Management](https://app.datadoghq.com/logs/activation).

--- a/output/datadog.md
+++ b/output/datadog.md
@@ -11,8 +11,8 @@ Before you begin, you need a [Datadog account](https://app.datadoghq.com/signup)
 | Host | _Required_ - The Datadog server where you are sending your logs.  | `http-intake.logs.datadoghq.com` |
 | TLS | _Required_ - End-to-end security communications security protocol. Datadog recommends leaving this `on`. | `on` |
 | apikey | _Required_ - Your [Datadog API key](https://app.datadoghq.com/account/settings#api). |  |
-| dd_service | _Recommended_ - the human readable name for your service generating the logs - the name of your application or database. |  |
-| dd_source | _Recommended_ - a human readable name for the underlying technology of your service. For example, `postgres` or `nginx`. |  |
+| dd_service | _Recommended_ - The human readable name for your service generating the logs - the name of your application or database. |  |
+| dd_source | _Recommended_ - A human readable name for the underlying technology of your service. For example, `postgres` or `nginx`. |  |
 | dd_tags | _Optional_ - The [tags](https://docs.datadoghq.com/tagging/) you want to assign to your logs in Datadog. |  |
 
 ### Configuration File


### PR DESCRIPTION
This is a new page in the output section to support the upcoming release of the Datadog integration.