### PR TITLE
add hint of forward plugin not allowing tag assignments to forward input section

### DIFF
--- a/concepts/key-concepts.md
+++ b/concepts/key-concepts.md
@@ -53,7 +53,7 @@ Every Event that gets into Fluent Bit gets assigned a Tag. This tag is an intern
 Most of the tags are assigned manually in the configuration. If a tag is not specified, Fluent Bit will assign the name of the Input plugin instance from where that Event was generated from.
 
 {% hint style="info" %}
-The only input plugin that **don't** assign Tags is [Forward]() input. This plugin speaks the Fluentd wire protocol called Forward where every Event already comes with a Tag associated. Fluent Bit will always use the incoming Tag set by the client.
+The only input plugin that **doesn't** assign Tags is [Forward]() input. This plugin speaks the Fluentd wire protocol called Forward where every Event already comes with a Tag associated. Fluent Bit will always use the incoming Tag set by the client.
 {% endhint %}
 
 A Tagged record must always have a Matching rule. To learn more about Tags and Matches check the [Routing](data-pipeline/router.md) section.

--- a/pipeline/inputs/forward.md
+++ b/pipeline/inputs/forward.md
@@ -2,6 +2,8 @@
 
 _Forward_ is the protocol used by [Fluent Bit](http://fluentbit.io) and [Fluentd](http://www.fluentd.org) to route messages between peers. This plugin implements the input service to listen for Forward messages.
 
+{% hint style="info" %} The Forward input is the only input plugin that **doesn't** assign Tags. It speaks the Fluentd wire protocol called Forward where every Event already comes with a Tag associated. Fluent Bit will always use the incoming Tag set by the client. For example the [fluentd logging driver](https://docs.docker.com/config/containers/logging/fluentd) for docker will use the container id as Tag. {% endhint %}
+
 ## Configuration Parameters
 
 The plugin supports the following configuration parameters:


### PR DESCRIPTION
The hint that the forward input plugin does not allow Tag assignment is only provided on the general input section but not on the section of the plugin itself. This PR adds this info to the section where a user would expect it.