### PR TITLE
Include json_date_key in s3 output docs

### DIFF
--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -20,7 +20,8 @@ Records are stored in files in S3 as newline delimited JSON.
 | :--- | :--- | :--- |
 | region | The AWS region of you S3 bucket | us-east-1 |
 | bucket | S3 Bucket name | None |
-| json\_date\_format | Specifies the format of the date. Supported formats are double, iso8601 and epoch. | iso8601 |
+| json\_date\_key | Specify the name of the time key in the output record. To disable the time key just set the value to `false`. | date |
+| json\_date\_format | Specify the format of the date. Supported formats are _double_, _epoch_ and _iso8601_ \(eg: _2018-05-30T09:39:52.000681Z_\) | iso8601 |
 | total\_file\_size | Specifies the size of files in S3. Maximum size is 50G, minimim is 1M. | 100M |
 | upload\_chunk\_size | The size of each 'part' for multipart uploads. Max: 50M | 5,242,880 bytes |
 | upload\_timeout | Whenever this amount of time has elapsed, Fluent Bit will complete an upload and create a new file in S3. For example, set this value to 60m and you will get a new file every hour. | 10m |


### PR DESCRIPTION
- Match `stdout` doc wording

Based on this https://github.com/fluent/fluent-bit/issues/2700#issuecomment-882212296 by @PettitWesley and confirmed by testing, `json_date_key` is already supported by the S3 output processor but not included in the docs which confused me.

Wording updated to match [stdout](https://github.com/fluent/fluent-bit-docs/blob/master/pipeline/outputs/standard-output.md)