### PR TITLE
workflows: add basic linting and stale checks

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+      {
+        "owner": "actionlint",
+        "pattern": [
+          {
+            "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "message": 4,
+            "code": 5
+          }
+        ]
+      }
+    ]
+  }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "workflows: "

--- a/.github/workflows/cron-stale.yaml
+++ b/.github/workflows/cron-stale.yaml
@@ -1,0 +1,30 @@
+name: 'Close stale issues and PR(s)'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    name: Mark stale
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 5 days. Maintainers can add the `exempt-stale` label.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 90
+          days-before-close: 5
+          days-before-pr-close: -1
+          exempt-all-pr-assignees: true
+          exempt-all-pr-milestones: true
+          exempt-issue-labels: 'long-term,enhancement,exempt-stale,waiting-on-code-merge'
+          exempt-pr-labels: 'long-term,enhancement,exempt-stale,waiting-on-code-merge'
+          # start with the oldest
+          ascending: true
+          # keep an eye on this
+          operations-per-run: 250

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,23 @@
+name: Lint PRs
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  actionlint-pr:
+    runs-on: ubuntu-latest
+    name: PR - Actionlint
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color -shellcheck=
+        shell: bash
+
+  docslint-pr:
+    runs-on: ubuntu-latest
+    name: PR - Markdownlint
+    steps:
+      - name: Run markdownlint
+        uses: actionshub/markdownlint@2.0.2

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "#{File.dirname(__FILE__)}/markdownlint.rb"

--- a/markdownlint.rb
+++ b/markdownlint.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/ruby
+
+# Enable all rules by default
+all
+
+# Extend line length, since each sentence should be on a separate line.
+rule 'MD013', :line_length => 99999, :ignore_code_blocks => true
+
+# Allow in-line HTML
+exclude_rule 'MD033'
+
+# Nested lists should be indented with two spaces.
+rule 'MD007', :indent => 2
+
+# Bash defaulting confuses this and now way to ignore code blocks
+exclude_rule 'MD029'


### PR DESCRIPTION
MarkdownLint will only flag changed Markdown in PRs - this may mean it will flag up existing issues next time someone edits the file in a PR but ideally they are then all resolved then. I use the VSCode extension to automate this easily.

Signed-off-by: Patrick Stephens <pat@calyptia.com>