### PR TITLE
improve wording of rewrite_tag recrod re-emitting

### DIFF
--- a/pipeline/filters/rewrite-tag.md
+++ b/pipeline/filters/rewrite-tag.md
@@ -10,7 +10,7 @@ The `rewrite_tag` filter, allows to re-emit a record under a new Tag. Once a rec
 
 ## How it Works
 
-The way it works is defining rules that matches specific record key content against a regular expression, if a match exists, a new record with the defined Tag will be emitted and go through the beginning of the pipeline. Multiple rules can be specified and they are processed in order until one of them matches.
+The way it works is defining rules that matches specific record key content against a regular expression, if a match exists, **a new record with the defined Tag will be emitted, entering from the beginning of the pipeline.** Multiple rules can be specified and they are processed in order until one of them matches.
 
 The new Tag to define can be composed by:
 
@@ -33,7 +33,7 @@ The `rewrite_tag` filter supports the following configuration parameters:
 
 ## Rules
 
-A rule aims to define matching criteria and specify how to create a new Tag for a record. You can define one or multiple rules in the same configuration section. The rules have the following format:
+A Rule aims to define matching criteria and specify how to create a new Tag for a record. You can define one or multiple Rules in the same configuration section. The Rules have the following format:
 
 ```text
 $KEY  REGEX  NEW_TAG  KEEP
@@ -79,15 +79,15 @@ If `$name` equals `abc-123` , then the following **placeholders** will be create
 * `$1` = "abc"
 * `$2` = "123"
 
-If the Regular expression do not matches an incoming record, the rule will be skipped and the next rule \(if any\) will be processed.
+If the Regular expression do not matches an incoming record, the Rule will be skipped and the next Rule \(if any\) will be processed.
 
 ### New Tag
 
-If a regular expression has matched the value of the defined key in the rule, we are ready to compose a new Tag for that specific record. The tag is a concatenated string that can contain any of the following characters: `a-z`,`A-Z`, `0-9` and `.-,`.
+If a regular expression has matched the value of the defined key in the Rule, we are ready to compose a new Tag for that specific record. The tag is a concatenated string that can contain any of the following characters: `a-z`,`A-Z`, `0-9` and `.-,`.
 
 A Tag can take any string value from the matching record, the original tag it self, environment variable or general placeholder.
 
-Consider the following incoming data on the rule:
+Consider the following incoming data on the Rule:
 
 * Tag = aa.bb.cc
 * Record =  `{"name": "abc-123", "ss": {"s1": {"s2": "flb"}}}`
@@ -109,9 +109,9 @@ We make use of placeholders, record content and environment variables.
 
 ### Keep
 
-If a rule matches the criteria the filter will emit a copy of the record with the new defined Tag. The property keep takes a boolean value to define if the original record with the old Tag must be preserved and continue in the pipeline or just be discarded.
+If a record matches a Rule the filter will emit a copy of the record with the new defined Tag. The property keep takes a boolean value to define if the original record with the old Tag must be preserved and continue in the pipeline or just be discarded.
 
-You can use `true` or `false` to decide the expected behavior. There is no default value and this is a mandatory field in the rule.
+You can use `true` or `false` to decide the expected behavior. There is no default value and this is a mandatory field in the Rule.
 
 ## Configuration Example
 


### PR DESCRIPTION
It is easily missed that the record under the new tag is re-emitted from the beginning of the pipeline. Also I aligned the usage of upper case for the keyword "Rule" to not be easily confused with the "Match rule".