### PR TITLE
output: elasticsearch: Document how to fix validation errors

### DIFF
--- a/pipeline/outputs/elasticsearch.md
+++ b/pipeline/outputs/elasticsearch.md
@@ -192,3 +192,16 @@ Example configuration:
     cloud_auth elastic:2vxxxxxxxxYV
 ```
 
+### Validation Failed: 1: an id must be provided if version type or value are set
+
+Since v1.8.2, Fluent Bit started using `create` method (instead of `index`) for data submission. This makes Flunt Bit compatible with Datastream introduced in Elasticsearch 7.9.
+
+If you see `action_request_validation_exception` errors on your pipeline with Fluent Bit >= v1.8.2, you can fix it up by turning on `Generate_ID` as follows:
+
+```text
+[OUTPUT]
+    Name es
+    Match *
+    Host  192.168.12.1
+    Generate_ID on
+```


### PR DESCRIPTION
This adds a FAQ that explains how to fix the following error:

    {"type":"action_request_validation_exception",
     "reason":"Validation Failed: 1: an id must be
     provided if version type or value are set;"}

Should fix fluent/fluent-bit/issues/3909

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>