### PR TITLE
Update exec documentation to include `buf_size`

### DIFF
--- a/input/exec.md
+++ b/input/exec.md
@@ -12,6 +12,7 @@ The plugin supports the following configuration parameters:
 | Parser | Specify the name of a parser to interpret the entry as a structured message. |
 | Interval\_Sec | Polling interval \(seconds\). |
 | Interval\_NSec | Polling interval \(nanosecond\). |
+| Buf\_Size | Size of the buffer (check [unit sizes](https://docs.fluentbit.io/manual/configuration/unit_sizes) for allowed values) |
 
 ## Getting Started
 
@@ -47,6 +48,7 @@ In your main configuration file append the following _Input_ & _Output_ sections
     Command       ls /var/log
     Interval_Sec  1
     Interval_NSec 0
+    Buf_Size      8mb
 
 [OUTPUT]
     Name   stdout


### PR DESCRIPTION
This was added in this PR: fluent/fluent-bit#1116