### PR TITLE
Fixed false property in example config for http input docs

### DIFF
--- a/pipeline/inputs/http.md
+++ b/pipeline/inputs/http.md
@@ -38,7 +38,7 @@ curl -d @app.log -XPOST -H "content-type: application/json" http://localhost:888
     port 8888
 
 [OUTPUT]
-    type stdout
+    name stdout
     match *
 ```
 


### PR DESCRIPTION
The property `type` was referenced instead of `name`, which made the example configuration invalid.