### PR TITLE
pipeline: inputs: node-expoerter-metrics: Fix parameter name in examples

### DIFF
--- a/pipeline/inputs/node-exporter-metrics.md
+++ b/pipeline/inputs/node-exporter-metrics.md
@@ -71,7 +71,7 @@ In the following configuration file, the input plugin _node_exporter_metrics col
 [OUTPUT]
     name            prometheus_exporter
     match           node_metrics
-    listen          0.0.0.0
+    host            0.0.0.0
     port            2021
 
         

--- a/pipeline/inputs/windows-exporter-metrics.md
+++ b/pipeline/inputs/windows-exporter-metrics.md
@@ -57,7 +57,7 @@ In the following configuration file, the input plugin _windows_exporter_metrics 
 [OUTPUT]
     name            prometheus_exporter
     match           node_metrics
-    listen          0.0.0.0
+    host            0.0.0.0
     port            2021
 
         


### PR DESCRIPTION
Config parameter of out_prometheus_exporter `listen` was deprecated in v1.9.

- https://github.com/fluent/fluent-bit/pull/4081
- https://github.com/fluent/fluent-bit-docs/pull/605

Signed-off-by: Haitao Li <hli@atlassian.com>