### PR TITLE
Add instructions to run a logging pipeline locally with docker.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -58,6 +58,10 @@
 * [Monitoring](administration/monitoring.md)
 * [Dump Internals / Signal](administration/dump-internals-signal.md)
 
+## Local Testing
+
+* [Running a Logging Pipeline Locally](local-testing/logging-pipeline.md)
+
 ## Data Pipeline <a id="pipeline"></a>
 
 * [Inputs](pipeline/inputs/README.md)
@@ -141,4 +145,3 @@
 * [Ingest Records Manually](development/ingest-records-manually.md)
 * [Golang Output Plugins](development/golang-output-plugins.md)
 * [Developer guide for beginners on contributing to Fluent Bit](development/developer-guide.md)
-

--- a/local-testing/logging-pipeline.md
+++ b/local-testing/logging-pipeline.md
@@ -1,0 +1,65 @@
+# Running a Logging Pipeline Locally
+
+You may wish to test a logging pipeline locally to observe how it deals with
+log messages. The following is a walk-through for running Fluent Bit and
+Elasticsearch locally with [Docker Compose](https://docs.docker.com/compose/) which can serve as an example for testing other plugins locally.
+
+## Create a Configuration File
+
+Refer to the [Configuration File
+section](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file)
+to create a configuration to test.
+
+`fluent-bit.conf`:
+
+```text
+[INPUT]
+  Name dummy
+  Dummy {"top": {".dotted": "value"}}
+
+[OUTPUT]
+  Name es
+  Host elasticsearch
+  Replace_Dots On
+```
+
+## Docker Compose
+
+Use [Docker Compose](https://docs.docker.com/compose/) to run Fluent Bit (with
+the configuration file mounted) and Elasticsearch.
+
+`docker-compose.yaml`:
+
+```yaml
+version: "3.7"
+
+services:
+  fluent-bit:
+    image: fluent/fluent-bit
+    volumes:
+      - ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+    depends_on:
+      - elasticsearch
+  elasticsearch:
+    image: elasticsearch:7.6.2
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node
+```
+
+## View indexed logs
+
+To view indexed logs run:
+
+```sh
+curl "localhost:9200/_search?pretty" \
+  -H 'Content-Type: application/json' \
+  -d'{ "query": { "match_all": {} }}'
+```
+
+To "start fresh", delete the index by running:
+
+```sh
+curl -X DELETE "localhost:9200/fluent-bit?pretty"
+```


### PR DESCRIPTION
It is not uncommon to want to see how a logging pipeline works locally, this can be achieved with docker.

This is, imho, the easiest way for operators to validate logging pipelines locally as to troubleshoot and catch bugs as done in https://github.com/fluent/fluent-bit/issues/2093
