### PR TITLE
tcp-and-tls: fix netcat missing '-p' port keyword

### DIFF
--- a/pipeline/outputs/tcp-and-tls.md
+++ b/pipeline/outputs/tcp-and-tls.md
@@ -39,7 +39,7 @@ We have specified to gather [CPU](https://github.com/fluent/fluent-bit-docs/tree
 Run the following in a separate terminal, netcat will start listening for messages on TCP port 5170
 
 ```text
-$ nc -l 5170
+$ nc -l -p 5170
 ```
 
 Start Fluent Bit


### PR DESCRIPTION
Current result with `nc -l 6666` I get `[error] [io] connection #19 failed to: 127.0.0.1:6666`:
```machine@buster:~/fluent-bit/build$ bin/fluent-bit -i cpu -o tcp://127.0.0.1:6666 -p format=json_lines -v
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/18 20:40:45] [ info] Configuration:
[2020/09/18 20:40:45] [ info]  flush time     | 5.000000 seconds
[2020/09/18 20:40:45] [ info]  grace          | 5 seconds
[2020/09/18 20:40:45] [ info]  daemon         | 0
[2020/09/18 20:40:45] [ info] ___________
[2020/09/18 20:40:45] [ info]  inputs:
[2020/09/18 20:40:45] [ info]      cpu
[2020/09/18 20:40:45] [ info] ___________
[2020/09/18 20:40:45] [ info]  filters:
[2020/09/18 20:40:45] [ info] ___________
[2020/09/18 20:40:45] [ info]  outputs:
[2020/09/18 20:40:45] [ info]      tcp.0
[2020/09/18 20:40:45] [ info] ___________
[2020/09/18 20:40:45] [ info]  collectors:
[2020/09/18 20:40:45] [ info] [engine] started (pid=24968)
[2020/09/18 20:40:45] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/18 20:40:45] [debug] [storage] [cio stream] new stream registered: cpu.0
[2020/09/18 20:40:45] [ info] [storage] version=1.0.5, initializing...
[2020/09/18 20:40:45] [ info] [storage] in-memory
[2020/09/18 20:40:45] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/18 20:40:45] [debug] [router] default match rule cpu.0:tcp.0
[2020/09/18 20:40:45] [ info] [sp] stream processor started
[2020/09/18 20:40:49] [debug] [task] created task=0x55f4bcd21720 id=0 OK
[2020/09/18 20:40:49] [error] [io] connection #19 failed to: 127.0.0.1:6666
[2020/09/18 20:40:49] [debug] [upstream] connection #19 failed to 127.0.0.1:6666
[2020/09/18 20:40:49] [error] [output:tcp:tcp.0] no upstream connections available to 127.0.0.1:6666
[2020/09/18 20:40:49] [debug] [retry] new retry created for task_id=0 attemps=1
[2020/09/18 20:40:49] [ warn] [engine] failed to flush chunk '24968-1600461645.885489579.flb', retry in 11 seconds: task_id=0, input=cpu.0 > output=tcp.0
[2020/09/18 20:40:54] [debug] [task] created task=0x55f4bcd21b80 id=1 OK
[2020/09/18 20:40:54] [error] [io] connection #20 failed to: 127.0.0.1:6666
```
With this fix `nc -l -p 6666` I get `[upstream] KA connection #19 to 127.0.0.1:6666 is now available`:
```machine@buster:~/fluent-bit/build$ bin/fluent-bit -i cpu -o tcp://127.0.0.1:6666 -p format=json_lines -v
Fluent Bit v1.6.0
* Copyright (C) 2019-2020 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2020/09/18 20:41:14] [ info] Configuration:
[2020/09/18 20:41:14] [ info]  flush time     | 5.000000 seconds
[2020/09/18 20:41:14] [ info]  grace          | 5 seconds
[2020/09/18 20:41:14] [ info]  daemon         | 0
[2020/09/18 20:41:14] [ info] ___________
[2020/09/18 20:41:14] [ info]  inputs:
[2020/09/18 20:41:14] [ info]      cpu
[2020/09/18 20:41:14] [ info] ___________
[2020/09/18 20:41:14] [ info]  filters:
[2020/09/18 20:41:14] [ info] ___________
[2020/09/18 20:41:14] [ info]  outputs:
[2020/09/18 20:41:14] [ info]      tcp.0
[2020/09/18 20:41:14] [ info] ___________
[2020/09/18 20:41:14] [ info]  collectors:
[2020/09/18 20:41:14] [ info] [engine] started (pid=25216)
[2020/09/18 20:41:14] [debug] [engine] coroutine stack size: 24576 bytes (24.0K)
[2020/09/18 20:41:14] [debug] [storage] [cio stream] new stream registered: cpu.0
[2020/09/18 20:41:14] [ info] [storage] version=1.0.5, initializing...
[2020/09/18 20:41:14] [ info] [storage] in-memory
[2020/09/18 20:41:14] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2020/09/18 20:41:14] [debug] [router] default match rule cpu.0:tcp.0
[2020/09/18 20:41:14] [ info] [sp] stream processor started
[2020/09/18 20:41:18] [debug] [task] created task=0x5632fdf66720 id=0 OK
[2020/09/18 20:41:18] [debug] [upstream] KA connection #19 to 127.0.0.1:6666 is now available
[2020/09/18 20:41:18] [debug] [task] destroy task=0x5632fdf66720 (task_id=0)
[2020/09/18 20:41:23] [debug] [task] created task=0x5632fdf67030 id=0 OK
[2020/09/18 20:41:23] [debug] [upstream] KA connection #19 to 127.0.0.1:6666 has been assigned (recycled)
[2020/09/18 20:41:23] [debug] [upstream] KA connection #19 to 127.0.0.1:6666 is now available
[2020/09/18 20:41:23] [debug] [task] destroy task=0x5632fdf67030 (task_id=0)
```
