### PR TITLE
pipeline: parser: Add a warning on ReDoS

### DIFF
--- a/pipeline/parsers/regular-expression.md
+++ b/pipeline/parsers/regular-expression.md
@@ -8,6 +8,8 @@ Fluent Bit uses [Onigmo](https://github.com/k-takata/Onigmo) regular expression 
 
 Important: do not attempt to add multiline support in your regular expressions if you are using [Tail](https://github.com/fluent/fluent-bit-docs/tree/1787fd8bfb2035bf10faf8cb7b14c4521e1265b3/pipeline/input/tail.md) input plugin since each line is handled as a separated entity. Instead use Tail [Multiline](https://github.com/fluent/fluent-bit-docs/tree/1787fd8bfb2035bf10faf8cb7b14c4521e1265b3/pipeline/input/tail.md#multiline) support configuration feature.
 
+Security Warning: Onigmo is a _backtracking_ regex engine. You need to be careful not to use expensive regex patterns, or Onigmo can take very long time to perform pattern matching. For details, please read the article ["ReDoS"](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) on OWASP.
+
 > Note: understanding how regular expressions works is out of the scope of this content.
 
 From a configuration perspective, when the format is set to **regex**, is mandatory and expected that a _Regex_ configuration key exists.


### PR DESCRIPTION
Fluent Bit uses Onigmo as the regex backend. It is known that Onigmo
is vulnerable to ReDoS i.e. it uses exponential computation time on
a certain type of expressions.

Add a clear warning about it, so that our users can exercise caution
when writing their configurations.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>