### PR TITLE
installation: linux: ubuntu: fix package url for sources.list

### DIFF
--- a/installation/linux/ubuntu.md
+++ b/installation/linux/ubuntu.md
@@ -34,7 +34,7 @@ Refer to the [supported platform documentation](./../supported-platforms.md) to 
 On Ubuntu, you need to add our APT server entry to your sources lists, please add the following content at bottom of your **/etc/apt/sources.list** file - ensure to set `CODENAME` to your specific [Ubuntu release name](https://wiki.ubuntu.com/Releases) (e.g. `focal` for Ubuntu 20.04):
 
 ```bash
-deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/debian/${CODENAME} ${CODENAME} main
+deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/${CODENAME} ${CODENAME} main
 ```
 
 ### Update your repositories database


### PR DESCRIPTION
In [Update your sources list](https://docs.fluentbit.io/manual/installation/linux/ubuntu#update-your-sources-lists) the package url incorrectly uses https://packages.fluentbit.io/debian/

Using the existing url returns the following error when running `sudo apt update`

`E: The repository 'https://packages.fluentbit.io/debian/focal focal Release' does not have a Release file.`

This is resolved by replacing 'debian' with 'ubuntu'.