### PR TITLE
windows: link out to default plugin config

### DIFF
--- a/installation/macos.md
+++ b/installation/macos.md
@@ -1,7 +1,11 @@
 # macOS
 
 Fluent Bit is compatible with latest Apple macOS system on x86_64 and Apple Silicon M1 architectures.
-At the moment there is no official supported package but you can build it from sources by following the instructions below.
+At the moment there is only an official supported package on x86_64 but you can build it from source as well by following the instructions below.
+
+## Installation Packages
+
+The packages can be found here: <https://packages.fluentbit.io/macos/>
 
 ## Requirements
 

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -2,6 +2,8 @@
 
 Fluent Bit is distributed as **fluent-bit** package for Windows and as a [Windows container on Docker Hub](docker.md). Fluent Bit has two flavours of Windows installers: a ZIP archive (for quick testing) and an EXE installer (for system installation).
 
+Not all plugins are supported on Windows: the [CMake configuration](https://github.com/fluent/fluent-bit/blob/master/cmake/windows-setup.cmake) shows the default set of supported plugins.
+
 ## Configuration
 
 Make sure to provide a valid Windows configuration with the installation, a sample one is shown below:


### PR DESCRIPTION
Addresses https://github.com/fluent/fluent-bit/issues/7235 by at least linking out to the default config.

Longer term we should have a matrix of supported plugins, ideally auto-generated from the cmake config.