### PR TITLE
filter: aws `tags_include` and `tags_exclude`

### DIFF
--- a/pipeline/filters/aws-metadata.md
+++ b/pipeline/filters/aws-metadata.md
@@ -17,6 +17,7 @@ The plugin supports the following configuration parameters:
 | account\_id | The account ID for current EC2 instance. | false |
 | hostname | The hostname for current EC2 instance. | false |
 | vpc\_id | The VPC ID for current EC2 instance. | false |
+| tags_enabled | Specifies if should attach EC2 instance tags. EC2 instance must have the [instance-metadata-tags](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-instance-metadata-options.html) option enabled (which is disabled by default). | false |
 
 Note: _If you run Fluent Bit in a container, you may have to use instance metadata v1._ The plugin behaves the same regardless of which version is used.
 
@@ -49,6 +50,7 @@ $ bin/fluent-bit -c /PATH_TO_CONF_FILE/fluent-bit.conf
     account_id true
     hostname true
     vpc_id true
+    tags_enabled true
 
 [OUTPUT]
     Name stdout

--- a/pipeline/filters/aws-metadata.md
+++ b/pipeline/filters/aws-metadata.md
@@ -18,6 +18,8 @@ The plugin supports the following configuration parameters:
 | hostname | The hostname for current EC2 instance. | false |
 | vpc\_id | The VPC ID for current EC2 instance. | false |
 | tags_enabled | Specifies if should attach EC2 instance tags. EC2 instance must have the [instance-metadata-tags](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-instance-metadata-options.html) option enabled (which is disabled by default). | false |
+| tags_include | Defines list of specific EC2 tag keys to inject into the logs. Tag keys must be separated by "," character. Tags which are not present in this list will be ignored. Example: `Name,tag1,tag2`. | |
+| tags_exclude | Defines list of specific EC2 tag keys not to inject into the logs. Tag keys must be separated by "," character. If `tags_include` is not empty then `tags_exclude` has no effect. Example: `Name,tag1,tag2` | |
 
 Note: _If you run Fluent Bit in a container, you may have to use instance metadata v1._ The plugin behaves the same regardless of which version is used.
 


### PR DESCRIPTION
PR adds the documentation for `tags_include` and `tags_exclude`. It contains the previous commit with `tags_enabled`.

I will update this PR once https://github.com/fluent/fluent-bit-docs/pull/897 is merged.