### PR TITLE
Added Syslog to list of plugins that support TLS

### DIFF
--- a/administration/security.md
+++ b/administration/security.md
@@ -40,6 +40,7 @@ The following **output** plugins can take advantage of the TLS feature:
 * [Slack](../pipeline/outputs/slack.md)
 * [Splunk](../pipeline/outputs/splunk.md)
 * [Stackdriver](../pipeline/outputs/stackdriver.md)
+* [Syslog](../pipeline/outputs/syslog.md)
 * [TCP & TLS](../pipeline/outputs/tcp-and-tls.md)
 * [Treasure Data](../pipeline/outputs/treasure-data.md)
 


### PR DESCRIPTION
Syslog has a TLS mode so I assume it should be on the list.

Signed-off-by: Kevin McNamee <46104536+mrkmcnamee@users.noreply.github.com>