### PR TITLE
service: remove never merged Config_Watch example

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -29,7 +29,6 @@ In addition to the properties listed in the table above, the Storage and Bufferi
 [SERVICE]
     Flush        1
     Daemon       Off
-    Config_Watch On
     Parsers_File parsers.conf
     Parsers_File custom_parsers.conf
 ```


### PR DESCRIPTION
fluent-bit PR [#842] which would have introduced `Config_Watch` was never
merged. This configuration option shouldn't be included in
documentation.

[#842]: https://github.com/fluent/fluent-bit/pull/842