### PR TITLE
add Grace key in service

### DIFF
--- a/administration/configuring-fluent-bit/configuration-file.md
+++ b/administration/configuring-fluent-bit/configuration-file.md
@@ -29,6 +29,10 @@ The _Service_ section defines global properties of the service, the keys availab
 | :--- | :--- | :--- |
 
 
+| Grace | Set the grace time in `seconds` as Integer value. The engine loop uses a Grace timeout to define wait time on exit | 5 |
+| :--- | :--- | :--- |
+
+
 | Daemon | Boolean value to set if Fluent Bit should run as a Daemon \(background\) or not. Allowed values are: yes, no, on and off.  note: If you are using a Systemd based unit as the one we provide in our packages, do not turn on this option. | Off |
 | :--- | :--- | :--- |
 


### PR DESCRIPTION
https://docs.fluentbit.io/ seems missing grace key in Service section once existed in the document for ver1.3.

 * v1.4/1.5: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
 * v1.3: https://docs.fluentbit.io/manual/v/1.3/service

It seems the code still has the grace key 

https://github.com/fluent/fluent-bit/blob/master/include/fluent-bit/flb_config.h#L50

This pr is to re-add the grace key once existed in the previous minor version.

reference: https://github.com/fluent/fluent-bit/issues/2563

Signed-off-by: Kengo Suzuki <kengoscal@gmail.com>

