### PR TITLE
Record accessor limitation

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/record-accessor.md
+++ b/administration/configuring-fluent-bit/classic-mode/record-accessor.md
@@ -95,3 +95,23 @@ Fluent Bit v1.x.x
 {"date":1599862267.483692,"log":"message 4","labels":{"color":"blue"}}
 ```
 
+### Limitations of record_accessor templating
+
+Notice in example 2, that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
+
+The following would be invalid templates because the two template variables are not separated by commas or dots:
+
+- `$TaskID-$ECSContainerName`
+- `$TaskID/$ECSContainerName`
+- `$TaskID_$ECSContainerName`
+- `$TaskIDfooo$ECSContainerName`
+
+However, the following are valid:
+- `$TaskID.$ECSContainerName`
+- `$TaskID.ecs_resource.$ECSContainerName`
+- `$TaskID.fooo.$ECSContainerName`
+
+And the following are valid since they only contain one template variable with nothing after it:
+- `fooo$TaskID`
+- `fooo____$TaskID`
+- `fooo/bar$TaskID`

--- a/administration/configuring-fluent-bit/classic-mode/record-accessor.md
+++ b/administration/configuring-fluent-bit/classic-mode/record-accessor.md
@@ -97,7 +97,7 @@ Fluent Bit v1.x.x
 
 ### Limitations of record_accessor templating
 
-Notice in example 2, that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
+Notice in example 2[Link to example2](../../../pipeline/filters/ecs-metadata.md#example-2-attach-customized-resource-name-to-container-logs), that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
 
 The following would be invalid templates because the two template variables are not separated by commas or dots:
 

--- a/administration/configuring-fluent-bit/classic-mode/record-accessor.md
+++ b/administration/configuring-fluent-bit/classic-mode/record-accessor.md
@@ -97,7 +97,7 @@ Fluent Bit v1.x.x
 
 ### Limitations of record_accessor templating
 
-Notice in the example from [Record accessor template usage](../../../pipeline/filters/ecs-metadata.md#example-2-attach-customized-resource-name-to-container-logs), that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
+The Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
 
 The following would be invalid templates because the two template variables are not separated by commas or dots:
 

--- a/administration/configuring-fluent-bit/classic-mode/record-accessor.md
+++ b/administration/configuring-fluent-bit/classic-mode/record-accessor.md
@@ -97,7 +97,7 @@ Fluent Bit v1.x.x
 
 ### Limitations of record_accessor templating
 
-Notice in the example from [Record accessor template usage Example](../../../pipeline/filters/ecs-metadata.md#example-2-attach-customized-resource-name-to-container-logs), that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
+Notice in the example from [Record accessor template usage](../../../pipeline/filters/ecs-metadata.md#example-2-attach-customized-resource-name-to-container-logs), that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
 
 The following would be invalid templates because the two template variables are not separated by commas or dots:
 

--- a/administration/configuring-fluent-bit/classic-mode/record-accessor.md
+++ b/administration/configuring-fluent-bit/classic-mode/record-accessor.md
@@ -97,7 +97,7 @@ Fluent Bit v1.x.x
 
 ### Limitations of record_accessor templating
 
-Notice in example 2[Link to example2](../../../pipeline/filters/ecs-metadata.md#example-2-attach-customized-resource-name-to-container-logs), that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
+Notice in the example from [Record accessor template usage Example](../../../pipeline/filters/ecs-metadata.md#example-2-attach-customized-resource-name-to-container-logs), that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
 
 The following would be invalid templates because the two template variables are not separated by commas or dots:
 

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -148,23 +148,4 @@ This examples shows a use case for the `Cluster_Metadata_Only` option- attaching
     Format json_lines
 ```
 
