### PR TITLE
installation: linux: redhat-centos: Update repo file to use releasever variable

### DIFF
--- a/installation/linux/redhat-centos.md
+++ b/installation/linux/redhat-centos.md
@@ -37,7 +37,7 @@ We provide **fluent-bit** through a Yum repository. In order to add the reposito
 ```
 [fluent-bit]
 name = Fluent Bit
-baseurl = https://packages.fluentbit.io/centos/7/$basearch/
+baseurl = https://packages.fluentbit.io/centos/$releasever/$basearch/
 gpgcheck=1
 gpgkey=https://packages.fluentbit.io/fluentbit.key
 repo_gpgcheck=1


### PR DESCRIPTION
Update repo file to use releasever variable.  I believe this works, but someone should verify, please.  It works in rocky 8.

Signed-off-by: justchris1 <30219018+justchris1@users.noreply.github.com>