### PR TITLE
input: stdin: Describe EoF behaviour, parser

### DIFF
--- a/concepts/key-concepts.md
+++ b/concepts/key-concepts.md
@@ -30,11 +30,35 @@ Jan 18 12:52:16 flb gsd-media-keys[2640]: # watch_fast: "/org/gnome/terminal/leg
 
 It contains four lines and all of them represents **four** independent Events.
 
-Internally, an Event always has two components \(in an array form\):
+Internally an Event is comprised of:
+
+* timestamp
+* key/value metadata (since v2.1.0)
+* payload
+
+### Event format
+
+The Fluent Bit wire protocol represents an Event is a 2-element array
+with a nested array as the first element:
+
+```javascript
+[[TIMESTAMP, METADATA], MESSAGE]
+```
+
+where
+
+* TIMESTAMP is a timestamp in seconds as an integer or floating point value (not a string);
+* METADATA is a possibly-empty object containing event metadata; and
+* MESSAGE is an object containing the event body.
+
+Fluent-bit versions prior to v2.1.0 instead used:
 
 ```javascript
 [TIMESTAMP, MESSAGE]
 ```
+
+to represent events. This format is still supported for reading input event
+streams.
 
 ## Filtering
 

--- a/concepts/key-concepts.md
+++ b/concepts/key-concepts.md
@@ -38,7 +38,7 @@ Internally an Event is comprised of:
 
 ### Event format
 
-The Fluent Bit wire protocol represents an Event is a 2-element array
+The Fluent Bit wire protocol represents an Event as a 2-element array
 with a nested array as the first element:
 
 ```javascript

--- a/concepts/key-concepts.md
+++ b/concepts/key-concepts.md
@@ -51,7 +51,7 @@ where
 * METADATA is a possibly-empty object containing event metadata; and
 * MESSAGE is an object containing the event body.
 
-Fluent-bit versions prior to v2.1.0 instead used:
+Fluent Bit versions prior to v2.1.0 instead used:
 
 ```javascript
 [TIMESTAMP, MESSAGE]

--- a/pipeline/inputs/standard-input.md
+++ b/pipeline/inputs/standard-input.md
@@ -1,17 +1,35 @@
 # Standard Input
 
-The **stdin** plugin allows to retrieve valid JSON text messages over the standard input interface \(stdin\). In order to use it, specify the plugin name as the input, e.g:
+The **stdin** plugin supports retrieving a message stream from the standard input interface \(stdin\) of the Fluent Bit process.
+In order to use it, specify the plugin name as the input, e.g:
 
 ```bash
 $ fluent-bit -i stdin -o stdout
 ```
 
-As input data the _stdin_ plugin recognize the following JSON data formats:
+If the stdin stream is closed (end-of-file), the stdin plugin will instruct
+Fluent Bit to exit with success (0) after flushing any pending output.
+
+## Input formats
+
+If no parser is configured for the stdin plugin, it expects *valid json* input input data with one of the following data formats:
 
 ```bash
 1. { map => val, map => val, map => val }
 2. [ time, { map => val, map => val, map => val } ]
 ```
