### PR TITLE
installation: sources: build-and-install : Add Optimization options.

### DIFF
--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -101,6 +101,13 @@ Fluent Bit provides certain options to CMake that can be enabled or disabled whe
 | FLB\_TESTS | Enable tests | No |
 | FLB\_BACKTRACE | Enable backtrace/stacktrace support | Yes |
 
+### Optimization Options
+
+| option | description | default |
+| :--- | :--- | :--- |
+| FLB\_MSGPACK\_TO\_JSON\_INIT\_BUFFER\_SIZE | Determine initial buffer size for msgpack to json conversion in terms of memory used by payload. | 2.0 |
+| FLB\_MSGPACK\_TO\_JSON\_REALLOC\_BUFFER\_SIZE | Determine percentage of reallocation size when msgpack to json conversion buffer runs out of memory. | 0.1 |
+
 ### Input Plugins
 
 The _input plugins_ provides certain features to gather information from a specific source type which can be a network interface, some built-in metric or through a specific input device, the following input plugins are available:


### PR DESCRIPTION
Adding a new `Optimization Options` section under `Build Options`.
Addind documentation about new build parameters to control the
memory usage of the msgpack to json conversion in the function
flb_msgpack_raw_to_json_sds. The parameters are :
- FLB_MSGPACK_TO_JSON_INIT_BUFFER_SIZE
- FLB_MSGPACK_TO_JSON_REALLOC_BUFFER_SIZE

Signed-off-by: Francisco Valente <fcovalente@google.com>