### PR TITLE
Docs about config files included using wildcard are unsorted

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -160,3 +160,5 @@ Wildcard character (\*) is supported to include multiple files, e.g:
 ```
 @INCLUDE input_*.conf
 ```
+
+Note files matching the wildcard character are included unsorted. If plugins ordering between files need to be preserved, the files should be incldued explicitly.

--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -161,4 +161,5 @@ Wildcard character (\*) is supported to include multiple files, e.g:
 @INCLUDE input_*.conf
 ```
 
-Note files matching the wildcard character are included unsorted. If plugins ordering between files need to be preserved, the files should be incldued explicitly.
+Note files matching the wildcard character are included unsorted. 
+If plugins ordering between files need to be preserved, the files should be included explicitly.


### PR DESCRIPTION
This patch adds document about the current behavior. The ordering issue is raised in https://github.com/fluent/fluent-bit/issues/5612

Signed-off-by: Haitao Li <lihaitao@gmail.com>