### PR TITLE
installation: td-agent-bit: add missing Raspbian stretch support

### DIFF
--- a/installation/td-agent-bit.md
+++ b/installation/td-agent-bit.md
@@ -11,6 +11,7 @@ The following distributions are supported:
 | [Debian](debian.md) | 10 | Buster |
 | [Debian](debian.md) | 9 | Stretch |
 | [Debian](debian.md) | 8 | Jessie |
+| [Raspbian](raspberry_pi.md) | 9 | Stretch |
 | [Raspbian](raspberry_pi.md) | 8 | Jessie |
 | [CentOS](redhat_centos.md) | 7 |   |
 


### PR DESCRIPTION
ref: https://docs.fluentbit.io/manual/installation/raspberry_pi

Signed-off-by: Kentaro Hayashi <hayashi@clear-code.com>