### PR TITLE
Add missing documentation for Tail plugin

### DIFF
--- a/pipeline/inputs/tail.md
+++ b/pipeline/inputs/tail.md
@@ -26,6 +26,7 @@ The plugin supports the following configuration parameters:
 | Key | When a message is unstructured \(no parser applied\), it's appended as a string under the key name _log_. This option allows to define an alternative name for that key. | log |
 | Tag | Set a tag \(with regex-extract fields\) that will be placed on lines read. E.g. `kube.<namespace_name>.<pod_name>.<container_name>`. Note that "tag expansion" is supported: if the tag includes an asterisk \(\*\), that asterisk will be replaced with the absolute path of the monitored file \(also see [Workflow of Tail + Kubernetes Filter](https://github.com/fluent/fluent-bit-docs/tree/00bb8cbd96cc06988ff3e51b4933e16e49206c70/pipeline/filter/kubernetes.md)\). |  |
 | Tag\_Regex | Set a regex to exctract fields from the file. E.g. `(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-` |  |
+| Exit\_On\_EOF | Exit Fluent Bit when reaching EOF on a monitored file. | Off |
 
 Note that if the database parameter _db_ is **not** specified, by default the plugin will start reading each target file from the beginning.
 
@@ -48,6 +49,7 @@ Docker mode exists to recombine JSON log lines split by the Docker daemon due to
 | :--- | :--- | :--- |
 | Docker\_Mode | If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline. | Off |
 | Docker\_Mode\_Flush | Wait period time in seconds to flush queued unfinished split lines. | 4 |
+| Docker\_Mode\_Parser | Specify the parser name to fetch log first line for muliline log. |  | 
 
 ## Getting Started <a id="getting_started"></a>
 


### PR DESCRIPTION
The Docker_Mode_Parser and Exit_On_EOF parameters were undocumented (Tail input plugin). This PR documents them.