### PR TITLE
installation: windows: Document "Windows Service"

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -90,3 +90,42 @@ Click Next and proceed. By default, Fluent Bit is installed into `C:\Program Fil
 PS> C:\Program Files\td-agent-bit\bin\fluent-bit.exe -i dummy -o stdout
 ```
 
+## Windows Service Support
+
+Windows services are equivalent to "daemons" in UNIX (i.e. long-running background processes). Since v1.5.0, Fluent Bit has the native support for Windows Service.
+
+Suppose you have the following installation layout:
+
+```
+C:\fluent-bit\
+├── conf
+│   ├── fluent-bit.conf
+│   └── parsers.conf
+└── bin
+    ├── fluent-bit.dll
+    └── fluent-bit.exe
+
+```
+
+To register Fluent Bit as a Windows service, you need to execute the following command on Command Prompt. Please be careful that a single space is required after `binpath=`.
+
+```
+% sc.exe create fluent-bit binpath= "\fluent-bit\bin\fluent-bit.exe -c \fluent-bit\conf\fluent-bit.conf"
+```
+
+Now Fluent Bit can be started and managed as a normal Windows service.
+
+```
+% sc.exe start fluent-bit
+% sc.exe query fluent-bit
+SERVICE_NAME: fluent-bit
+    TYPE               : 10  WIN32_OWN_PROCESS
+    STATE              : 4 Running
+    ...
+```
+
+To halt the Fluent Bit service, just execute the "stop" command.
+
+```
+% sc.exe stop fluent-bit
+``


### PR DESCRIPTION
This adds a basic explanation on how to register & manipulate
Fluent Bit as Windows Service.

This should be useful for users who want to install Fluent Bit to
their Windows servers.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>