### PR TITLE
Document configuring plugin log_level

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -56,6 +56,7 @@ An _INPUT_ section defines a source (related to an input plugin), here we will d
 | ---- | ----------------------------------------------------------- |
 | Name | Name of the input plugin.                                   |
 | Tag  | Tag name associated to all records coming from this plugin. |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which input plugin should be loaded. The _Tag_ is mandatory for all plugins except for the _input forward_ plugin (as it provides dynamic tags).
 
@@ -78,6 +79,7 @@ A _FILTER_ section defines a filter (related to an filter plugin), here we will 
 | Name        | Name of the filter plugin.                                                                                                      |   |
 | Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |   |
 | Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |   |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which filter plugin should be loaded. The _Match_ or _Match_Regex_ is mandatory for all plugins. If both are specified, _Match_Regex_ takes precedence.
 
@@ -101,6 +103,7 @@ The _OUTPUT_ section specify a destination that certain records should follow af
 | Name        | Name of the output plugin.                                                                                                      |   |
 | Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |   |
 | Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |   |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 ### Example
 

--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -52,10 +52,10 @@ The following is an example of a _SERVICE_ section:
 
 An _INPUT_ section defines a source (related to an input plugin), here we will describe the base configuration for each _INPUT_ section. Note that each input plugin may add it own configuration keys:
 
-| Key  | Description                                                 |
-| ---- | ----------------------------------------------------------- |
-| Name | Name of the input plugin.                                   |
-| Tag  | Tag name associated to all records coming from this plugin. |
+| Key         | Description                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name        | Name of the input plugin.                                                                                                                               |
+| Tag         | Tag name associated to all records coming from this plugin.                                                                                             |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which input plugin should be loaded. The _Tag_ is mandatory for all plugins except for the _input forward_ plugin (as it provides dynamic tags).
@@ -74,11 +74,11 @@ The following is an example of an _INPUT_ section:
 
 A _FILTER_ section defines a filter (related to an filter plugin), here we will describe the base configuration for each _FILTER_ section. Note that each filter plugin may add it own configuration keys:
 
-| Key         | Description                                                                                                                     |   |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- | - |
-| Name        | Name of the filter plugin.                                                                                                      |   |
-| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |   |
-| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |   |
+| Key         | Description                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name        | Name of the filter plugin.                                                                                                                              |
+| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard.                         |
+| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.                           |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which filter plugin should be loaded. The _Match_ or _Match_Regex_ is mandatory for all plugins. If both are specified, _Match_Regex_ takes precedence.
@@ -98,11 +98,11 @@ The following is an example of an _FILTER_ section:
 
 The _OUTPUT_ section specify a destination that certain records should follow after a Tag match. The configuration support the following keys:
 
-| Key         | Description                                                                                                                     |   |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- | - |
-| Name        | Name of the output plugin.                                                                                                      |   |
-| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |   |
-| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |   |
+| Key         | Description                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name        | Name of the output plugin.                                                                                                                              |
+| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard.                         |
+| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.                           |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 ### Example

--- a/administration/configuring-fluent-bit/yaml/configuration-file.md
+++ b/administration/configuring-fluent-bit/yaml/configuration-file.md
@@ -86,6 +86,7 @@ An _input_ section defines a source (related to an input plugin). Here we will d
 | ---- |--------------------------------------------------------------------------|
 | Name | Name of the input plugin. Defined as subsection of the _inputs_ section. |
 | Tag  | Tag name associated to all records coming from this plugin.              |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which input plugin should be loaded. The _Tag_ is mandatory for all plugins except for the _input forward_ plugin (as it provides dynamic tags).
 
@@ -109,6 +110,7 @@ A _filter_ section defines a filter (related to an filter plugin). Here we will 
 | Name        | Name of the filter plugin. Defined as a subsection of the _filters_ section.                                                    |
 | Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |
 | Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which filter plugin should be loaded. The _Match_ or _Match_Regex_ is mandatory for all plugins. If both are specified, _Match_Regex_ takes precedence.
 
@@ -133,6 +135,7 @@ The _outputs_ section specify a destination that certain records should follow a
 | Name        | Name of the output plugin. Defined as a subsection of the _outputs_ section.                                                                                                      |   |
 | Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |
 | Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 #### Example
 

--- a/administration/configuring-fluent-bit/yaml/configuration-file.md
+++ b/administration/configuring-fluent-bit/yaml/configuration-file.md
@@ -82,10 +82,10 @@ pipeline:
 
 An _input_ section defines a source (related to an input plugin). Here we will describe the base configuration for each _input_ section. Note that each input plugin may add it own configuration keys:
 
-| Key  | Description                                                              |
-| ---- |--------------------------------------------------------------------------|
-| Name | Name of the input plugin. Defined as subsection of the _inputs_ section. |
-| Tag  | Tag name associated to all records coming from this plugin.              |
+| Key         | Description                                                                                                                                             |
+| ----------- |-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name        | Name of the input plugin. Defined as subsection of the _inputs_ section.                                                                                |
+| Tag         | Tag name associated to all records coming from this plugin.                                                                                             |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which input plugin should be loaded. The _Tag_ is mandatory for all plugins except for the _input forward_ plugin (as it provides dynamic tags).
@@ -105,11 +105,11 @@ pipeline:
 
 A _filter_ section defines a filter (related to an filter plugin). Here we will describe the base configuration for each _filter_ section. Note that each filter plugin may add it own configuration keys:
 
-| Key | Description                                                                                                                     |
-|--- |---------------------------------------------------------------------------------------------------------------------------------|
-| Name        | Name of the filter plugin. Defined as a subsection of the _filters_ section.                                                    |
-| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |
-| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |
+| Key         | Description                                                                                                                                             |
+|------------ |-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name        | Name of the filter plugin. Defined as a subsection of the _filters_ section.                                                                            |
+| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard.                         |
+| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.                           |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 The _Name_ is mandatory and it let Fluent Bit know which filter plugin should be loaded. The _Match_ or _Match_Regex_ is mandatory for all plugins. If both are specified, _Match_Regex_ takes precedence.
@@ -130,11 +130,11 @@ pipeline:
 
 The _outputs_ section specify a destination that certain records should follow after a Tag match. The configuration support the following keys:
 
-| Key         | Description                                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Name        | Name of the output plugin. Defined as a subsection of the _outputs_ section.                                                                                                      |   |
-| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard. |
-| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.   |
+| Key         | Description                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name        | Name of the output plugin. Defined as a subsection of the _outputs_ section.                                                                            |
+| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard.                         |
+| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.                           |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
 #### Example


### PR DESCRIPTION
`Log_Level` can be set for individual plugins the same way it can be set for the service as a whole. Is this supported? If so, could we add this to the docs like this?