### PR TITLE
output: http: Sample config and query for Sumo Logic usage

### DIFF
--- a/output/http.md
+++ b/output/http.md
@@ -111,3 +111,30 @@ Notice how we override the tag, which is from URI path, with our custom header
     Header         X-Key-B Value_B
     URI            /something
 ```
+
+#### Example : Sumo Logic HTTP Collector
+
+Suggested configuration for Sumo Logic using `json_lines` with `iso8601` timestamps.
+The `PrivateKey` is specific to a configured HTTP collector.
+
+```
+[OUTPUT]
+    Name             http
+    Match            *
+    Host             collectors.au.sumologic.com
+    Port             443
+    URI              /receiver/v1/http/[PrivateKey]
+    Format           json_lines
+    Json_date_key    timestamp
+    Json_date_format iso8601
+```
+
+A sample Sumo Logic query for the [CPU](../input/cpu.md) input.
+(Requires `json_lines` format with `iso8601` date format for the `timestamp` field).
+
+```
+_sourcecategory="my_fluent_bit"
+| json "cpu_p" as cpu
+| timeslice 1m
+| max(cpu) as cpu group by _timeslice
+```


### PR DESCRIPTION
I did some integration of fluent-bit into a [Sumo Logic](https://www.sumologic.com) dashboard for a Raspberry Pi version 1.

Aligning the `http` output for Sumo Logic is a little bit non-obvious, so I documented some settings that seem to work well for me.  Specifically the `timestamp` and `json_lines` format.

![Screenshot from 2019-10-06 22-06-44](https://user-images.githubusercontent.com/545677/66268950-eb733080-e885-11e9-9201-f4d68a57df30.png)


