### PR TITLE
pipeline: outputs: postgresql: add schema params

### DIFF
--- a/pipeline/outputs/postgresql.md
+++ b/pipeline/outputs/postgresql.md
@@ -61,6 +61,7 @@ Make sure that the `fluentbit` user can connect to the `fluentbit` database on t
 | `min_pool_size` | Minimum number of connection in async mode | 1 |
 | `max_pool_size` | Maximum amount of connections in async mode | 4 |
 | `cockroachdb` | Set to `true` if you will connect the plugin with a CockroachDB | false |
+| `schema` | Schema name to set search_path | - |
 
 ### Libpq
 


### PR DESCRIPTION
This commit adds documentation for configuring to set search_path with the out_pgsql plugin.

Ref: https://github.com/fluent/fluent-bit/pull/5450

Signed-off-by: sho shimohata <pontatanpo1014@gmail.com>