### PR TITLE
input_winevtlog: documentation updates

### DIFF
--- a/pipeline/inputs/windows-event-log-winevtlog.md
+++ b/pipeline/inputs/windows-event-log-winevtlog.md
@@ -13,9 +13,9 @@ The plugin supports the following configuration parameters:
 | Interval\_NSec | Set the polling interval for each channel (sub seconds. \(optional\) | 0 |
 | Read\_Existing\_Events | Whether to read existing events from head or tailing events at last on subscribing. \(optional\) | False |
 | DB | Set the path to save the read offsets. \(optional\) |  |
-| String\_Inserts | Whether to include StringInserts in output records. \(optional\) | False  |
+| String\_Inserts | Whether to include StringInserts in output records. \(optional\) | True  |
 | Render\_Event\_As\_XML | Whether to render system part of event as XML string or not. \(optional\) | False  |
-| Use\_ANSI | Use ANSI encoding on eventlog messages. \(optional\) | False  |
+| Use\_ANSI | Use ANSI encoding on eventlog messages. If you have issues receiving blank strings with old Windows versions (Server 2012 R2), setting this to True may solve the problem. \(optional\) | False  |
 
 Note that if you do not set _db_, the plugin will tail channels on each startup.
 


### PR DESCRIPTION
Two updates, one is the default setting for `String_Inserts` so it matches with that is in the code, the other is a subtle information about `Use_ANSI` that took me a week and reading the source code to find out.

Signed-off-by: Marcos Diez <marcos@unitron.com.br>