### PR TITLE
out_datadog: add missing properties.

### DIFF
--- a/pipeline/outputs/datadog.md
+++ b/pipeline/outputs/datadog.md
@@ -16,9 +16,15 @@ Before you begin, you need a [Datadog account](https://app.datadoghq.com/signup)
 | TLS | _Required_ - End-to-end security communications security protocol. Datadog recommends setting this to `on`. | `off` |
 | compress | _Recommended_ - compresses the payload in GZIP format, Datadog supports and recommends setting this to `gzip`. |  |
 | apikey | _Required_ - Your [Datadog API key](https://app.datadoghq.com/account/settings#api). |  |
+| Proxy | _Optional_ - Specify an HTTP Proxy. The expected format of this value is _http://host:port_. Note that _https_ is __not__ supported yet. |  |
+| provider| To activate the remapping, specify configuration flag provider with value `ecs`.| |
+| json\_date\_key | Date key name for output. | `timestamp` |
+| include\_tag\_key| If enabled, a tag is appended to output. The key name is used `tag_key` property. |`false`|
+| tag\_key| The key name of tag. If `include_tag_key` is false, This property is ignored. | `tagkey` |
 | dd\_service | _Recommended_ - The human readable name for your service generating the logs - the name of your application or database. |  |
 | dd\_source | _Recommended_ - A human readable name for the underlying technology of your service. For example, `postgres` or `nginx`. |  |
 | dd\_tags | _Optional_ - The [tags](https://docs.datadoghq.com/tagging/) you want to assign to your logs in Datadog. |  |
+| dd\_message\_key | By default, the plugin searches for the key 'log' and remap the value to the key 'message'. If the property is set, the plugin will search the property name key.| |
 
 ### Configuration File
 


### PR DESCRIPTION
I added missing properties of out_datadog plugin.

- `proxy`
  - #249 
-  `provider`
  -  https://github.com/fluent/fluent-bit/pull/1579
- `json_date_key`
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog.c#L188
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog_conf.c#L170
- `include_tag_key`
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog.c#L194
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog_conf.c#L92
- `tag_key`
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog.c#L197
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog_conf.c#L103
- `dd_message_key`
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog.c#L235
  - https://github.com/fluent/fluent-bit/blob/v1.8.4/plugins/out_datadog/datadog_conf.c#L130