### PR TITLE
Doc for setting up http proxy via `HTTP_PROXY`

### DIFF
--- a/administration/http-proxy.md
+++ b/administration/http-proxy.md
@@ -1,0 +1,14 @@
+---
+description: User a http proxy via HTTP\_PROXY environment variable.
+---
+
+# HTTP Proxy
+
+Fluent Bit supports setting up a HTTP proxy for all egress HTTP/HTTPS traffic by setting `HTTP_PROXY` environment variable:
+
+- You can setup `HTTP_PROXY=http://username:password@your-proxy.com:port` to use a `username` and `password` when connecting to the proxy.
+- You can also setup `HTTP_PROXY=http://your-proxy.com:port` to omit `username` and `password` if there is none.
+
+The `HTTP_PROXY` environment variable is a standard way for setting a HTTP proxy in a containerized environment ([reference](https://docs.docker.com/network/proxy/#use-environment-variables)), and it is also natively supported by any application written in Go. Therefore, we follow and implement the same convention for Fluent Bit.
+
+**Note**: we also have an older way for http proxy support in specific output plugins `output` plugin by its configuration. The configuration continues to work, however it _should not_ be used together with the `HTTP_PROXY` environment variable. This is because: under the hood, the `HTTP_RPOXY` based proxy support is implemented by setting up a TCP connection tunnel via [HTTP CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT). Both HTTP and HTTPS egress traffic can work this way. And this is different than the current plugin's implementation.

--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -10,7 +10,7 @@ The **http** output plugin allows to flush your records into a HTTP endpoint. Fo
 | http\_User | Basic Auth Username |  |
 | http\_Passwd | Basic Auth Password. Requires HTTP\_User to be set |  |
 | port | TCP port of the target HTTP Server | 80 |
-| Proxy | Specify an HTTP Proxy. The expected format of this value is [http://host:port](http://host:port). Note that _https_ is **not** supported yet. |  |
+| Proxy | Specify an HTTP Proxy. The expected format of this value is [http://host:port](http://host:port). Note that _https_ is **not** supported yet. Please consider not setting this and use `HTTP_PROXY` environment variable instead, which supports both http and https. |  |
 | uri | Specify an optional HTTP URI for the target web server, e.g: /something | / |
 | compress | Set payload compression mechanism. Option available is 'gzip' |  |
 | format | Specify the data format to be used in the HTTP request body, by default it uses _msgpack_. Other supported formats are _json_, _json\_stream_ and _json\_lines_ and _gelf_. | msgpack |
@@ -138,4 +138,3 @@ _sourcecategory="my_fluent_bit"
 | timeslice 1m
 | max(cpu) as cpu group by _timeslice
 ```
-


### PR DESCRIPTION
This is for documenting the `HTTP_PROXY` support implemented in https://github.com/fluent/fluent-bit/pull/2694

Signed-off-by: Yu Yi <yiyu@google.com>