### PR TITLE
Bump dependency inside local-pipeline

### DIFF
--- a/local-testing/logging-pipeline.md
+++ b/local-testing/logging-pipeline.md
@@ -36,7 +36,7 @@ services:
     depends_on:
       - elasticsearch
   elasticsearch:
-    image: elasticsearch:7.6.2
+    image: elasticsearch:7.17.6
     ports:
       - "9200:9200"
     environment:


### PR DESCRIPTION
The previous version listed does not appear to be in the registry any longer. This is the latest release in the 7.x series of Elasticsearch.