### PR TITLE
Build flag `FLB_OUT_NATS` is default to On

### DIFF
--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -172,7 +172,7 @@ The _output plugins_ gives the capacity to flush the information to some externa
 | [FLB\_OUT\_KAFKA](../../pipeline/outputs/kafka.md) | Enable Kafka output | Off |
 | [FLB\_OUT\_KAFKA\_REST](../../pipeline/outputs/kafka-rest-proxy.md) | Enable Kafka REST Proxy output plugin | On |
 | FLB\_OUT\_LIB | Enable Lib output plugin | On |
-| [FLB\_OUT\_NATS](../../pipeline/outputs/nats.md) | Enable [NATS](http://www.nats.io) output plugin | Off |
+| [FLB\_OUT\_NATS](../../pipeline/outputs/nats.md) | Enable [NATS](http://www.nats.io) output plugin | On |
 | FLB\_OUT\_NULL | Enable NULL output plugin | On |
 | FLB\_OUT\_PGSQL | Enable PostgreSQL output plugin | On |
 | FLB\_OUT\_PLOT | Enable Plot output plugin | On |


### PR DESCRIPTION
Build flag `FLB_OUT_NATS` seems to be enabled by default, according to the current CMakeLists.txt:
https://github.com/fluent/fluent-bit/blob/8c491202d62d996b7412726bb2c13f0761b887f6/CMakeLists.txt#L159