### PR TITLE
Specifying nginx_plus off for nginx metrics

### DIFF
--- a/pipeline/inputs/nginx.md
+++ b/pipeline/inputs/nginx.md
@@ -79,6 +79,7 @@ In your main configuration file append the following _Input_ & _Output_ sections
 ```ini
 [INPUT]
     Name          nginx_metrics
+    Nginx_Plus    off
     Host          127.0.0.1
     Port          80
     Status_URL    /status


### PR DESCRIPTION
By default is enabled so we need to disable if we are not using Nginx Plus

Signed-off-by: Pablo Fredrikson <pablo.fredrikson@gmail.com>