### PR TITLE
in_docker_events: add parameters to reconnect with docker socket

### DIFF
--- a/pipeline/inputs/docker-events.md
+++ b/pipeline/inputs/docker-events.md
@@ -12,6 +12,8 @@ This plugin supports the following configuration parameters:
 | Buffer\_Size | The size of the buffer used to read docker events \(in bytes\) | 8192 |
 | Parser | Specify the name of a parser to interpret the entry as a structured message. | None |
 | Key | When a message is unstructured \(no parser applied\), it's appended as a string under the key name _message_. | message |
+| Reconnect.Retry_limits| The maximum number of retries allowed. The plugin tries to reconnect with docker socket when EOF is detected. | 5 |
+| Reconnect.Retry_interval| The retrying interval. Unit is second. | 1 |
 
 ### Command Line
 


### PR DESCRIPTION
This is a documentation of https://github.com/fluent/fluent-bit/pull/3440