### PR TITLE
aws: add documentation for credentials chain

### DIFF
--- a/administration/aws-credentials.md
+++ b/administration/aws-credentials.md
@@ -1,0 +1,38 @@
+# AWS Credentials
+
+Plugins that interact with AWS services will fetch credentials from various providers in the following order.
+Only the first provider that is able to provide credentials will be used.
+
+All AWS plugins additionally support a `role_arn` (or `AWS_ROLE_ARN`, for [Elasticsearch](../pipeline/outputs/elasticsearch.md)) configuration parameter. If specified, the fetched credentials will then be used to assume the given role.
+
+## 1. Environment Variables
+
+Uses the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (and optionally `AWS_SESSION_TOKEN`) environment variables if set.
+
+## 2. Shared Configuration and Credentials Files
+
+Reads the shared config file at `$AWS_CONFIG_FILE` (or `$HOME/.aws/config`) and the shared credentials file at `$AWS_SHARED_CREDENTIALS_FILE` (or `$HOME/.aws/credentials`) to fetch the credentials for the profile named `$AWS_PROFILE` or `$AWS_DEFAULT_PROFILE` (or "default"). See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html.
+
+The shared settings will be evaluated in the following order.
+
+Setting|File|Description
+---|---|---
+`credential_process`|config| See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html.<br/>Supported on Linux only.
+`aws_access_key_id`<br/>`aws_secret_access_key`<br/>*`aws_session_token`*|credentials|Access key ID and secret key to use to authenticate.<br/>The session token must be set for temporary credentials.
+
+At this time, no other settings are supported.
+
+## 3. EKS Web Identity Token (OIDC)
+
+Fetches credentials via a signed web identity token for a Kubernetes service account.
+See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+
+## 4. ECS HTTP Credentials Endpoint
+
+Fetches credentials for the ECS task's role.
+See https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html.
+
+## 5. EC2 Instance Profile Credentials (IMDS)
+
+Fetches credentials for the EC2 instance profile's role.
+See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html.

--- a/pipeline/outputs/cloudwatch.md
+++ b/pipeline/outputs/cloudwatch.md
@@ -10,6 +10,8 @@ The Amazon CloudWatch output plugin allows to ingest your records into the [Clou
 
 This is the documentation for the core Fluent Bit CloudWatch plugin written in C. It can replace the [aws/amazon-cloudwatch-logs-for-fluent-bit](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit) Golang Fluent Bit plugin released last year. The Golang plugin was named `cloudwatch`; this new high performance CloudWatch plugin is called `cloudwatch_logs` to prevent conflicts/confusion. Check the amazon repo for the Golang plugin for details on the deprecation/migration plan for the original plugin.
 
+See [here](../../administration/aws-credentials.md) for details on how AWS credentials are fetched.
+
 ## Configuration Parameters
 
 | Key | Description |

--- a/pipeline/outputs/elasticsearch.md
+++ b/pipeline/outputs/elasticsearch.md
@@ -156,7 +156,7 @@ Fluent Bit v1.5 changed the default mapping type from `flb_type` to `_doc`, whic
 
 The Amazon ElasticSearch Service adds an extra security layer where HTTP requests must be signed with AWS Sigv4. Fluent Bit v1.5 introduced full support for Amazon ElasticSearch Service with IAM Authentication.
 
-Fluent Bit supports sourcing AWS credentials from any of the standard sources \(for example, an [Amazon EKS IAM Role for a Service Account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)\).
+See [here](../../administration/aws-credentials.md) for details on how AWS credentials are fetched.
 
 Example configuration:
 

--- a/pipeline/outputs/firehose.md
+++ b/pipeline/outputs/firehose.md
@@ -10,6 +10,8 @@ The Amazon Kinesis Data Firehose output plugin allows to ingest your records int
 
 This is the documentation for the core Fluent Bit Firehose plugin written in C. It can replace the [aws/amazon-kinesis-firehose-for-fluent-bit](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) Golang Fluent Bit plugin released last year. The Golang plugin was named `firehose`; this new high performance and highly efficient firehose plugin is called `kinesis_firehose` to prevent conflicts/confusion.
 
+See [here](../../administration/aws-credentials.md) for details on how AWS credentials are fetched.
+
 ## Configuration Parameters
 
 | Key | Description |

--- a/pipeline/outputs/kinesis.md
+++ b/pipeline/outputs/kinesis.md
@@ -10,6 +10,8 @@ The Amazon Kinesis Data Streams output plugin allows to ingest your records into
 
 This is the documentation for the core Fluent Bit Kinesis plugin written in C. It has all the core features of the [aws/amazon-kinesis-streams-for-fluent-bit](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) Golang Fluent Bit plugin released in 2019. The Golang plugin was named `kinesis`; this new high performance and highly efficient kinesis plugin is called `kinesis_streams` to prevent conflicts/confusion.
 
+See [here](../../administration/aws-credentials.md) for details on how AWS credentials are fetched.
+
 ## Configuration Parameters
 
 | Key | Description |

--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -14,6 +14,8 @@ The plugin allows you to specify a maximum file size, and a timeout for uploads.
 
 Records are stored in files in S3 as newline delimited JSON.
 
+See [here](../../administration/aws-credentials.md) for details on how AWS credentials are fetched.
+
 ## Configuration Parameters
 
 | Key | Description | Default |


### PR DESCRIPTION
Added documentation for the AWS credential chain precedence hierarchy, including the recently added support for `credential_process`.

cc @PettitWesley 