### PR TITLE
Document Oneshot and Exit parameters in Exec input plugin

### DIFF
--- a/pipeline/inputs/exec.md
+++ b/pipeline/inputs/exec.md
@@ -16,7 +16,9 @@ The plugin supports the following configuration parameters:
 | Parser | Specify the name of a parser to interpret the entry as a structured message. |
 | Interval\_Sec | Polling interval \(seconds\). |
 | Interval\_NSec | Polling interval \(nanosecond\). |
-| Buf\_Size | Size of the buffer \(check [unit sizes](https://docs.fluentbit.io/manual/configuration/unit_sizes) for allowed values\) |
+| Buf\_Size | Size of the buffer \(check [unit sizes](https://docs.fluentbit.io/manual/configuration/unit_sizes) for allowed values\). |
+| Oneshot | Execute the command only once. |
+| Exit | Exit after the command finishes \(implies Oneshot=true\). |
 
 ## Getting Started
 


### PR DESCRIPTION
The `Oneshot` option already exists but wasn't documented (though it's name is currently buggy in 1.9.9, see https://github.com/fluent/fluent-bit/pull/5127).

The `Exit` parameter would is added by https://github.com/fluent/fluent-bit/pull/5126.