### PR TITLE
configuration: tls: document tls.vhost option

### DIFF
--- a/configuration/tls_ssl.md
+++ b/configuration/tls_ssl.md
@@ -14,6 +14,7 @@ Each output plugin that requires to perform Network I/O can optionally enable TL
 | tls.crt\_file | absolute path to Certificate file |  |
 | tls.key\_file | absolute path to private Key file |  |
 | tls.key\_passwd | optional password for tls.key\_file file |  |
+| tls.vhost | hostname to be used for TLS SNI extension | |
 
 The listed properties can be enabled in the configuration file, specifically on each output plugin section or directly through the command line. The following **output** plugins can take advantage of the TLS feature:
 
@@ -51,4 +52,26 @@ The same behavior can be accomplished using a configuration file:
     URI        /something
     tls        On
     tls.verify Off
+```
+
+## Tips and Tricks
+
+### Connect to virtual servers using TLS
+
+Fluent Bit supports [TLS server name indication](https://en.wikipedia.org/wiki/Server_Name_Indication). If you are serving multiple hostnames on a single IP address (a.k.a. virtual hosting), you can make use of `tls.vhost` to connect to a specific hostname.
+
+```
+[INPUT]
+    Name  cpu
+    Tag   cpu
+
+[OUTPUT]
+    Name        forward
+    Match       *
+    Host        192.168.10.100
+    Port        24224
+    tls         On
+    tls.verify  On
+    tls.ca_file /etc/certs/fluent.crt
+    tls.vhost   fluent.example.com
 ```


### PR DESCRIPTION
Also adds a configuration example to illustrate what is the good
of `tls.vhost` option and how to use it.

This is a supplemental material of fluent/fluent-bit/pull/1313.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>