### PR TITLE
administration: networking: add missing info (#889) backport to 1.9

### DIFF
--- a/administration/networking.md
+++ b/administration/networking.md
@@ -45,12 +45,14 @@ For plugins that rely on networking I/O, the following section describes the net
 | Property | Description | Default |
 | :--- | :--- | :--- |
 | `net.connect_timeout` | Set maximum time expressed in seconds to wait for a TCP connection to be established, this include the TLS handshake time. | 10 |
-| `net.connect_timeout_log_error` | On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message | true
-| `net.source_address` | Specify network address \(interface\) to use for connection and data traffic. |  |
+| `net.connect_timeout_log_error` | On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message. | true |
+| `net.dns.mode` | Select the primary DNS connection type (TCP or UDP). Can be set in the [SERVICE] section and overridden on a per plugin basis if desired. |  |
+| `net.dns.prefer_ipv4` |  Prioritize IPv4 DNS results when trying to establish a connection. | false |
+| `net.dns.resolver`| Select the primary DNS resolver type (LEGACY or ASYNC). | |
 | `net.keepalive` | Enable or disable connection keepalive support. Accepts a boolean value: on / off. | on |
 | `net.keepalive_idle_timeout` | Set maximum time expressed in seconds for an idle keepalive connection. | 30 |
-| `net.keepalive_max_recycle` | Set the maximum number of times a keepalive connection can be used before it is destroyed. | 0 |
-| `net.dns.mode` | Set the primary transport layer protocol used by the asynchronous DNS resolver for connections established in the plugin where this configuration value is used | UDP |
+| `net.keepalive_max_recycle` | Set maximum number of times a keepalive connection can be used before it is retired. | 2000 |
+| `net.source_address` | Specify network address to bind for data traffic. |  |
 
 ## Example
 
@@ -101,4 +103,3 @@ $ nc -l 9090
 If the `net.keepalive` option is not enabled, Fluent Bit will close the TCP connection and netcat will quit, here we can see how the keepalive connection works.
 
 After the 5 records arrive, the connection will keep idle and after 10 seconds it will be closed due to `net.keepalive_idle_timeout`.
-


### PR DESCRIPTION
* [ADD] add networking info

Signed-off-by: David Latorre <david@calyptia.com>

* administration: networking: add missing info

Signed-off-by: David Latorre <david@calyptia.com>

* administration: networking: add missing info

Signed-off-by: David Latorre <david@calyptia.com>

* administration: networking: add missing info

Signed-off-by: David Latorre <david@calyptia.com>

* administration: networking: add complementary info to net.dns.mode property

Signed-off-by: David Latorre <david@calyptia.com>

* administration: networking: Deleted no related http info

Signed-off-by: David Latorre <david@calyptia.com>

Signed-off-by: David Latorre <david@calyptia.com>