### PR TITLE
outputs: loki output add worker configuration paramenter

### DIFF
--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -24,6 +24,7 @@ Be aware there is a separate Golang output plugin provided by [Grafana](https://
 | line\_format | Format to use when flattening the record to a log line. Valid values are `json` or `key_value`. If set to `json`,  the log line sent to Loki will be the Fluent Bit record dumped as JSON. If set to `key_value`, the log line will be each item in the record concatenated together \(separated by a single space\) in the format. | json |
 | auto\_kubernetes\_labels | If set to true, it will add all Kubernetes labels to the Stream labels | off |
 | tenant\_id\_key | Specify the name of the key from the original record that contains the Tenant ID. The value of the key is set as `X-Scope-OrgID` of HTTP header. It is useful to set Tenant ID dynamically. ||
+| workers | Enables dedicated thread(s) for this output. Default value is set since version 1.8.13. For previous versions is 0. | 1 |
 
 ## Labels
 


### PR DESCRIPTION
`Worker` parameter is missing from most outputs documentation, copied it from [stdout docs](https://docs.fluentbit.io/manual/pipeline/outputs/standard-output). I recently discovered it worked by digging through some github issues. Is this config available for all outputs? And if so is there a more centralized doc where this should be / already is available?