### PR TITLE
in_prom_scrape: modify scrape_interval

### DIFF
--- a/pipeline/inputs/prometheus-scrape-metrics.md
+++ b/pipeline/inputs/prometheus-scrape-metrics.md
@@ -10,7 +10,7 @@ The initial release of the Prometheus Scrape metric allows you to collect metric
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | host            | The host of the prometheus metric endpoint that you want to scrape                                                                                   |          |
 | port            | The port of the promethes metric endpoint that you want to scrape                                                                                    |          |
-| scrape interval | The interval to scrape metrics                                                                                                                       | 10s      |
+| scrape\_interval | The interval to scrape metrics                                                                                                                       | 10s      |
 | metrics\_path   | <p>The metrics URI endpoint, that must start with a forward slash.<br><br>Note: Parameters can also be added to the path by using <code>?</code></p> | /metrics |
 
 ## Example


### PR DESCRIPTION
I fixed `scrape interval`.
I think it needs underscore. `scrape_interval`.

https://github.com/fluent/fluent-bit/blob/v1.9.2/plugins/in_prometheus_scrape/prom_scrape.c#L194