### PR TITLE
Fix Authorization header in remote-write example

### DIFF
--- a/pipeline/outputs/prometheus-remote-write.md
+++ b/pipeline/outputs/prometheus-remote-write.md
@@ -44,7 +44,7 @@ The Prometheus remote write plugin only works with metrics collected by one of t
     Host                 metric-api.newrelic.com
     Port                 443
     Uri                  /prometheus/v1/write?prometheus_server=YOUR_DATA_SOURCE_NAME
-    Header               bearer_token YOUR_LICENSE_KEY
+    Header               Authorization Bearer YOUR_LICENSE_KEY
     Log_response_payload True
     Tls                  On
     Tls.verify           On


### PR DESCRIPTION
The example for sending prometheus metrics to New Relic sets the header "bearer_token" when it should be setting the header "Authorization". The former doesn't work, and results in a 400 response. The Logz.io and Coralogix examples already used the correct form, this just brings the main example into line.