### PR TITLE
pipeline: outputs: splunk: fix broken link

### DIFF
--- a/pipeline/outputs/splunk.md
+++ b/pipeline/outputs/splunk.md
@@ -60,7 +60,7 @@ To get more details about how to setup the HEC in Splunk please refer to the fol
 
 ### TLS / SSL
 
-Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](https://github.com/fluent/fluent-bit-docs/tree/16f30161dc4c79d407cd9c586a0c6839d0969d97/pipeline/configuration/tls_ssl.md) section.
+Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/security.md) section.
 
 ## Getting Started
 


### PR DESCRIPTION
Fix broken link.

https://docs.fluentbit.io/manual/pipeline/outputs/splunk#tls-ssl
```
Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the TLS/SSL section.
```