### PR TITLE
parser: specify parsers which support Types option

### DIFF
--- a/parser/README.md
+++ b/parser/README.md
@@ -32,7 +32,7 @@ Multiple parsers can be defined and each section have it own properties. The fol
 | Time\_Format | Specify the format of the time field so it can be recognized and analyzed properly. Fluent-bit uses `strptime(3)` to parse time so you can ferer to [strptime documentation](https://linux.die.net/man/3/strptime) for available modifiers. |
 | Time\_Offset | Specify a fixed UTC time offset \(e.g. -0600, +0200, etc.\) for local dates. |
 | Time\_Keep | By default when a time key is recognized and parsed, the parser will drop the original time field. Enabling this option will make the parser to keep the original time field and it value in the log entry. |
-| Types | Specify the data type of parsed field. The syntax is `types <field_name_1>:<type_name_1> <field_name_2>:<type_name_2> ...`. The supported types are `string`\(default\), `integer`, `bool`, `float`, `hex`. |
+| Types | Specify the data type of parsed field. The syntax is `types <field_name_1>:<type_name_1> <field_name_2>:<type_name_2> ...`. The supported types are `string`\(default\), `integer`, `bool`, `float`, `hex`. `ltsv`, `logfmt` and `regex` supports this option.|
 | Decode\_Field | Decode a field value, the only decoder available is `json`. The syntax is: `Decode_Field json <field_name>`. |
 
 ## Parsers Configuration File


### PR DESCRIPTION
To make clear which parser supports `Types` option.

https://github.com/fluent/fluent-bit/issues/1563

> Clearly states in the documentation that this is working as intended and it can be used only with the other parser (like the Decode_Fieldkey that on the contrary work only on json parsers).