### PR TITLE
Just updating to the latest tagged version

### DIFF
--- a/installation/yocto-embedded-linux.md
+++ b/installation/yocto-embedded-linux.md
@@ -7,7 +7,7 @@ We distribute two main recipes, one for testing/dev purposes and other with the 
 | Version | Recipe | Description |
 | :--- | :--- | :--- |
 | devel | [fluent-bit\_git.bb](https://github.com/fluent/fluent-bit/blob/master/fluent-bit_git.bb) | Build Fluent Bit from GIT master. This recipe aims to be used for development and testing purposes only. |
-| v1.6.10 | [fluent-bit\_1.6.10.bb](https://github.com/fluent/fluent-bit/blob/1.6/fluent-bit_1.6.10.bb) | Build latest stable version of Fluent Bit. |
+| v1.7.0 | [fluent-bit\_1.7.0.bb](https://github.com/fluent/fluent-bit/blob/v1.7.0/fluent-bit_1.7.0.bb) | Build latest stable version of Fluent Bit. |
 
 It's strongly recommended to always use the stable release of Fluent Bit recipe and not the one from GIT master for production deployments.
 


### PR DESCRIPTION
Currently the latest tagged version is 1.7.0.
We could consider tagging 1.8.0 and updating the docs appropriately. 