### PR TITLE
administration: rename Security to Transport Security (transport-secu…

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -59,7 +59,7 @@
     * [Configuration File](administration/configuring-fluent-bit/yaml/configuration-file.md)
   * [Unit Sizes](administration/configuring-fluent-bit/unit-sizes.md)
   * [Multiline Parsing](administration/configuring-fluent-bit/multiline-parsing.md)
-* [Security](administration/security.md)
+* [Transport Security](administration/transport-security.md)
 * [Buffering & Storage](administration/buffering-and-storage.md)
 * [Backpressure](administration/backpressure.md)
 * [Scheduling and Retries](administration/scheduling-and-retries.md)

--- a/administration/configuring-fluent-bit/classic-mode/upstream-servers.md
+++ b/administration/configuring-fluent-bit/classic-mode/upstream-servers.md
@@ -27,7 +27,7 @@ A _Node_ might contain additional configuration keys required by the plugin, on 
 
 In addition to the properties defined in the table above, the network operations against a defined node can optionally be done through the use of TLS for further encryption and certificates use.
 
-The TLS options available are described in the [TLS/SSL](../../security.md) section and can be added to the any _Node_ section.
+The TLS options available are described in the [TLS/SSL](../../transport-security.md) section and can be added to the any _Node_ section.
 
 ### Configuration File Example
 

--- a/administration/networking.md
+++ b/administration/networking.md
@@ -26,7 +26,7 @@ TCP is a _connected oriented_ channel, to deliver and receive data from a remote
 
 The concept of `Connection Keepalive` refers to the ability of the client \(Fluent Bit on this case\) to keep the TCP connection open in a persistent way, that means that once the connection is created and used, instead of close it, it can be recycled. This feature offers many benefits in terms of performance since communication channels are always established before hand.
 
-Any component that uses TCP channels like HTTP or [TLS](security.md), can take advantage of this feature. For configuration purposes use the `net.keepalive` property.
+Any component that uses TCP channels like HTTP or [TLS](transport-security.md), can take advantage of this feature. For configuration purposes use the `net.keepalive` property.
 
 ### Connection Keepalive Idle Timeout
 

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -1,5 +1,5 @@
 
-# Security
+# Transport Security
 
 Fluent Bit provides integrated support for _Transport Layer Security_ \(TLS\) and it predecessor _Secure Sockets Layer_ \(SSL\) respectively. In this section we will refer as TLS only for both implementations.
 

--- a/pipeline/outputs/forward.md
+++ b/pipeline/outputs/forward.md
@@ -27,7 +27,7 @@ The following parameters are mandatory for either Forward for Secure Forward mod
 
 ## Secure Forward Mode Configuration Parameters
 
-When using Secure Forward mode, the [TLS](../../administration/security.md) mode requires to be enabled. The following additional configuration parameters are available:
+When using Secure Forward mode, the [TLS](../../administration/transport-security.md) mode requires to be enabled. The following additional configuration parameters are available:
 
 | Key              | Description                                                                                                                               | Default   |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- |

--- a/pipeline/outputs/gelf.md
+++ b/pipeline/outputs/gelf.md
@@ -24,7 +24,7 @@ According to [GELF Payload Specification](https://docs.graylog.org/en/latest/pag
 
 ### TLS / SSL
 
-GELF output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/security.md) section.
+GELF output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
 
 ## Notes
 

--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -177,7 +177,7 @@ job="fluentbit", team="Santiago Wanderers"
 This plugin inherit core Fluent Bit features to customize the network behavior and optionally enable TLS in the communication channel. For more details about the specific options available refer to the following articles:
 
 * [Networking Setup](../../administration/networking.md): timeouts, keepalive and source address
-* [Security & TLS](../../administration/security.md): all about TLS configuration and certificates
+* [Security & TLS](../../administration/transport-security.md): all about TLS configuration and certificates
 
 Note that all options mentioned in the articles above must be enabled in the plugin configuration in question.
 

--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -51,7 +51,7 @@ See [here](https://github.com/fluent/fluent-bit-docs/tree/43c4fe134611da471e706b
 
 ## TLS / SSL
 
-To skip TLS verification, set `tls.verify` as `false`. For more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/security.md) section.
+To skip TLS verification, set `tls.verify` as `false`. For more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
 
 ## Permissions
 

--- a/pipeline/outputs/splunk.md
+++ b/pipeline/outputs/splunk.md
@@ -41,7 +41,7 @@ Content and Splunk metadata \(fields\) handling configuration properties:
 
 ### TLS / SSL
 
-Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/security.md) section.
+Splunk output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
 
 ## Getting Started
 


### PR DESCRIPTION
…rity) (#1065)

* administration: security: rename to Transport Security (transport-security)



* Summary: rename security to transport-security



* administration: networking: rename security to transport-security



* administration: configuring fluent bit: classic mode: upstream servers: rename security to transport-security



* pipeline: outputs: rename security to transport-security



---------