### PR TITLE
installation: linux: debian: fix start command

### DIFF
--- a/installation/linux/debian.md
+++ b/installation/linux/debian.md
@@ -79,7 +79,7 @@ sudo apt-get install fluent-bit
 Now the following step is to instruct _systemd_ to enable the service:
 
 ```bash
-sudo systemctl fluent-bit start
+sudo systemctl start fluent-bit
 ```
 
 If you do a status check, you should see a similar output like this:


### PR DESCRIPTION
the `systemctl start` command in Debian installation is incorrect, it should be the same as [Ubuntu](https://github.com/fluent/fluent-bit-docs/blob/master/installation/linux/ubuntu.md#install-fluent-bit): `sudo systemctl start fluent-bit`

See also: https://github.com/fluent/fluent-bit-docs/commit/d0cd5b59790da4b6d5033ea7d5ae3292486bd640

I also want to point out that  `sudo service status fluent-bit` in [Ubuntu](https://github.com/fluent/fluent-bit-docs/blob/master/installation/linux/ubuntu.md#install-fluent-bit) is also wrong because the usage of  `systemctl` and `service` is different.

systemctl usage: `systemctl COMMAND SERVICE`
service usage: `service SERVICE COMMAND`