### PR TITLE
init: systemd: allow to set environment variables from file

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/variables.md
+++ b/administration/configuring-fluent-bit/classic-mode/variables.md
@@ -10,6 +10,12 @@ ${MY_VARIABLE}
 
 When Fluent Bit starts, the configuration reader will detect any request for `${MY_VARIABLE}` and will try to resolve its value.
 
+If Fluent Bit is running on systemd, environment variables are to be sourced from these files:
+* `/etc/default/fluent-bit` (Debian based system)
+* `/etc/sysconfig/fluent-bit` (Others)
+
+They are only loaded if exists.
+
 ## Example
 
 Create the following configuration file \(`fluent-bit.conf`\):


### PR DESCRIPTION
ref: fluent/fluent-bit#5933

I'm using a translation tool.
Please comment if you have a more general phrasing.