### PR TITLE
pipeline: filters: multiline-stacktrace: add ruby support

### DIFF
--- a/pipeline/filters/multiline-stacktrace.md
+++ b/pipeline/filters/multiline-stacktrace.md
@@ -12,6 +12,7 @@ As part of the built-in functionality, without major configuration effort, you c
 
 * go
 * python
+* ruby
 * java (Google Cloud Platform Java stacktrace format)
 
 Some comments about this filter:


### PR DESCRIPTION
This patch is to revert #903 since https://github.com/fluent/fluent-bit/pull/6169 is to support multiline ruby parser.