### PR TITLE
backport: improve documentation for CLIST and SLIST in yaml.

### DIFF
--- a/administration/configuring-fluent-bit/yaml/configuration-file.md
+++ b/administration/configuring-fluent-bit/yaml/configuration-file.md
@@ -85,6 +85,41 @@ pipeline:
         ...
 ```
 
+Each of the subsections for _inputs_, _filters_ and _outputs_ constitutes an array of maps that has the parameters for each.
+
+```yaml
+pipeline:
+    inputs:
+        - name: tail
+          tag: syslog
+          path: /var/log/syslog
+        - name: http
+          tag: http_server
+          port: 8080
+```
+
+As an example, this pipeline consists of two _inputs_; a tail plugin and an http server plugin. Each plugin has its own map in the array of _inputs_ consisting of simple properties. To use more advanced properties that consist of multiple values the property itself can be defined using an array, ie: the _record_ and _allowlist_key_ properties for the _record_modifier_ _filter_:
+
+```
+pipeline:
+    inputs:
+        - name: tail
+          tag: syslog
+          path: /var/log/syslog
+    filters:
+        - name: record_modifier
+          match: syslog
+          record:
+              - powered_by calyptia
+        - name: record_modifier
+          match: syslog
+          allowlist_key:
+              - powered_by
+              - message
+```
+
+In the cases where each value in a list requires two values they must be separated by a space, such as in the _record_ property for the _record_modifier_ filter.
+
 ### Input <a href="config_input" id="config_input"></a>
 
 An _input_ section defines a source (related to an input plugin). Here we will describe the base configuration for each _input_ section. Note that each input plugin may add it own configuration keys:
@@ -95,7 +130,7 @@ An _input_ section defines a source (related to an input plugin). Here we will d
 | Tag         | Tag name associated to all records coming from this plugin.                                                                                             |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
-The _Name_ is mandatory and it let Fluent Bit know which input plugin should be loaded. The _Tag_ is mandatory for all plugins except for the _input forward_ plugin (as it provides dynamic tags).
+The _Name_ is mandatory and it lets Fluent Bit know which input plugin should be loaded. The _Tag_ is mandatory for all plugins except for the _input forward_ plugin (as it provides dynamic tags).
 
 #### Example input
 
@@ -110,16 +145,16 @@ pipeline:
 
 ### Filter <a href="config_filter" id="config_filter"></a>
 
-A _filter_ section defines a filter (related to an filter plugin). Here we will describe the base configuration for each _filter_ section. Note that each filter plugin may add it own configuration keys:
+A _filter_ section defines a filter (related to a filter plugin). Here we will describe the base configuration for each _filter_ section. Note that each filter plugin may add its own configuration keys:
 
-| Key         | Description                                                                                                                                             |
-|------------ |-------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Name        | Name of the filter plugin. Defined as a subsection of the _filters_ section.                                                                            |
-| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard.                         |
-| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.                           |
+| Key         | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Name        | Name of the filter plugin. Defined as a subsection of the _filters_ section. |
+| Match       | A pattern to match against the tags of incoming records. It's case-sensitive and supports the star (\*) character as a wildcard. |
+| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax. |
 | Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
 
-The _Name_ is mandatory and it let Fluent Bit know which filter plugin should be loaded. The _Match_ or _Match_Regex_ is mandatory for all plugins. If both are specified, _Match_Regex_ takes precedence.
+The _Name_ is mandatory and it lets Fluent Bit know which filter plugin should be loaded. The _Match_ or _Match_Regex_ is mandatory for all plugins. If both are specified, _Match_Regex_ takes precedence.
 
 #### Example filter
 
@@ -135,14 +170,14 @@ pipeline:
 
 ### Output <a href="config_output" id="config_output"></a>
 
-The _outputs_ section specify a destination that certain records should follow after a Tag match. Currently, Fluent Bit can route up to 256 _OUTPUT_ plugins. The configuration support the following keys:
+The _outputs_ section specify a destination that certain records should follow after a Tag match. Currently, Fluent Bit can route up to 256 _OUTPUT_ plugins. The configuration supports the following keys:
 
-| Key         | Description                                                                                                                                             |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Name        | Name of the output plugin. Defined as a subsection of the _outputs_ section.                                                                            |
-| Match       | A pattern to match against the tags of incoming records. It's case sensitive and support the star (\*) character as a wildcard.                         |
-| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax.                           |
-| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. Defaults to the _SERVICE_ section's _Log_Level._ |
+| Key         | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Name        | Name of the output plugin. Defined as a subsection of the _outputs_ section. |
+| Match       | A pattern to match against the tags of incoming records. It's case-sensitive and supports the star (\*) character as a wildcard. |
+| Match_Regex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax. |
+| Log_Level   | Set the plugin's logging verbosity level. Allowed values are: off, error, warn, info, debug and trace. The output log level defaults to the _SERVICE_ section's _Log_Level._ |
 
 #### Example output
 
@@ -173,3 +208,4 @@ pipeline:
         - name: stdout
           match: 'my*cpu'
 ```
+


### PR DESCRIPTION
Backport documentation from fluent/fluent-bit-docs#1110 for version 2.0, since the change was admitted into the 2.0 release of fluent-bit, specifically in [5f50ae806d57e5277ebc476633f3ffd66bcff22b].

There are few irrelevant and superfluous changes. I will attempt to revert them later.