### PR TITLE
Loki can also utilize TLS

### DIFF
--- a/administration/security.md
+++ b/administration/security.md
@@ -33,6 +33,7 @@ The following **output** plugins can take advantage of the TLS feature:
 * [HTTP](../pipeline/outputs/http.md)
 * [InfluxDB](../pipeline/outputs/influxdb.md)
 * [Kafka REST Proxy](../pipeline/outputs/kafka-rest-proxy.md)
+* [Loki](../pipeline/outputs/loki.md)
 * [Slack](../pipeline/outputs/slack.md)
 * [Splunk](../pipeline/outputs/splunk.md)
 * [Stackdriver](../pipeline/outputs/stackdriver.md)


### PR DESCRIPTION
Example working configuration

```
[OUTPUT]
    Name loki
    Match *
    tls on
    Host loki.example.com
    Port 443
    http_user loki
    http_passwd 12345
```