### PR TITLE
parser: logfmt: document logfmt_no_bare_keys

### DIFF
--- a/pipeline/parsers/logfmt.md
+++ b/pipeline/parsers/logfmt.md
@@ -13,13 +13,23 @@ Here is an example configuration:
 The following log entry is a valid content for the parser defined above:
 
 ```text
-key1=val1 key2=val2
+key1=val1 key2=val2 key3
 ```
 
 After processing, it internal representation will be:
 
 ```text
 [1540936693, {"key1"=>"val1",
-              "key2"=>"val2"}]
+              "key2"=>"val2"
+              "key3"=>true}]
 ```
 
+If you want to be more strict than the logfmt standard and not parse lines where some attributes do
+not have values (such as `key3`) in the example above, you can configure the parser as follows:
+
+```python
+[PARSER]
+    Name        logfmt
+    Format      logfmt
+    Logfmt_No_Bare_Keys true
+```


### PR DESCRIPTION
This documents https://github.com/fluent/fluent-bit/pull/6100

Signed-off-by: Dennis Kaarsemaker <dennis@kaarsemaker.net>
