### PR TITLE
output: forward: Document 'Empty_Shared_Key'

### DIFF
--- a/output/forward.md
+++ b/output/forward.md
@@ -28,6 +28,7 @@ When using Secure Forward mode, the [TLS](../configuration/tls_ssl.md) mode requ
 | Key | Description | Default |
 | :--- | :--- | :--- |
 | Shared\_Key | A key string known by the remote Fluentd used for authorization. |  |
+| Empty\_Shared\_Key | Use this option to connect to Fluentd with a zero-length secret. | False |
 | Username | Specify the username to present to a Fluentd server that enables `user_auth`. |  |
 | Password | Specify the password corresponding to the username. |  |
 | Self\_Hostname | Default value of the auto-generated certificate common name \(CN\). |  |


### PR DESCRIPTION
This option is a special configuration to connect to Fluentd nodes
that use zero-length strings (a.k.a. "") as shared secrets. Let's
document it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>