### PR TITLE
Add explanations of kinesis_firehose and cloudwatch_logs

### DIFF
--- a/installation/aws-container.md
+++ b/installation/aws-container.md
@@ -3,12 +3,20 @@
 AWS maintains a distribution of Fluent Bit combining the latest official release with a set of Go Plugins for sending logs to AWS services. AWS and Fluent Bit are working together to rewrite their plugins for inclusion in the official Fluent Bit distribution.
 
 ## Plugins
-
 Currently, the [AWS for Fluent Bit](https://github.com/aws/aws-for-fluent-bit) image contains Go Plugins for:
 
 * [Amazon CloudWatch Logs](https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit)
 * [Amazon Kinesis Firehose](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit)
 * [Amazon Kinesis Streams](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit)
+
+Fluent Bit includes Amazon CloudWatch Logs plugin named `cloudwatch_logs`, Amazon Kinesis Firehose plugin named `kinesis_firehose` and Amazon Kinesis Data Streams plugin named `kinesis_streams` which are higher performance than Go plugins.
+
+* [Amazon CloudWatch](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch)
+* [Amazon Kinesis Data Firehose](https://docs.fluentbit.io/manual/pipeline/outputs/firehose)
+* [Amazon Kinesis Data Streams](https://docs.fluentbit.io/manual/pipeline/outputs/kinesis)
+
+Also, Fluent Bit includes S3 output plugin named `s3`.
+* [Amazon S3](https://docs.fluentbit.io/manual/pipeline/outputs/s3)
 
 ## Versions and Regional Repositories
 


### PR DESCRIPTION
Added `kinesis_firehose` and `cloudwatch_logs` plugins into Core Fluent Bit Plugin.

* https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit#new-higher-performance-core-fluent-bit-plugin
* https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit#new-higher-performance-core-fluent-bit-plugin

So, add descriptions about them.
