### PR TITLE
administration: monitoring: add note on Windows support

### DIFF
--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -8,6 +8,8 @@ Fluent Bit comes with a built-in HTTP Server that can be used to query internal 
 
 The monitoring interface can be easily integrated with Prometheus since we support it native format.
 
+NOTE: The Windows version does not support the HTTP monitoring feature yet as of v1.6.0.
+
 ## Getting Started <a id="getting_started"></a>
 
 To get started, the first step is to enable the HTTP Server from the configuration file:


### PR DESCRIPTION
Pierre-Olivier Latour submitted an issue that asked if Windows builds
support HTTP monitoring. Evidently this seems to be a rather common
question among Windows users.

https://github.com/fluent/fluent-bit/issues/2696

Let's document the support state clearly in the documentation.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>