### PR TITLE
filter: geoip2: Document GeoIP2 filter plugin

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -106,6 +106,7 @@
   * [Grep](pipeline/filters/grep.md)
   * [Kubernetes](pipeline/filters/kubernetes.md)
   * [Lua](pipeline/filters/lua.md)
+  * [GeoIP2](pipeline/filters/geoip2.md)
   * [Parser](pipeline/filters/parser.md)
   * [Record Modifier](pipeline/filters/record-modifier.md)
   * [Rewrite Tag](pipeline/filters/rewrite-tag.md)

--- a/pipeline/filters/geoip2.md
+++ b/pipeline/filters/geoip2.md
@@ -1,0 +1,50 @@
+# GeoIP2
+
+GeoIP2 Filter allows you to enrich the incoming data stream using location data from GeoIP2 database.
+
+## Configuration Parameters <a id="config"></a>
+
+This plugin supports the following configuration parameters:
+
+| Key | Description |
+| :--- | :--- |
+| database   | Path to the GeoIP2 database. |
+| lookup_key | Field name to process |
+| record     | Defines the `KEY LOOKUP_KEY VALUE` triplet. See below for how to set up this option. |
+
+## Getting Started <a id="getting_started"></a>
+
+The following configuration will process incoming `remote_addr`, and append country information retrieved from GeoLite2 database.
+
+```ini
+[INPUT]
+    Name   dummy
+    Dummy  {"remote_addr": "8.8.8.8"}
+
+[FILTER]
+    Name geoip2
+    Match *
+    Database GeoLite2-City.mmdb
+    Lookup_key remote_addr
+    Record country remote_addr %{country.names.en}
+    Record isocode remote_addr %{country.iso_code}
+
+[OUTPUT]
+    Name   stdout
+    Match  *
+```
+
+Each `Record` parameter above specifies the following triplet:
+
+ 1. The field name to be added to records (`country`)
+ 2. The lookup key to process (`remote_addr`)
+ 3. The query for GeoIP2 database (`%{country.names.en}`)
+
+By running Fluent Bit with the configuration above, you will see the following output:
+
+```json
+{"remote_addr": "8.8.8.8", "country": "United States", "isocode": "US"}
+```
+
+Note that the `GeoLite2-City.mmdb` database is available from [MaxMind's official site](https://dev.maxmind.com/geoip/geoip2/geolite2/).
+


### PR DESCRIPTION
Commit 3785f8a added a new filter plugin `filter_geoip2`.

https://github.com/fluent/fluent-bit/commit/3785f8a5a50b9ededaaf732c06285e9dc88f551e

This adds the basic documentation for the new plugin.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>