### PR TITLE
docs: update docker images to v2.0.1

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -16,6 +16,10 @@ The following table describes the tags that are available on Docker Hub [fluent/
 
 | Tag(s)      | Manifest Architectures    | Description                                                  |
 | ----------- | ------------------------- | ------------------------------------------------------------ |
+| 2.0.1       | x86\_64, arm64v8, arm32v7 | Release [v2.0.0](https://fluentbit.io/announcements/v2.0.1/) |
+| 2.0.1-debug | x86\_64, arm64v8, arm32v7 | v2.0.x releases (production + debug)                         |
+| 2.0.0       | x86\_64, arm64v8, arm32v7 | Release [v2.0.0](https://fluentbit.io/announcements/v2.0.0/) |
+| 2.0.0-debug | x86\_64, arm64v8, arm32v7 | v2.0.x releases (production + debug)                         |
 | 1.9.9       | x86\_64, arm64v8, arm32v7 | Release [v1.9.9](https://fluentbit.io/announcements/v1.9.9/) |
 | 1.9.9-debug | x86\_64, arm64v8, arm32v7 | v1.9.x releases (production + debug)                         |
 | 1.9.8       | x86\_64, arm64v8, arm32v7 | Release [v1.9.8](https://fluentbit.io/announcements/v1.9.8/) |


### PR DESCRIPTION
Update docker images to v2.0.1

Signed-off-by: Jorge Niedbalski <j@calyptia.com>