### PR TITLE
s3: tweak preserve_data_ordering discussion

### DIFF
--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -76,7 +76,7 @@ When Fluent Bit recieves logs, it stores them in chunks, either in memory or the
 
 The S3 output plugin is a Fluent Bit output plugin and thus it conforms to the Fluent Bit output plugin specification. However, since the S3 use case is to upload large files, generally much larger than 2 MB, its behavior is different. The S3 "flush callback function" simply buffers the incoming chunk to the filesystem, and returns an `FLB_OK`. *Consequently, the prometheus metrics available via the Fluent Bit http server are meaningless for S3.* In addition, the `storage.total_limit_size` parameter is not meaningful for S3 since it has its own buffering system in the `store_dir`. Instead, use `store_dir_limit_size`. 
 
-S3 uploads are primarily initiated via the S3 "timer callback function", which runs separately from its "flush callback function". Because S3 has its own system of buffering and its own callback to upload data, the normal sequential data ordering of chunks provided by the Fluent Bit engine may be compromised. Consequently, S3 has the `presevere_data_ordering` option which will ensure its buffer files are uploaded in order in its "timer callback function". 
+S3 uploads are primarily initiated via the S3 "timer callback function", which runs separately from its "flush callback function". Because S3 has its own system of buffering and its own callback to upload data, the normal sequential data ordering of chunks provided by the Fluent Bit engine may be compromised. Consequently, S3 has the `presevere_data_ordering` option which will ensure data is uploaded in the original order it was collected by Fluent Bit. 
 
 ### Summary: Uniqueness in S3 Plugin 
 


### PR DESCRIPTION
My description before wasn't exactly correctly and also trying to explain why we needed to add the
preserve_data_ordering option is probably too much for end-user documentation. Better to just note
the problem and the option.

Signed-off-by: Wesley Pettit <wppttt@amazon.com>