### PR TITLE
Document in_docker plugin

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -48,6 +48,7 @@
   * [Collectd](input/collectd.md)
   * [CPU Usage](input/cpu.md)
   * [Disk Usage](input/disk.md)
+  * [Docker](input/docker.md)
   * [Dummy](input/dummy.md)
   * [Exec](input/exec.md)
   * [Forward](input/forward.md)

--- a/input/README.md
+++ b/input/README.md
@@ -7,6 +7,7 @@ The _input plugins_ defines the source from where [Fluent Bit](http://fluentbit.
 | [collectd](collectd.md) | Collectd | Listen for UDP packets from Collectd. |
 | [cpu](cpu.md) | CPU Usage | measure total CPU usage of the system. |
 | [disk](disk.md) | Disk Usage | measure Disk I/Os. |
+| [docker](docker.md) | Docker | collect Docker container metrics. |
 | [dummy](dummy.md) | Dummy | generate dummy event. |
 | [exec](exec.md) | Exec | executes external program and collects event logs. |
 | [forward](forward.md) | Forward | Fluentd forward protocol. |

--- a/input/docker.md
+++ b/input/docker.md
@@ -1,0 +1,43 @@
+# Docker
+
+The **docker** input plugin allows you to collect Docker container metrics
+like memory usage and CPU consumption.
+
+Content:
+
+* [Configuration Parameters](docker.md#config)
+* [Configuration Parameters](docker.md#config_example)
+
+## Configuration Parameters {#config}
+
+The plugin supports the following configuration parameters:
+
+| Key           | Description                                     | Default  |
+| :------------ | :---------------------------------------------- | :--------|
+| Interval\_Sec | Polling interval in seconds                     | 1        |
+| Include       | A space-separated list of containers to include |          |
+| Exclude       | A space-separated list of containers to exclude |          |
+
+If you set neither `Include` nor `Exclude`, the plugin will try to get
+metrics from _all_ the running containers.
+
+## Configuration Examples {#config_example}
+
+Here is an example configuration that collects metrics from two docker
+instances (`6bab19c3a0f9` and `14159be4ca2c`).
+
+```python
+[INPUT]
+    Name         docker
+    Include      6bab19c3a0f9 14159be4ca2c
+
+[OUTPUT]
+    Name   stdout
+    Match  *
+```
+
+This configuration will produce records like below.
+
+```
+[1] docker.0: [1571994772.00555745, {"id"=>"6bab19c3a0f9", "name"=>"postgresql", "cpu_used"=>172102435, "mem_used"=>5693400, "mem_limit"=>4294963200}]
+```


### PR DESCRIPTION
We added a new input plugin to collect metrics from running Docker
containers (see d19be0d765 in fluent/fluent-bit).

This adds the documentation for the new plugin, explaining the list
of available parameters and its basic usage.

Fixes #222 

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>