### PR TITLE
output: forward: Add Username and Password options

### DIFF
--- a/output/forward.md
+++ b/output/forward.md
@@ -28,6 +28,8 @@ When using Secure Forward mode, the [TLS](../configuration/tls_ssl.md) mode requ
 | Key | Description | Default |
 | :--- | :--- | :--- |
 | Shared\_Key | A key string known by the remote Fluentd used for authorization. |  |
+| Username | Specify the username to present to a Fluentd server that enables `user_auth`. |  |
+| Password | Specify the password corresponding to the username. |  |
 | Self\_Hostname | Default value of the auto-generated certificate common name \(CN\). |  |
 | tls | Enable or disable TLS support | Off |
 | tls.verify | Force certificate validation | On |


### PR DESCRIPTION
This documents the upcoming "Username" and "Password" parameters,
which enables Fluent Bit to connect to a Fluentd server that forces
password authentication.

NOTE the main patch is being submitted at https://github.com/fluent/fluent-bit/pull/1574.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>