### PR TITLE
installation: sources: build-and-install: Document CMake 3.x

### DIFF
--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -5,6 +5,7 @@
 ## Prepare environment
 
 > In the following steps you can find exact commands to build and install the project with the default options. If you already know how CMake works you can skip this part and look at the build options available.
+> Note that Fluent Bit requires CMake 3.x. You may need to use `cmake3` instead of `cmake` to complete the following steps on your system.
 
 Change to the _build/_ directory inside the Fluent Bit sources:
 


### PR DESCRIPTION
The default version of CMake on CentOS 7 is 2.x. For this reason,
we keep hearing complaints that cmake fails to set up the build
directory.

Fix that by documenting the version requirement clearly.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>