### PR TITLE
multiline: remove ref to ruby

### DIFF
--- a/pipeline/filters/multiline-stacktrace.md
+++ b/pipeline/filters/multiline-stacktrace.md
@@ -12,7 +12,6 @@ As part of the built-in functionality, without major configuration effort, you c
 
 * go
 * python
-* ruby
 * java (Google Cloud Platform Java stacktrace format)
 
 Some comments about this filter:


### PR DESCRIPTION
Remove unsupported `ruby` parser as per: https://github.com/fluent/fluent-bit/issues/6050
Likely need to target 1.9 branch as well: https://github.com/fluent/fluent-bit-docs/pull/902

Signed-off-by: Patrick Stephens <pat@calyptia.com>