### PR TITLE
linux: key update info

### DIFF
--- a/installation/linux/README.md
+++ b/installation/linux/README.md
@@ -9,6 +9,11 @@ curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 
 If this fails or for more details on the installation then please refer to the specific section for your OS.
 
+## GPG key updates
+
+From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
+The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
+
 ## Migration to Fluent Bit
 
 From version 1.9, `td-agent-bit` is a deprecated package and will be removed in the future.

--- a/installation/linux/README.md
+++ b/installation/linux/README.md
@@ -14,6 +14,11 @@ If this fails or for more details on the installation then please refer to the s
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
+The fingerprint of the new key is:
+```
+C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
+Fluentbit releases (Releases signing key) <releases@fluentbit.io>
+```
 ## Migration to Fluent Bit
 
 From version 1.9, `td-agent-bit` is a deprecated package and will be removed in the future.

--- a/installation/linux/README.md
+++ b/installation/linux/README.md
@@ -14,11 +14,17 @@ If this fails or for more details on the installation then please refer to the s
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
-The fingerprint of the new key is:
+The GPG Key fingerprint of the new key is:
 ```
 C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
 Fluentbit releases (Releases signing key) <releases@fluentbit.io>
 ```
+
+Note that if the platform is not supported in 1.9 you should include the https://packages.fluentbit.io/fluentbit-legacy.key key.
+
+The GPG Key fingerprint of the old key is: `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+
+Refer to the [supported platform documentation](./../supported-platforms.md) to see which platforms are supported in each release.
 ## Migration to Fluent Bit
 
 From version 1.9, `td-agent-bit` is a deprecated package and will be removed in the future.

--- a/installation/linux/amazon-linux.md
+++ b/installation/linux/amazon-linux.md
@@ -22,7 +22,10 @@ enabled=1
 
 note: we encourage you always enable the _gpgcheck_ for security reasons. All our packages are signed.
 
-The GPG Key fingerprint is `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+### Updated key for 1.9 release onwards
+
+From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
+The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
 ### Install
 

