### PR TITLE
Correct syslog default parser documentation

### DIFF
--- a/input/syslog.md
+++ b/input/syslog.md
@@ -13,7 +13,7 @@ The plugin supports the following configuration parameters:
 | Port | If _Mode_ is set to _tcp_, specify the TCP port to listen for incoming connections. | 5140 |
 | Path | If _Mode_ is set to _unix\_tcp_ or _unix\_udp_, set the absolute path to the Unix socket file. |  |
 | Unix_Perm | If _Mode_ is set to _unix\_tcp_ or _unix\_udp_, set the permission of the Unix socket file. | 0644 |
-| Parser | Specify an alternative parser for the message. By default, the plugin uses the parser _syslog-rfc3164_. If your syslog messages have fractional seconds set this Parser value to _syslog-rfc5424_ instead. |  |
+| Parser | Specify an alternative parser for the message. If _Mode_ is set to _tcp_ or _udp_ then the default parser is _syslog-rfc5424_ otherwise _syslog-rfc3164-local_ is used. If your syslog messages have fractional seconds set this Parser value to _syslog-rfc5424_ instead. |  |
 | Buffer\_Chunk\_Size | By default the buffer to store the incoming Syslog messages, do not allocate the maximum memory allowed, instead it allocate memory when is required. The rounds of allocations are set by _Buffer\_Chunk\_Size_. If not set, _Buffer\_Chunk\_Size_ is equal to 32000 bytes \(32KB\). Read considerations below when using _udp_ or _unix\_udp_ mode. |  |
 | Buffer\_Max_Size | Specify the maximum buffer size to receive a Syslog message. If not set, the default size will be the value of _Buffer\_Chunk\_Size_. |  |
 


### PR DESCRIPTION
I hit this problem today, I thought it was worth expanding the documentation.

---

Selection of the default parser was not as described, refer to:

https://github.com/fluent/fluent-bit/blob/baff15640e97ac46d457aab011e9103f2dca53ce/plugins/in_syslog/syslog_conf.c#L118-L129