### PR TITLE
installation: macos: change directory info

### DIFF
--- a/installation/macos.md
+++ b/installation/macos.md
@@ -40,6 +40,12 @@ export OPENSSL_ROOT_DIR=`brew --prefix openssl`
 export PATH=`brew --prefix bison`/bin:$PATH
 ```
 
+Change to the _build/_ directory inside the Fluent Bit sources:
+
+```bash
+$ cd build/
+```
+
 Build Fluent Bit. Note that we are indicating to the build system "where" the final binaries and config files should be installed:
 
 ```bash


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

We should `cd build/` before run the `cmake`.