### PR TITLE
out_file: fix 'path' description(#534)

### DIFF
--- a/pipeline/outputs/file.md
+++ b/pipeline/outputs/file.md
@@ -8,7 +8,7 @@ The plugin supports the following configuration parameters:
 
 | Key | Description |
 | :--- | :--- |
-| Path | Absolute directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory. note: this option was added on Fluent Bit v1.4.6 |
+| Path | Directory path to store files. If not set, Fluent Bit will write the files on it's own positioned directory. note: this option was added on Fluent Bit v1.4.6 |
 | File | Set file name to store the records. If not set, the file name will be the _tag_ associated with the records. |
 | Format | The format of the file content. See also Format section. Default: out\_file. |
 
@@ -107,6 +107,6 @@ In your main configuration file append the following Input & Output sections:
 [OUTPUT]
     Name file
     Match *
-    Path output.txt
+    Path output_dir
 ```
 


### PR DESCRIPTION
Fixes #534 

- `Path` should support absolute and relative path
- `Path` should be a directory path