--- a/installation/linux/amazon-linux.md
+++ b/installation/linux/amazon-linux.md
@@ -27,6 +27,17 @@ note: we encourage you always enable the _gpgcheck_ for security reasons. All ou
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
+The GPG Key fingerprint of the new key is:
+```
+C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
+Fluentbit releases (Releases signing key) <releases@fluentbit.io>
+```
+
+Note that if the platform is not supported in 1.9 you should include the https://packages.fluentbit.io/fluentbit-legacy.key key.
+
+The GPG Key fingerprint of the old key is: `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+
+Refer to the [supported platform documentation](./../supported-platforms.md) to see which platforms are supported in each release.
 ### Install
 
 Once your repository is configured, run the following command to install it:

--- a/installation/linux/debian.md
+++ b/installation/linux/debian.md
@@ -10,6 +10,12 @@ Follow the official Debian wiki guidance: https://wiki.debian.org/DebianReposito
 ```bash
 curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
 ```
+
+### Updated key for 1.9 release onwards
+
+From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
+The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
+
 ## Update your sources lists
 
 On Debian, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file - ensure to set `CODENAME` to your specific [Ubuntu release name](https://wiki.ubuntu.com/Releases) (e.g. `focal` for Ubuntu 20.04):

--- a/installation/linux/debian.md
+++ b/installation/linux/debian.md
@@ -16,6 +16,17 @@ curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/ke
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
+The GPG Key fingerprint of the new key is:
+```
+C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
+Fluentbit releases (Releases signing key) <releases@fluentbit.io>
+```
+
+Note that if the platform is not supported in 1.9 you should include the https://packages.fluentbit.io/fluentbit-legacy.key key.
+
+The GPG Key fingerprint of the old key is: `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+
+Refer to the [supported platform documentation](./../supported-platforms.md) to see which platforms are supported in each release.
 ## Update your sources lists
 
 On Debian, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file - ensure to set `CODENAME` to your specific [Ubuntu release name](https://wiki.ubuntu.com/Releases) (e.g. `focal` for Ubuntu 20.04):

--- a/installation/linux/raspbian-raspberry-pi.md
+++ b/installation/linux/raspbian-raspberry-pi.md
@@ -18,6 +18,17 @@ curl https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
+The GPG Key fingerprint of the new key is:
+```
+C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
+Fluentbit releases (Releases signing key) <releases@fluentbit.io>
+```
+
+Note that if the platform is not supported in 1.9 you should include the https://packages.fluentbit.io/fluentbit-legacy.key key.
+
+The GPG Key fingerprint of the old key is: `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+
+Refer to the [supported platform documentation](./../supported-platforms.md) to see which platforms are supported in each release.
 ## Update your sources lists
 
 On Debian and derivative systems such as Raspbian, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file.

--- a/installation/linux/raspbian-raspberry-pi.md
+++ b/installation/linux/raspbian-raspberry-pi.md
@@ -13,6 +13,11 @@ The first step is to add our server GPG key to your keyring, on that way you can
 curl https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -
 ```
 
+### Updated key for 1.9 release onwards
+
+From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
+The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
+
 ## Update your sources lists
 
 On Debian and derivative systems such as Raspbian, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file.

--- a/installation/linux/redhat-centos.md
+++ b/installation/linux/redhat-centos.md
@@ -28,6 +28,17 @@ All our packages are signed.
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
+The GPG Key fingerprint of the new key is:
+```
+C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
+Fluentbit releases (Releases signing key) <releases@fluentbit.io>
+```
+
+Note that if the platform is not supported in 1.9 you should include the https://packages.fluentbit.io/fluentbit-legacy.key key.
+
+The GPG Key fingerprint of the old key is: `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+
+Refer to the [supported platform documentation](./../supported-platforms.md) to see which platforms are supported in each release.
 ### Install
 
 Once your repository is configured, run the following command to install it:

--- a/installation/linux/redhat-centos.md
+++ b/installation/linux/redhat-centos.md
@@ -23,6 +23,11 @@ enabled=1
 It is best practice to always enable the _gpgcheck_ for security reasons.
 All our packages are signed.
 
+### GPG key updates
+
+From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
+The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
+
 ### Install
 
 Once your repository is configured, run the following command to install it:

--- a/installation/linux/snap.md
+++ b/installation/linux/snap.md
@@ -19,11 +19,3 @@ $ sudo snap services fluent-bit
 Service             Startup  Current  Notes
 fluent-bit.service  enabled  active   -
 ```
-
-### Service Configuration
-
-To get the exact path of the configuration file, start a Snap shell and dig into the environment variables:
-
-
-
-The default configuration file for the running service is located at

--- a/installation/linux/ubuntu.md
+++ b/installation/linux/ubuntu.md
@@ -11,9 +11,15 @@ Follow the official Debian wiki guidance: https://wiki.debian.org/DebianReposito
 curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg
 ```
 
+
+### Updated key for 1.9 release onwards
+
+From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
+The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
+
 ## Update your sources lists
 
-On Debian, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file - ensure to set `CODENAME` to your specific [Debian release name](https://wiki.debian.org/DebianReleases#Production_Releases) (e.g. `bullseye` for Debian 11):
+On Ubuntu, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file - ensure to set `CODENAME` to your specific [Ubuntu release name](https://wiki.ubuntu.com/Releases) (e.g. `focal` for Ubuntu 20.04):
 
 ```bash
 deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/debian/${CODENAME} ${CODENAME} main

--- a/installation/linux/ubuntu.md
+++ b/installation/linux/ubuntu.md
@@ -17,6 +17,17 @@ curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/ke
 From the 1.9 release please note that the GPG key has been updated at https://packages.fluentbit.io/fluentbit.key so ensure the new one is added.
 The previous key is still available at https://packages.fluentbit.io/fluentbit-legacy.key and may be required to install previous versions.
 
+The GPG Key fingerprint of the new key is:
+```
+C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
+Fluentbit releases (Releases signing key) <releases@fluentbit.io>
+```
+
+Note that if the platform is not supported in 1.9 you should include the https://packages.fluentbit.io/fluentbit-legacy.key key.
+
+The GPG Key fingerprint of the old key is: `F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A`
+
+Refer to the [supported platform documentation](./../supported-platforms.md) to see which platforms are supported in each release.
 ## Update your sources lists
 
 On Ubuntu, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file - ensure to set `CODENAME` to your specific [Ubuntu release name](https://wiki.ubuntu.com/Releases) (e.g. `focal` for Ubuntu 20.04):

--- a/installation/supported-platforms.md
+++ b/installation/supported-platforms.md
@@ -7,12 +7,14 @@ The following operating systems and architectures are supported in Fluent Bit.
 | Linux | [Amazon Linux 2](linux/amazon-linux.md) | x86\_64, Arm64v8 |
 |  | [Centos 8](linux/redhat-centos.md) | x86\_64, Arm64v8 |
 |  | [Centos 7](linux/redhat-centos.md) | x86\_64, Arm64v8 |
+|  | [Debian 11 \(Bullseye\)](linux/debian.md) | x86\_64, Arm64v8 |
 |  | [Debian 10 \(Buster\)](linux/debian.md) | x86\_64, Arm64v8 |
 |  | [Debian 9 \(Stretch\)](linux/debian.md) | x86\_64, Arm64v8 |
 |  | [Nixos](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/fluent-bit/default.nix) | x86\_64, Arm64v8 |
 |  | [Ubuntu 20.04 \(Focal Fossa\)](linux/ubuntu.md) | x86\_64, Arm64v8 |
 |  | [Ubuntu 18.04 \(Bionic Beaver\)](linux/ubuntu.md) | x86\_64, Arm64v8 |
 |  | [Ubuntu 16.04 \(Xenial Xerus\)](linux/ubuntu.md) | x86\_64 |
+|  | [Raspbian 11 \(Bullseye\)](linux/raspbian-raspberry-pi.md) | Arm32v7 |
 |  | [Raspbian 10 \(Buster\)](linux/raspbian-raspberry-pi.md) | Arm32v7 |
 | macOS | * | x86_64, Apple M1 |
 | Windows | [Windows Server 2019](windows.md) | x86\_64, x86 |


### PR DESCRIPTION
For 1.9 we have updated the GPG key to use fluentbit.io email address rather than a personal one.
This is the docs update to make it clear and should go in release note too.

Signed-off-by: Patrick Stephens <pat@calyptia.com>