### PR TITLE
inputs/tail: Clarify path pattern and file rotation

### DIFF
--- a/pipeline/inputs/tail.md
+++ b/pipeline/inputs/tail.md
@@ -1,8 +1,8 @@
 # Tail
 
-The **tail** input plugin allows to monitor one or several text files. It has a similar behavior like _tail -f_ shell command.
+The **tail** input plugin allows to monitor one or several text files. It has a similar behavior like `tail -f` shell command.
 
-The plugin reads every matched file in the _Path_ pattern and for every new line found \(separated by a \n\), it generates a new record. Optionally a database file can be used so the plugin can have a history of tracked files and a state of offsets, this is very useful to resume a state if the service is restarted.
+The plugin reads every matched file in the `Path` pattern and for every new line found \(separated by a `\n`\), it generates a new record. Optionally a database file can be used so the plugin can have a history of tracked files and a state of offsets, this is very useful to resume a state if the service is restarted.
 
 ## Configuration Parameters <a id="config"></a>
 
@@ -10,11 +10,11 @@ The plugin supports the following configuration parameters:
 
 | Key | Description | Default |
 | :--- | :--- | :--- |
-| Buffer\_Chunk\_Size | Set the initial buffer size to read files data. This value is used too to increase buffer size. The value must be according to the [Unit Size](https://github.com/fluent/fluent-bit-docs/tree/00bb8cbd96cc06988ff3e51b4933e16e49206c70/pipeline/configuration/unit_sizes.md) specification. | 32k |
-| Buffer\_Max\_Size | Set the limit of the buffer size per monitored file. When a buffer needs to be increased \(e.g: very long lines\), this value is used to restrict how much the memory buffer can grow. If reading a file exceed this limit, the file is removed from the monitored file list. The value must be according to the [Unit Size](https://github.com/fluent/fluent-bit-docs/tree/00bb8cbd96cc06988ff3e51b4933e16e49206c70/pipeline/configuration/unit_sizes.md) specification. | Buffer\_Chunk\_Size |
-| Path | Pattern specifying a specific log files or multiple ones through the use of common wildcards. |  |
+| Buffer\_Chunk\_Size | Set the initial buffer size to read files data. This value is used to increase buffer size. The value must be according to the [Unit Size](https://github.com/fluent/fluent-bit-docs/tree/00bb8cbd96cc06988ff3e51b4933e16e49206c70/pipeline/configuration/unit_sizes.md) specification. | 32k |
+| Buffer\_Max\_Size | Set the limit of the buffer size per monitored file. When a buffer needs to be increased \(e.g: very long lines\), this value is used to restrict how much the memory buffer can grow. If reading a file exceeds this limit, the file is removed from the monitored file list. The value must be according to the [Unit Size](https://github.com/fluent/fluent-bit-docs/tree/00bb8cbd96cc06988ff3e51b4933e16e49206c70/pipeline/configuration/unit_sizes.md) specification. | Buffer\_Chunk\_Size |
+| Path | Pattern specifying a specific log file or multiple ones through the use of common wildcards. Multiple patterns separated by commas are also allowed. |  |
 | Path\_Key | If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map. |  |
-| Exclude\_Path | Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: Exclude\_Path \*.gz,\*.zip |  |
+| Exclude\_Path | Set one or multiple shell patterns separated by commas to exclude files matching certain criteria, e.g: `Exclude_Path *.gz,*.zip` |  |
 | Refresh\_Interval | The interval of refreshing the list of watched files in seconds. | 60 |
 | Rotate\_Wait | Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed. | 5 |
 | Ignore\_Older | Ignores records which are older than this time in seconds. Supports m,h,d \(minutes, hours, days\) syntax. Default behavior is to read all records from specified files. Only available when a Parser is specificied and it can parse the time of a record. |  |
@@ -22,13 +22,13 @@ The plugin supports the following configuration parameters:
 | DB | Specify the database file to keep track of monitored files and offsets. |  |
 | DB.Sync | Set a default synchronization \(I/O\) method. Values: Extra, Full, Normal, Off. This flag affects how the internal SQLite engine do synchronization to disk, for more details about each option please refer to [this section](https://www.sqlite.org/pragma.html#pragma_synchronous). | Full |
 | Mem\_Buf\_Limit | Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes. |  |
-| exit\_on\_eof | exit Fluent Bit when reaching EOF of the monitored files | false |
+| exit\_on\_eof | Exit Fluent Bit when reaching EOF of the monitored files. | false |
 | Parser | Specify the name of a parser to interpret the entry as a structured message. |  |
 | Key | When a message is unstructured \(no parser applied\), it's appended as a string under the key name _log_. This option allows to define an alternative name for that key. | log |
 | Tag | Set a tag \(with regex-extract fields\) that will be placed on lines read. E.g. `kube.<namespace_name>.<pod_name>.<container_name>`. Note that "tag expansion" is supported: if the tag includes an asterisk \(\*\), that asterisk will be replaced with the absolute path of the monitored file \(also see [Workflow of Tail + Kubernetes Filter](https://github.com/fluent/fluent-bit-docs/tree/00bb8cbd96cc06988ff3e51b4933e16e49206c70/pipeline/filter/kubernetes.md)\). |  |
 | Tag\_Regex | Set a regex to exctract fields from the file. E.g. `(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace_name>[^_]+)_(?<container_name>.+)-` |  |
 
-Note that if the database parameter _db_ is **not** specified, by default the plugin will start reading each target file from the beginning.
+Note that if the database parameter `DB` is **not** specified, by default the plugin will start reading each target file from the beginning.
 
 ### Multiline Configuration Parameters <a id="multiline"></a>
 
@@ -112,7 +112,8 @@ By default SQLite client tool do not format the columns in a human read-way, so 
 .width 5 32 12 12 10
 ```
 
-## Files Rotation
+## File Rotation
 
-Files rotation are properly handled, including logrotate _copytruncate_ mode.
+File rotation is properly handled, including logrotate's _copytruncate_ mode.
 
+Note that the `Path` patterns **cannot** match the rotated files. Otherwise, the rotated file would be read again and lead to duplicate records.


### PR DESCRIPTION
Clarify that the path pattern cannot match the rotated files; otherwise,
the rotated files would get read again and lead to duplicate records.

While there, fix some minor grammar and formatting issues.

Signed-off-by: Aaron LI <aly@aaronly.me>