### PR TITLE
configuration-file: add 'scheduler.cap' and 'scheduler.base'

### DIFF
--- a/administration/configuring-fluent-bit/configuration-file.md
+++ b/administration/configuring-fluent-bit/configuration-file.md
@@ -35,6 +35,8 @@ The _Service_ section defines global properties of the service, the keys availab
 | HTTP\_Listen | Set listening interface for HTTP Server when it's enabled | 0.0.0.0 |
 | HTTP\_Port | Set TCP Port for the HTTP Server | 2020 |
 | Coro\_Stack\_Size | Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value \(say 4096\), or coroutine threads can overrun the stack buffer. Do not change the default value of this parameter unless you know what you are doing. | 24576 |
+| scheduler.cap | Set a maximum retry time in second. The property is supported from v1.8.7. |2000|
+| scheduler.base | Set a base of exponential backoff. The property is supported from v1.8.7. |5|
 
 The following is an example of a _SERVICE_ section:
 


### PR DESCRIPTION
This patch is to add description about https://github.com/fluent/fluent-bit/pull/4099
The feature is supported from v1.8.7.

https://github.com/fluent/fluent-bit/commits/v1.8.7