### PR TITLE
input: statsd: add documentation for the new "in_statsd" plugin

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -61,6 +61,7 @@
   * [Random](input/random.md)
   * [Serial Interface](input/serial.md)
   * [Standard Input](input/stdin.md)
+  * [StatsD Input](input/statsd.md)
   * [Syslog](input/syslog.md)
   * [Systemd](input/systemd.md)
   * [Tail](input/tail.md)

--- a/input/README.md
+++ b/input/README.md
@@ -20,6 +20,7 @@ The _input plugins_ defines the source from where [Fluent Bit](http://fluentbit.
 | [random](random.md) | Random | Generate Random samples. |
 | [serial](serial.md) | Serial Interface | read data information from the serial interface. |
 | [stdin](stdin.md) | Standard Input | read data from the standard input. |
+| [statsd](statsd.md) | StatsD | receive metrics in StatsD protocol. |
 | [syslog](syslog.md) | Syslog | read syslog messages from a Unix socket. |
 | [systemd](systemd.md) | Systemd | read logs from Systemd/Journald. |
 | [tail](tail.md) | Tail | Tail log files |

--- a/input/statsd.md
+++ b/input/statsd.md
@@ -1,0 +1,42 @@
+# StatsD
+
+The **statsd** input plugin allows you to receive metrics via StatsD protocol.
+
+Content:
+
+* [Configuration Parameters](statsd.md#config)
+* [Configuration Examples](statsd.md#config_example)
+
+## Configuration Parameters {#config}
+
+The plugin supports the following configuration parameters:
+
+| Key      | Description                              | Default |
+| :------- | :--------------------------------------- | :------ |
+| Listen   | Listener network interface.              | 0.0.0.0 |
+| Port     | UDP port where listening for connections | 8125    |
+
+## Configuration Examples {#config_example}
+
+Here is a configuration example.
+
+```python
+[INPUT]
+    Name   statsd
+    Listen 0.0.0.0
+    Port   8125
+
+[OUTPUT]
+    Name   stdout
+    Match  *
+```
+
+Now you can input metrics through the UDP port as follows.
+
+  $ echo "click:10|c|@0.1" | nc -q0 -u 127.0.0.1 8125
+  $ echo "active:99|g" | nc -q0 -u 127.0.0.1 8125
+
+Fluent Bit will produce the following records:
+
+    [0] statsd.0: [1574905088.971380537, {"type"=>"counter", "bucket"=>"click", "value"=>10.000000, "sample_rate"=>0.100000}]
+    [0] statsd.0: [1574905141.863344517, {"type"=>"gauge", "bucket"=>"active", "value"=>99.000000, "incremental"=>0}]


### PR DESCRIPTION
We have recently implemented a new plugin to receive metrics via
StatsD protocol (will be included in Fluent Bit v1.4.0).

This documents the configuration parameters of the new plugin and
its basic usage.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>