### PR TITLE
linux: add AL 2022 as a supported platform

### DIFF
--- a/installation/linux/amazon-linux.md
+++ b/installation/linux/amazon-linux.md
@@ -1,8 +1,8 @@
 # Amazon Linux
 
-## Install on Amazon Linux 2
+## Install on Amazon Linux
 
-Fluent Bit is distributed as **fluent-bit** package and is available for the latest Amazon Linux 2. The following architectures are supported
+Fluent Bit is distributed as **fluent-bit** package and is available for the latest Amazon Linux 2 and Amazon Linux 2022. The following architectures are supported
 
 * x86\_64
 * aarch64 / arm64v8
@@ -21,7 +21,9 @@ If this fails or for more details on the installation then please refer to the s
 
 We provide **fluent-bit** through a Yum repository. In order to add the repository reference to your system, please add a new file called _fluent-bit.repo_ in _/etc/yum.repos.d/_ with the following content:
 
-```
+### Amazon Linux 2
+
+```config
 [fluent-bit]
 name = Fluent Bit
 baseurl = https://packages.fluentbit.io/amazonlinux/2/$basearch/
@@ -30,7 +32,18 @@ gpgkey=https://packages.fluentbit.io/fluentbit.key
 enabled=1
 ```
 
-note: we encourage you always enable the _gpgcheck_ for security reasons. All our packages are signed.
+### Amazon Linux 2022
+
+```config
+[fluent-bit]
+name = Fluent Bit
+baseurl = https://packages.fluentbit.io/amazonlinux/2022/$basearch/
+gpgcheck=1
+gpgkey=https://packages.fluentbit.io/fluentbit.key
+enabled=1
+```
+
+Note: we encourage you always enable the _gpgcheck_ for security reasons. All our packages are signed.
 
 ### Updated key from March 2022
 
@@ -38,7 +51,7 @@ From the 1.9.0 and 1.8.15 releases please note that the GPG key has been updated
 
 The GPG Key fingerprint of the new key is:
 
-```
+```text
 C3C0 A285 34B9 293E AF51  FABD 9F9D DC08 3888 C1CD
 Fluentbit releases (Releases signing key) <releases@fluentbit.io>
 ```
@@ -47,7 +60,7 @@ The previous key is still available at [https://packages.fluentbit.io/fluentbit-
 
 The GPG Key fingerprint of the old key is:
 
-```
+```text
 F209 D876 2A60 CD49 E680 633B 4FF8 368B 6EA0 722A
 ```
 
@@ -58,13 +71,13 @@ Refer to the [supported platform documentation](../supported-platforms.md) to se
 Once your repository is configured, run the following command to install it:
 
 ```bash
-$ yum install fluent-bit
+yum install fluent-bit
 ```
 
 Now the following step is to instruct _systemd_ to enable the service:
 
 ```bash
-$ sudo service fluent-bit start
+sudo service fluent-bit start
 ```
 
 If you do a status check, you should see a similar output like this:

--- a/installation/requirements.md
+++ b/installation/requirements.md
@@ -5,6 +5,7 @@
 * Compiler: GCC or clang
 * CMake
 * Flex & Bison: only if you enable the Stream Processor or Record Accessor feature \(both enabled by default\)
+* Libyaml development headers and libraries
 
 In the core there are not other dependencies, For certain features that depends on third party components like output plugins with special backend libraries \(e.g: kafka\), those are included in the main source code repository.
 

--- a/installation/supported-platforms.md
+++ b/installation/supported-platforms.md
@@ -4,7 +4,8 @@ The following operating systems and architectures are supported in Fluent Bit.
 
 | Operating System | Distribution | Architectures |
 | :--- | :--- | :--- |
-| Linux | [Amazon Linux 2](linux/amazon-linux.md) | x86\_64, Arm64v8 |
+| Linux | [Amazon Linux 2022](linux/amazon-linux.md) | x86\_64, Arm64v8 |
+|  | [Amazon Linux 2](linux/amazon-linux.md) | x86\_64, Arm64v8 |
 |  | [Centos 8](linux/redhat-centos.md) | x86\_64, Arm64v8 |
 |  | [Centos 7](linux/redhat-centos.md) | x86\_64, Arm64v8 |
 |  | [Rocky Linux 8](linux/redhat-centos.md) | x86\_64, Arm64v8 |
@@ -24,4 +25,3 @@ The following operating systems and architectures are supported in Fluent Bit.
 From an architecture support perspective, Fluent Bit is fully functional on x86\_64, Arm64v8 and Arm32v7 based processors.
 
 Fluent Bit can work also on OSX and \*BSD systems, but not all plugins will be available on all platforms. Official support will be expanding based on community demand. Fluent Bit may run on older operating systems though will need to be built from source, or use custom packages from [enterprise providers](https://fluentbit.io/enterprise)
-


### PR DESCRIPTION
Part of work for https://github.com/fluent/fluent-bit/issues/6020.

Release updates here: https://github.com/fluent/fluent-bit/pull/6186

Signed-off-by: Patrick Stephens <pat@calyptia.com>