### PR TITLE
out_opentelemetry: adjust `add_label` description

### DIFF
--- a/pipeline/outputs/opentelemetry.md
+++ b/pipeline/outputs/opentelemetry.md
@@ -27,7 +27,7 @@ Only HTTP endpoints are supported.
 | `logs_span_id_message_key` | The span id key to look up in the log events body/message. Sets the `SpanId` field of the OpenTelemetry logs data model. | `spanId` |
 | `logs_severity_text_message_key` | The severity text id key to look up in the log events body/message. Sets the `SeverityText` field of the OpenTelemetry logs data model. | `severityText` |
 | `logs_severity_number_message_key` | The severity number id key to look up in the log events body/message. Sets the `SeverityNumber` field of the OpenTelemetry logs data model. | `severityNumber` |
-| `add_label` | Lets you add custom labels to all metrics and logs (resource attributes) exposed through the OpenTelemetry exporter. You may have multiple `add_label` fields for each label you want to add. | _none_ |
+| `add_label` | Lets you add custom labels to all metrics and logs (resource attributes) exposed through the OpenTelemetry exporter. You can have multiple `add_label` fields for each label you want to add. | _none_ |
 | `compress` | Set payload compression mechanism. Allowed value: `gzip`. | _none_ |
 | `logs_observed_timestamp_metadata_key` | Specify an `ObservedTimestamp` key to look up in the metadata. | `$ObservedKey` |
 | `logs_timestamp_metadata_key` | Specify a `Timestamp` key to look up in the metadata.        | `$Timestamp`      |


### PR DESCRIPTION
`add_label` can add attributes to logs data (Resource attributes instead of LogRecord's attributes) after this PR: https://github.com/fluent/fluent-bit/pull/7029