+
+Any input data that is *not* in one of the above formats will cause the plugin to log errors like:
+
+```
+[error] [input:stdin:stdin.0] invalid record found, it's not a JSON map or array
+```
+
+To handle inputs in other formats, a parser must be explicitly specified in the configuration for the `stdin` plugin. See [parser input example](#parser-input-example) for sample configuration.
+
+## Examples
+
+### Json input example
 
 A better example to demonstrate how it works will be through a _Bash_ script that generates messages and writes them to [Fluent Bit](http://fluentbit.io). Write the following content in a file named _test.sh_:
 
@@ -48,6 +66,51 @@ Fluent Bit v1.x.x
 [4] stdin.0: [1475898290, {"key"=>"some value"}]
 ```
 
+### Parser input example <a id="parser-input-example"></a>
+
+To capture inputs in other formats, specify a parser configuration for the
+`stdin` plugin.
+
+For example, if you want to read raw messages line-by-line and forward them you
+could use a `parser.conf` that captures the whole message line:
+
+```
+[PARSER]
+    name        stringify_message
+    format      regex
+    Key_Name    message
+    regex       ^(?<message>.*)
+```
+
+then use that in the `parser` clause of the stdin plugin in the `fluent-bit.conf`:
+
+```
+[INPUT]
+    Name    stdin
+    Tag     stdin
+    Parser  stringify_message
+
+[OUTPUT]
+    Name   stdout
+    Match  *
+```
+
+Fluent Bit will now read each line and emit a single message for each input
+line:
+
+```
+$ seq 1 5 | /opt/fluent-bit/bin/fluent-bit -c fluent-bit.conf -R parser.conf -q
+[0] stdin: [1681358780.517029169, {"message"=>"1"}]
+[1] stdin: [1681358780.517068334, {"message"=>"2"}]
+[2] stdin: [1681358780.517072116, {"message"=>"3"}]
+[3] stdin: [1681358780.517074758, {"message"=>"4"}]
+[4] stdin: [1681358780.517077392, {"message"=>"5"}]
+$
+```
+
+In real-world deployments it is best to use a more realistic parser that splits
+messages into real fields and adds appropriate tags.
+
 ## Configuration Parameters <a id="config"></a>
 
 The plugin supports the following configuration parameters:
@@ -55,4 +118,4 @@ The plugin supports the following configuration parameters:
 | Key | Description | Default |
 | :--- | :--- | :--- |
 | Buffer\_Size | Set the buffer size to read data. This value is used to increase buffer size. The value must be according to the [Unit Size](../../administration/configuring-fluent-bit/unit-sizes.md) specification. | 16k |
-
+| Parser | The name of the parser to invoke instead of the default json input parser | |

--- a/pipeline/inputs/standard-input.md
+++ b/pipeline/inputs/standard-input.md
@@ -12,20 +12,27 @@ Fluent Bit to exit with success (0) after flushing any pending output.
 
 ## Input formats
 
-If no parser is configured for the stdin plugin, it expects *valid json* input input data with one of the following data formats:
+If no parser is configured for the stdin plugin, it expects *valid JSON* input data in one of the following formats:
 
-```bash
-1. { map => val, map => val, map => val }
-2. [ time, { map => val, map => val, map => val } ]
-```
+1. A JSON object with one or more key-value pairs: `{ "key": "value", "key2": "value2" }`
+3. A 2-element JSON array in [Fluent Bit Event](../../concepts/key-concepts.md#event-or-record) format, which may be:
+  * `[TIMESTAMP, { "key": "value" }]` where TIMESTAMP is a floating point value representing a timestamp in seconds; or
+  * from Fluent Bit v2.1.0, `[[TIMESTAMP, METADATA], { "key": "value" }]` where TIMESTAMP has the same meaning as above and and METADATA is a JSON object.
+
+Multi-line input JSON is supported.
 
 Any input data that is *not* in one of the above formats will cause the plugin to log errors like:
 
 ```
+[debug] [input:stdin:stdin.0] invalid JSON message, skipping
 [error] [input:stdin:stdin.0] invalid record found, it's not a JSON map or array
 ```
 
 To handle inputs in other formats, a parser must be explicitly specified in the configuration for the `stdin` plugin. See [parser input example](#parser-input-example) for sample configuration.
+
+## Log event timestamps
+
+The Fluent Bit event timestamp will be set from the input record if the 2-element event input is used or a custom parser configuration supplies a timestamp. Otherwise the event timestamp will be set to the timestamp at which the record is read by the stdin plugin.
 
 ## Examples
 
@@ -36,35 +43,96 @@ A better example to demonstrate how it works will be through a _Bash_ script tha
 ```bash
 #!/bin/sh
 
-while :; do
+for ((i=0; i<=5; i++)); do
   echo -n "{\"key\": \"some value\"}"
   sleep 1
 done
 ```
 
-Give the script execution permission:
+Now lets start the script and [Fluent Bit](http://fluentbit.io):
 
 ```bash
-$ chmod 755 test.sh
+$ bash test.sh | fluent-bit -q -i stdin -o stdout
+[0] stdin.0: [[1684196745.942883835, {}], {"key"=>"some value"}]
+[0] stdin.0: [[1684196746.938949056, {}], {"key"=>"some value"}]
+[0] stdin.0: [[1684196747.940162493, {}], {"key"=>"some value"}]
+[0] stdin.0: [[1684196748.941392297, {}], {"key"=>"some value"}]
+[0] stdin.0: [[1684196749.942644238, {}], {"key"=>"some value"}]
+[0] stdin.0: [[1684196750.943721442, {}], {"key"=>"some value"}]
 ```
 
-Now lets start the script and [Fluent Bit](http://fluentbit.io) in the following way:
+### Json input with timestamp example
+
+An input event timestamp may also be supplied. Replace `test.sh` with:
 
 ```bash
-$ ./test.sh | fluent-bit -i stdin -o stdout
-Fluent Bit v1.x.x
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
+#!/bin/sh
 
-[2016/10/07 21:44:46] [ info] [engine] started
-[0] stdin.0: [1475898286, {"key"=>"some value"}]
-[1] stdin.0: [1475898287, {"key"=>"some value"}]
-[2] stdin.0: [1475898288, {"key"=>"some value"}]
-[3] stdin.0: [1475898289, {"key"=>"some value"}]
-[4] stdin.0: [1475898290, {"key"=>"some value"}]
+for ((i=0; i<=5; i++)); do
+  echo -n "
+    [
+      $(date '+%s.%N' -d '1 day ago'),
+      {
+        \"realtimestamp\": $(date '+%s.%N')
+      }
+    ]
+  "
+  sleep 1
+done
 ```
+
+Re-run the sample command. Note that the timestamps output by Fluent Bit are now one day old because Fluent Bit used the input message timestamp.
+
+```bash
+$ bash test.sh | fluent-bit -q -i stdin -o stdout
+[0] stdin.0: [[1684110480.028171300, {}], {"realtimestamp"=>1684196880.030070}]
+[0] stdin.0: [[1684110481.033753395, {}], {"realtimestamp"=>1684196881.034741}]
+[0] stdin.0: [[1684110482.036730051, {}], {"realtimestamp"=>1684196882.037704}]
+[0] stdin.0: [[1684110483.039903879, {}], {"realtimestamp"=>1684196883.041081}]
+[0] stdin.0: [[1684110484.044719457, {}], {"realtimestamp"=>1684196884.046404}]
+[0] stdin.0: [[1684110485.048710107, {}], {"realtimestamp"=>1684196885.049651}]
+```
+
+### Json input with metadata example
+
+Additional metadata is also supported on Fluent Bit v2.1.0 and above by replacing the timestamp
+with a 2-element object, e.g.:
+
+```bash
+#!/bin/sh
+for ((i=0; i<=5; i++)); do
+  echo -n "
+    [
+      [
+        $(date '+%s.%N' -d '1 day ago'),
+	{\"metakey\": \"metavalue\"}
+      ],
+      {
+        \"realtimestamp\": $(date '+%s.%N')
+      }
+    ]
+  "
+  sleep 1
+done
+```
+
+```
+$ bash ./test.sh | fluent-bit -q -i stdin -o stdout
+[0] stdin.0: [[1684110513.060139417, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196913.061017}]
+[0] stdin.0: [[1684110514.063085317, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196914.064145}]
+[0] stdin.0: [[1684110515.066210508, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196915.067155}]
+[0] stdin.0: [[1684110516.069149971, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196916.070132}]
+[0] stdin.0: [[1684110517.072484016, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196917.073636}]
+[0] stdin.0: [[1684110518.075428724, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196918.076292}]
+```
+
+On older Fluent Bit versions records in this format will be discarded. Fluent Bit will log:
+
+```
+[ warn] unknown time format 6
+```
+
+if the log level permits.
 
 ### Parser input example <a id="parser-input-example"></a>
 
@@ -118,4 +186,4 @@ The plugin supports the following configuration parameters:
 | Key | Description | Default |
 | :--- | :--- | :--- |
 | Buffer\_Size | Set the buffer size to read data. This value is used to increase buffer size. The value must be according to the [Unit Size](../../administration/configuring-fluent-bit/unit-sizes.md) specification. | 16k |
-| Parser | The name of the parser to invoke instead of the default json input parser | |
+| Parser | The name of the parser to invoke instead of the default JSON input parser | |


### PR DESCRIPTION
Document how to use a parser with the stdin plugin to read arbitrary messages, since the default behaviour is to assume a specific json input format. This is very confusing for new users, since the plugin just logs

    invalid record found, it's not a JSON map or array

when it sees inputs it doesn't expect, and the docs don't explain that you can set a parser to handle other formats.

Document the stdin plugin's behaviour on end-of-file.

Also explain the accepted input formats for the plugin's default reader: object, object with timestamp, or object with timestamp and metadata.