### PR TITLE
output: es: Add Trace_Error

### DIFF
--- a/pipeline/outputs/elasticsearch.md
+++ b/pipeline/outputs/elasticsearch.md
@@ -31,6 +31,7 @@ The **es** output plugin, allows to ingest your records into a [Elasticsearch](h
 | Generate\_ID | When enabled, generate `_id` for outgoing records. This prevents duplicate records when retrying ES. | Off |
 | Replace\_Dots | When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3. | Off |
 | Trace\_Output | When enabled print the elasticsearch API calls to stdout \(for diag only\) | Off |
+| Trace\_Error | When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error | Off |
 | Current\_Time\_Index | Use current time for index generation instead of message record | Off |
 | Logstash\_Prefix\_Key | When included: the value in the record that belongs to the key will be looked up and over-write the Logstash\_Prefix for index generation. If the key/value is not found in the record then the Logstash\_Prefix option will act as a fallback. Nested keys are not supported \(if desired, you can use the nest filter plugin to remove nesting\) |  |
 


### PR DESCRIPTION
This must have been removed in the docs transition because it's visible on the website [for the 1.3 docs](https://docs.fluentbit.io/manual/v/1.3/output/elasticsearch).