### PR TITLE
docs: Fix syntax error in debian installation docs

### DIFF
--- a/installation/linux/debian.md
+++ b/installation/linux/debian.md
@@ -79,7 +79,7 @@ sudo apt-get install fluent-bit
 Now the following step is to instruct _systemd_ to enable the service:
 
 ```bash
-sudo systemctl fluent-bit start
+sudo systemctl start fluent-bit
 ```
 
 If you do a status check, you should see a similar output like this:


### PR DESCRIPTION
Wrong arg order in debian docs, similar to PR https://github.com/fluent/fluent-bit-docs/pull/962