### PR TITLE
update out_pgsql document

### DIFF
--- a/pipeline/outputs/postgresql.md
+++ b/pipeline/outputs/postgresql.md
@@ -61,6 +61,7 @@ Make sure that the `fluentbit` user can connect to the `fluentbit` database on t
 | `min_pool_size` | Minimum number of connection in async mode | 1 |
 | `max_pool_size` | Maximum amount of connections in async mode | 4 |
 | `cockroachdb` | Set to `true` if you will connect the plugin with a CockroachDB | false |
+| `Daemon` | Set to `true` if you want run this plugin instance in daemon mode | false |
 
 ### Libpq
 


### PR DESCRIPTION
update out_pgsql plugin: add a configurable parameter to support run this plugin in a daemon mode.
if in daemon mode, configuration error of out_pgsql will not cause fluentbit crash or exit.

code Merge Request link as follows:
https://github.com/fluent/fluent-bit/pull/7215