### PR TITLE
out_influxdb: remove tags_list_enabled, tags_list_keys

### DIFF
--- a/pipeline/outputs/influxdb.md
+++ b/pipeline/outputs/influxdb.md
@@ -15,10 +15,10 @@ The **influxdb** output plugin, allows to flush your records into a [InfluxDB](h
 | HTTP\_User | Optional username for HTTP Basic Authentication |  |
 | HTTP\_Passwd | Password for user defined in HTTP\_User |  |
 | HTTP\_Token | Authentication token used with InfluDB v2 - if specified, both HTTP\_User and HTTP\_Passwd are ignored |  |
+| HTTP\_Header | Add a HTTP header key/value pair. Multiple headers can be set | |
 | Tag\_Keys | Space separated list of keys that needs to be tagged |  |
 | Auto\_Tags | Automatically tag keys where value is _string_. This option takes a boolean value: True/False, On/Off. | Off |
-| Tags\_List\_Enabled | Dynamically tag keys which are in the _string array_ at Tags\_List\_Key key. This option takes a boolean value: True/False, On/Off. | Off |
-| Tags\_List\_Key | Key of the _string array_ optionally contained within each log record that contains tag keys for that record | tags |
+| Uri | Custom URI endpoint | |
 
 ### TLS / SSL
 


### PR DESCRIPTION
Before merging:

1. I added header following the http output text (https://docs.fluentbit.io/manual/pipeline/outputs/http) but imo this should be later be renamed http_header for more clarity.
2.  I added the uri parameter but the description is not clear (I don't know what it does), see https://github.com/fluent/fluent-bit/blob/master/plugins/out_influxdb/influxdb.c