### PR TITLE
Remove "auto_create_group" option of Firehose output plugin.

### DIFF
--- a/pipeline/outputs/firehose.md
+++ b/pipeline/outputs/firehose.md
@@ -14,7 +14,6 @@ This is the documentation for the core Fluent Bit Firehose plugin written in C. 
 | time\_key\_format | strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. This option is used with time\_key. |
 | log\_key | By default, the whole log record will be sent to Firehose. If you specify a key name with this option, then only the value of that key will be sent to Firehose. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to Firehose. |
 | role\_arn | ARN of an IAM role to assume \(for cross account access\). |
-| auto\_create\_group | Automatically create the log group. Valid values are "true" or "false" \(case insensitive\). Defaults to false. |
 | endpoint | Specify a custom endpoint for the Firehose API. |
 | sts\_endpoint | Custom endpoint for the STS API. |
 


### PR DESCRIPTION
Remove "auto_create_group" option as it's not a valid option for firehose output plugin.