### PR TITLE
Document FLB_TLS as on by default.

### DIFF
--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -73,7 +73,7 @@ Fluent Bit provides certain options to CMake that can be enabled or disabled whe
 | :--- | :--- | :--- |
 | FLB\_ALL | Enable all features available | No |
 | FLB\_JEMALLOC | Use Jemalloc as default memory allocator | No |
-| FLB\_TLS | Build with SSL/TLS support | No |
+| FLB\_TLS | Build with SSL/TLS support | Yes |
 | FLB\_BINARY | Build executable | Yes |
 | FLB\_EXAMPLES | Build examples | Yes |
 | FLB\_SHARED\_LIB | Build shared library | Yes |


### PR DESCRIPTION
FLB_TLS is set to "on" [if FLB_OUT_TD is on](https://github.com/fluent/fluent-bit/blob/1b262cebff01a2d54c7dab8ff5d3d8e340faed30/CMakeLists.txt#L247-L249). FLB_OUT_TD is on by default, so FLB_TLS is on by default.