### PR TITLE
 pipeline: outputs: cloudwatch: fix IAM permission

### DIFF
--- a/pipeline/outputs/cloudwatch.md
+++ b/pipeline/outputs/cloudwatch.md
@@ -71,7 +71,9 @@ The following AWS IAM permissions are required to use this plugin:
 		"Action": [
 			"logs:CreateLogStream",
 			"logs:CreateLogGroup",
-			"logs:PutLogEvents"
+			"logs:PutLogEvents",
+			"logs:DescribeLogStreams"
+			
 		],
 		"Resource": "*"
 	}]


### PR DESCRIPTION
fix for issue fluent#913
when using fluent-bit for sending log to cloudwatch  also the permission for  ` logs:DescribeLogStreams` is needed