### PR TITLE
change stale link due to CORS

### DIFF
--- a/administration/configuring-fluent-bit/configuration-file.md
+++ b/administration/configuring-fluent-bit/configuration-file.md
@@ -132,7 +132,7 @@ The following configuration file example demonstrates how to collect CPU metrics
 
 ## Visualize <a href="config_include_file" id="config_include_file"></a>
 
-You can also visualize Fluent Bit INPUT, FILTER, and OUTPUT configuration via [https://config.calyptia.com](https://config.calyptia.com)
+You can also visualize Fluent Bit INPUT, FILTER, and OUTPUT configuration via [https://cloud.calyptia.com](https://cloud.calyptia.com/visualizer)
 
 ![](../../.gitbook/assets/image.png)
 


### PR DESCRIPTION
In the recent documentation, the link to the config virtualization tool cannot open, due to the CORS policy from https://cloud-api.calyptia.com/

<img width="1610" alt="CleanShot 2022-01-26 at 07 45 53@2x" src="https://user-images.githubusercontent.com/965612/151078594-625786b2-2964-444b-8a36-8ad883311496.png">

After digging, I think the link should be change to https://cloud.calyptia.com