### PR TITLE
Macos homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ description: High Performance Log and Metrics Processor
   * Create new streams of data using query results
   * Aggregation Windows
   * Data analysis and prediction: Timeseries forecasting
-* Portable: runs on Linux, MacOS, Windows and BSD systems
+* Portable: runs on Linux, macOS, Windows and BSD systems
 
 ## Fluent Bit, Fluentd and CNCF
 

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -41,7 +41,7 @@ description: The following serves as a guide on how to install/deploy/upgrade Fl
 | Operating System | Installation Instructions                                   |
 | ---------------- | ----------------------------------------------------------- |
 | Linux, FreeBSD   | [Compile from source](sources/build-and-install.md)         |
-| macOS            | [Compile from source](macos.md#get-the-source-and-build-it) |
+| macOS            | [Compile from source](macos.md#compile-from-source) |
 | Windows          | [Compile from Source](windows.md#compile-from-source)       |
 
 ## Sandbox Environment

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -30,12 +30,12 @@ description: The following serves as a guide on how to install/deploy/upgrade Fl
 | Windows Server 2019 | [Windows Server EXE](windows.md#installing-from-exe-installer), [Windows Server ZIP](windows.md#installing-from-zip-archive) |
 | Windows 10 2019.03  | [Windows EXE](windows.md#installing-from-exe-installer), [Windows ZIP](windows.md#installing-from-zip-archive)               |
 
-## Compile from Source (Linux, Windows, FreeBSD, MacOS)
+## Compile from Source (Linux, Windows, FreeBSD, macOS)
 
 | Operating System | Installation Instructions                                   |
 | ---------------- | ----------------------------------------------------------- |
 | Linux, FreeBSD   | [Compile from source](sources/build-and-install.md)         |
-| MacOS            | [Compile from source](macos.md#get-the-source-and-build-it) |
+| macOS            | [Compile from source](macos.md#get-the-source-and-build-it) |
 | Windows          | [Compile from Source](windows.md#compile-from-source)       |
 
 ## Sandbox Environment

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -30,6 +30,12 @@ description: The following serves as a guide on how to install/deploy/upgrade Fl
 | Windows Server 2019 | [Windows Server EXE](windows.md#installing-from-exe-installer), [Windows Server ZIP](windows.md#installing-from-zip-archive) |
 | Windows 10 2019.03  | [Windows EXE](windows.md#installing-from-exe-installer), [Windows ZIP](windows.md#installing-from-zip-archive)               |
 
+## Install on macOS (Packages)
+
+| Operating System    | Installation Instructions                     |
+| ------------------- | --------------------------------------------- |
+| macOS               | [Homebrew](macos.md#installing-from-homebrew) |
+
 ## Compile from Source (Linux, Windows, FreeBSD, macOS)
 
 | Operating System | Installation Instructions                                   |

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -14,7 +14,7 @@ If is not there, you can install it with the following command:
 
 ## Installing from Homebrew
 
-The Fluent Bit package on Homebrew is not officially supported, but should work for basic use cases and testing. It can be installed using.
+The Fluent Bit package on Homebrew is not officially supported, but should work for basic use cases and testing. It can be installed using:
 
 ```bash
 brew install fluent-bit

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -1,6 +1,6 @@
 # macOS
 
-Fluent Bit is compatible with latest Apple macOS system on x86_64 and Apple Silicon M1 architectures. 
+Fluent Bit is compatible with latest Apple macOS system on x86_64 and Apple Silicon M1 architectures.
 At the moment there is no official supported package but you can build it from sources by following the instructions below.
 
 ## Requirements
@@ -11,6 +11,16 @@ If is not there, you can install it with the following command:
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
+
+## Installing from Homebrew
+
+The Fluent Bit package on Homebrew is not officially supported, but should work for basic use cases and testing. It can be installed using.
+
+```bash
+brew install fluent-bit
+```
+
+## Compile from Source
 
 ### Install build dependencies
 


### PR DESCRIPTION
Adds homebrew instructions to the macOS section of the getting started page.

While I can see that @chenrui333's homebrew this isn't an "offical" package, it's been working great for me.

I'd like to be able to recommend it to new users of fluent-bit as well.

Note: this also replaces a few remaining "MacOS" usages with the more modern "macOS" used in the majority of the documentation.