### PR TITLE
Clarify @INCLUDE limitations

### DIFF
--- a/administration/configuring-fluent-bit/configuration-file.md
+++ b/administration/configuring-fluent-bit/configuration-file.md
@@ -220,6 +220,8 @@ The configuration reader will try to open the path _somefile.conf_, if not found
 * Included file: somefile.conf
 * Fluent Bit will try to open somefile.conf, if it fails it will try /tmp/somefile.conf.
 
+Once the file is found, its contents will replace the `@INCLUDE somefile.conf` line. This is a simple textual inclusion. You must still follow the [Format and Schema](format-schema.md) defined previously. For example, you cannot define multiple `[SERVICE]` sections.
+
 The _@INCLUDE_ command only works at top-left level of the configuration line, it cannot be used inside sections.
 
 Wildcard character \(\*\) is supported to include multiple files, e.g:


### PR DESCRIPTION
I spent a while trying to figure out why config like this wasn't working:

`config-main.conf`:

```
[SERVICE]
    Daemon Off

$INCLUDE config-extra.conf
```

`config-extra.conf`:

```
[SERVICE]
    Parser_File parsers_extra.conf
```

Hopefully this docs addition will save others 🙏 