-### Limitations of record_accessor templating
-
-Notice in example 2, that the template values are separated by dot characters. This is important; the Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable. This is because the templating library must parse the template and determine the end of a variable.
-
-The following would be invalid templates because the two template variables are not separated by commas or dots:
-
-- `$TaskID-$ECSContainerName`
-- `$TaskID/$ECSContainerName`
-- `$TaskID_$ECSContainerName`
-- `$TaskIDfooo$ECSContainerName`
-
-However, the following are valid:
-- `$TaskID.$ECSContainerName`
-- `$TaskID.ecs_resource.$ECSContainerName`
-- `$TaskID.fooo.$ECSContainerName`
-
-And the following are valid since they only contain one template variable with nothing after it:
-- `fooo$TaskID`
-- `fooo____$TaskID`
-- `fooo/bar$TaskID`
+To learn more about record accessor feature and its limitations check the [Record accessor](administration/configuring-fluent-bit/classic-mode/record-accessor#limitations-of-record_accessor-templating) section.

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -116,7 +116,7 @@ The output log would be similar to:
 }
 ```
 
-Notice that the template variables in the value for the `resource` key are separated by dot charactersi, only dots and commas
+Notice that the template variables in the value for the `resource` key are separated by dot characters, only dots and commas
  (`.` and `,`) can come after a template variable. For more information, please check the [Record accessor limitation's section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
 
 #### Example 3: Attach cluster metadata to non-container logs

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -148,4 +148,5 @@ This examples shows a use case for the `Cluster_Metadata_Only` option- attaching
     Format json_lines
 ```
 
-To learn more about record accessor feature and its limitations check the [Record accessor](administration/configuring-fluent-bit/classic-mode/record-accessor#limitations-of-record_accessor-templating) section.
+To learn more about record accessor feature and its limitations check the [Record accessor](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating) section.
+

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -116,8 +116,11 @@ The output log would be similar to:
 }
 ```
 
-Notice that the template variables in the value for the `resource` key are separated by dot characters. For more information, please check the [Record accessor limitation's section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
+Notice that the template variables in the value for the `resource` key are separated by dot characters. The Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas
+ (`.` and `,`) can come after a template variable. For more information, please check the [Record accessor limitation's section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
 
+The Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas
+ (`.` and `,`) can come after a template variable
 #### Example 3: Attach cluster metadata to non-container logs
 
 This examples shows a use case for the `Cluster_Metadata_Only` option- attaching cluster metadata to ECS Agent logs. 

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -116,7 +116,7 @@ The output log would be similar to:
 }
 ```
 
-Notice that the template variables in the value for the `resource` key are separated by dot characters. For more information, please check the [Record accessor limitation section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
+Notice that the template variables in the value for the `resource` key are separated by dot characters. For more information, please check the [Record accessor limitation's section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
 
 #### Example 3: Attach cluster metadata to non-container logs
 

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -116,7 +116,7 @@ The output log would be similar to:
 }
 ```
 
-Notice that the template variables in the value for the `resource` key are separated by dot characters. Please see the section below about limitations in which characters can be used to separate template variables. 
+Notice that the template variables in the value for the `resource` key are separated by dot characters. For more information, please check the [Record accessor limitation section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
 
 #### Example 3: Attach cluster metadata to non-container logs
 
@@ -147,6 +147,4 @@ This examples shows a use case for the `Cluster_Metadata_Only` option- attaching
     Match *
     Format json_lines
 ```
-
-To learn more about record accessor feature and its limitations check the [Record accessor](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating) section.
 

--- a/pipeline/filters/ecs-metadata.md
+++ b/pipeline/filters/ecs-metadata.md
@@ -116,11 +116,9 @@ The output log would be similar to:
 }
 ```
 
-Notice that the template variables in the value for the `resource` key are separated by dot characters. The Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas
+Notice that the template variables in the value for the `resource` key are separated by dot charactersi, only dots and commas
  (`.` and `,`) can come after a template variable. For more information, please check the [Record accessor limitation's section](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md#limitations-of-record_accessor-templating).
 
-The Fluent Bit record_accessor library has a limitation in the characters that can separate template variables- only dots and commas
- (`.` and `,`) can come after a template variable
 #### Example 3: Attach cluster metadata to non-container logs
 
 This examples shows a use case for the `Cluster_Metadata_Only` option- attaching cluster metadata to ECS Agent logs. 


### PR DESCRIPTION
Removed the Limitation section from https://docs.fluentbit.io/manual/pipeline/filters/ecs-metadata#limitations-of-record_accessor-templating and added this section to https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/record-accessor