### PR TITLE
out_loki: fix loki output plugin default label

### DIFF
--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -13,7 +13,7 @@ The Fluent Bit `loki` built-in output plugin allows you to send your log or even
 | http\_user | Set HTTP basic authentication user name |  |
 | http\_passwd | Set HTTP basic authentication password |  |
 | tenant\_id | Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent. |  |
-| labels | Stream labels for API request. It can be multiple comma separated of strings specifying  `key=value` pairs. In addition to fixed parameters, it also allows to add custom record keys \(similar to `label_keys` property\). More details in the Labels section. | job=fluentbit |
+| labels | Stream labels for API request. It can be multiple comma separated of strings specifying  `key=value` pairs. In addition to fixed parameters, it also allows to add custom record keys \(similar to `label_keys` property\). More details in the Labels section. | job=fluent-bit |
 | label\_keys | Optional list of record keys that will be placed as stream labels. This configuration property is for records key only. More details in the Labels section. |  |
 | line\_format | Format to use when flattening the record to a log line. Valid values are `json` or `key_value`. If set to `json`,  the log line sent to Loki will be the Fluent Bit record dumped as JSON. If set to `key_value`, the log line will be each item in the record concatenated together \(separated by a single space\) in the format. | json |
 | auto\_kubernetes\_labels | If set to true, it will add all Kubernetes labels to the Stream labels | off |
@@ -45,15 +45,15 @@ If you decide that your Loki Stream will be composed by two labels called `job` 
 [OUTPUT]
     name   loki
     match  *
-    labels job=fluentbit, $sub['stream']
+    labels job=fluent-bit, $sub['stream']
 ```
 
-As you can see the label `job` has the value `fluentbit` and the second label is configured to access the nested map called `sub` targeting the value of the key `stream` . Note that the second label name **must** starts with a `$`, that means that's a [Record Accessor](https://github.com/fluent/fluent-bit-docs/tree/e09a871abb92a44911c8aa0edb2a3b58d2c36b6e/administration/configuring-fluent-bit/record-accessor/README.md) pattern so it provide you the ability to retrieve values from nested maps by using the key names.
+As you can see the label `job` has the value `fluent-bit` and the second label is configured to access the nested map called `sub` targeting the value of the key `stream` . Note that the second label name **must** starts with a `$`, that means that's a [Record Accessor](https://github.com/fluent/fluent-bit-docs/tree/e09a871abb92a44911c8aa0edb2a3b58d2c36b6e/administration/configuring-fluent-bit/record-accessor/README.md) pattern so it provide you the ability to retrieve values from nested maps by using the key names.
 
 When processing above's configuration, internally the ending labels for the stream in question becomes:
 
 ```text
-job="fluentbit", stream="stdout"
+job="fluent-bit", stream="stdout"
 ```
 
 Another feature of Labels management is the ability to provide custom key names, using the same record accessor pattern we can specify the key name manually and let the value to be populated automatically at runtime, e.g:
@@ -62,13 +62,13 @@ Another feature of Labels management is the ability to provide custom key names,
 [OUTPUT]
     name   loki
     match  *
-    labels job=fluentbit, mystream=$sub['stream']
+    labels job=fluent-bit, mystream=$sub['stream']
 ```
 
 When processing that new configuration, the internal labels will be:
 
 ```text
-job="fluentbit", mystream="stdout"
+job="fluent-bit", mystream="stdout"
 ```
 
 ### Using the `label_keys` property
@@ -81,7 +81,7 @@ The following configuration examples generate the same Stream Labels:
 [OUTPUT]
     name       loki
     match      *
-    labels     job=fluentbit
+    labels     job=fluent-bit
     label_keys $sub['stream']
 ```
 
@@ -91,13 +91,13 @@ the above configuration accomplish the same than this one:
 [OUTPUT]
     name   loki
     match  *
-    labels job=fluentbit, $sub['stream']
+    labels job=fluent-bit, $sub['stream']
 ```
 
 both will generate the following Streams label:
 
 ```text
-job="fluentbit", stream="stdout"
+job="fluent-bit", stream="stdout"
 ```
 
 ### Kubernetes & Labels
@@ -108,14 +108,14 @@ Note that if you are running in a Kubernetes environment, you might want to enab
 [OUTPUT]
     name                   loki
     match                  *
-    labels                 job=fluentbit
+    labels                 job=fluent-bit
     auto_kubernetes_labels on
 ```
 
 Based in the JSON example provided above, the internal stream labels will be:
 
 ```text
-job="fluentbit", team="Santiago Wanderers"
+job="fluent-bit", team="Santiago Wanderers"
 ```
 
 ## Networking and TLS Configuration
@@ -146,7 +146,7 @@ The following configuration example, will emit a dummy example record and ingest
     match                  *
     host                   127.0.0.1
     port                   3100
-    labels                 job=fluentbit    
+    labels                 job=fluent-bit
     label_keys             $sub['stream']
     auto_kubernetes_labels on
 ```


### PR DESCRIPTION
Loki output plugin use default label `job=fluent-bit`

https://github.com/fluent/fluent-bit/blob/26426262ebdf606139af4a241e25ece3afe5451a/plugins/out_loki/loki.c#L373-L381