### PR TITLE
release: update for 2.1.4

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -17,6 +17,10 @@ The following table describes the Linux container tags that are available on Doc
 
 | Tag(s)       | Manifest Architectures    | Description                                                    |
 | ------------ | ------------------------- | -------------------------------------------------------------- |
+| 2.1.4 | x86_64, arm64v8, arm32v7 | Debug images |
+| 2.1.4-debug | x86_64, arm64v8, arm32v7 | Release [v2.1.4](https://fluentbit.io/announcements/v2.1.4/) |
+| 2.1.3 | x86_64, arm64v8, arm32v7 | Debug images |
+| 2.1.3-debug | x86_64, arm64v8, arm32v7 | Release [v2.1.3](https://fluentbit.io/announcements/v2.1.3/) |
 | 2.1.2 | x86_64, arm64v8, arm32v7 | Debug images |
 | 2.1.2-debug | x86_64, arm64v8, arm32v7 | Release [v2.1.2](https://fluentbit.io/announcements/v2.1.2/) |
 | 2.1.1        | x86\_64, arm64v8, arm32v7 | Release [v2.1.1](https://fluentbit.io/announcements/v2.1.1/)   |

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -83,15 +83,15 @@ The latest stable version is 2.1.2 each version is available on the Github relea
 
 | INSTALLERS                                                                                       | SHA256 CHECKSUMS                                                 |
 | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [fluent-bit-2.1.2-win32.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win32.exe) | [fa1a6c6a1d8dcf3bff34aca35e52b7c9159d63d2d4602c3862407dde7a8ff0d2](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win32.exe.sha256) |
-| [fluent-bit-2.1.2-win32.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win32.zip) | [94a1d238163b052ebcfa25708e6d10cef418fed0625afc1014186ca9e5eded7c](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win32.zip.sha256) |
-| [fluent-bit-2.1.2-win64.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win64.exe) | [d53b3239dac064b2308590b7a5ccaa54cb277f8201d4283976775b0478253c85](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win64.exe.sha256) |
-| [fluent-bit-2.1.2-win64.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win64.zip) | [aca353818b1c06cf51f3080c59d7dce973fc3244dcd09c229206bf9d9cbcb61b](https://releases.fluentbit.io/2.1/fluent-bit-2.1.2-win64.zip.sha256) |
+| [fluent-bit-2.1.4-win32.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win32.exe) | [57cb24443214c55358ed2a2f4df80eb84b043313bd9d4e565da1fbb9df1d3eeb](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win32.exe.sha256) |
+| [fluent-bit-2.1.4-win32.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win32.zip) | [5200df3c2bbaf27ced711135e8e235f6733f67128c714565f3617b05a40bcb8e](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win32.zip.sha256) |
+| [fluent-bit-2.1.4-win64.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win64.exe) | [e3026786931f0d8115b75e86c19ae9d45d78b87a5c1e31e9f14362afbd28b6a0](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win64.exe.sha256) |
+| [fluent-bit-2.1.4-win64.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win64.zip) | [61450c27902e36e382010b54af01a9e70b5351cabc0f89b3c62b7d10b5dc7d32](https://releases.fluentbit.io/2.1/fluent-bit-2.1.4-win64.zip.sha256) |
 
 To check the integrity, use `Get-FileHash` cmdlet on PowerShell.
 
 ```powershell
-PS> Get-FileHash fluent-bit-2.1.2-win32.exe
+PS> Get-FileHash fluent-bit-2.1.4-win32.exe
 ```
 
 ## Installing from ZIP archive
@@ -101,7 +101,7 @@ Download a ZIP archive from above. There are installers for 32-bit and 64-bit en
 Then you need to expand the ZIP archive. You can do this by clicking "Extract All" on Explorer, or if you're using PowerShell, you can use `Expand-Archive` cmdlet.
 
 ```powershell
-PS> Expand-Archive fluent-bit-2.1.2-win64.zip
+PS> Expand-Archive fluent-bit-2.1.4-win64.zip
 ```
 
 The ZIP package contains the following set of files.

--- a/update-release-version-docs.sh
+++ b/update-release-version-docs.sh
@@ -19,13 +19,13 @@ function sed_wrapper() {
 
 NEW_VERSION=${NEW_VERSION:?}
 if [[ -z "$NEW_VERSION" ]]; then
-    echo "Missing VERSION value"
+    echo "Missing NEW_VERSION value"
     exit 1
 fi
 
 MAJOR_VERSION=${MAJOR_VERSION:-}
 if [[ -z "$MAJOR_VERSION" ]]; then
-    MAJOR_VERSION=${VERSION%.*}
+    MAJOR_VERSION=${NEW_VERSION%.*}
 fi
 
 # Add Docker after first line in the table


### PR DESCRIPTION
Updates for release 2.1.4 and to ensure the script runs with valid inputs:

```shell
$ export NEW_VERSION=2.1.4
$ export WIN_32_EXE_HASH=57cb24443214c55358ed2a2f4df80eb84b043313bd9d4e565da1fbb9df1d3eeb
$ export WIN_32_ZIP_HASH=5200df3c2bbaf27ced711135e8e235f6733f67128c714565f3617b05a40bcb8e
$ export WIN_64_EXE_HASH=e3026786931f0d8115b75e86c19ae9d45d78b87a5c1e31e9f14362afbd28b6a0
$ export WIN_64_ZIP_HASH=61450c27902e36e382010b54af01a9e70b5351cabc0f89b3c62b7d10b5dc7d32
$ ./update-release-version-docs.sh 
+++ dirname ./update-release-version-docs.sh
++ cd .
++ pwd
+ SCRIPT_DIR=/home/pat/github/fluent/fluent-bit-docs
+ NEW_VERSION=2.1.4
+ [[ -z 2.1.4 ]]
+ MAJOR_VERSION=
+ [[ -z '' ]]
+ MAJOR_VERSION=2.1
+ grep -q 2.1.4 /home/pat/github/fluent/fluent-bit-docs/installation/docker.md
+ sed_wrapper -i -e '/| -.*$/a | 2.1.4-debug | x86\_64, arm64v8, arm32v7 | Release [v2.1.4](https://fluentbit.io/announcements/v2.1.4/) |' /home/pat/github/fluent/fluent-bit-docs/installation/docker.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e '/| -.*$/a | 2.1.4-debug | x86\_64, arm64v8, arm32v7 | Release [v2.1.4](https://fluentbit.io/announcements/v2.1.4/) |' /home/pat/github/fluent/fluent-bit-docs/installation/docker.md
+ sed_wrapper -i -e '/| -.*$/a | 2.1.4 | x86\_64, arm64v8, arm32v7 | Debug images |' /home/pat/github/fluent/fluent-bit-docs/installation/docker.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e '/| -.*$/a | 2.1.4 | x86\_64, arm64v8, arm32v7 | Debug images |' /home/pat/github/fluent/fluent-bit-docs/installation/docker.md
+ WIN_32_EXE_HASH=57cb24443214c55358ed2a2f4df80eb84b043313bd9d4e565da1fbb9df1d3eeb
+ WIN_32_ZIP_HASH=5200df3c2bbaf27ced711135e8e235f6733f67128c714565f3617b05a40bcb8e
+ WIN_64_EXE_HASH=e3026786931f0d8115b75e86c19ae9d45d78b87a5c1e31e9f14362afbd28b6a0
+ WIN_64_ZIP_HASH=61450c27902e36e382010b54af01a9e70b5351cabc0f89b3c62b7d10b5dc7d32
+ sed_wrapper -i -e 's/The latest stable version is .*,/The latest stable version is 2.1.4/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's/The latest stable version is .*,/The latest stable version is 2.1.4/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed_wrapper -i -e 's/fluent-bit-[0-9\.]*-win/fluent-bit-2.1.4-win/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's/fluent-bit-[0-9\.]*-win/fluent-bit-2.1.4-win/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed_wrapper -i -e 's|releases.fluentbit.io/[0-9\.]*/|releases.fluentbit.io/2.1/|g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's|releases.fluentbit.io/[0-9\.]*/|releases.fluentbit.io/2.1/|g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed_wrapper -i -e 's/win32.exe) | \[.*\]/win32.exe) | \[57cb24443214c55358ed2a2f4df80eb84b043313bd9d4e565da1fbb9df1d3eeb\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's/win32.exe) | \[.*\]/win32.exe) | \[57cb24443214c55358ed2a2f4df80eb84b043313bd9d4e565da1fbb9df1d3eeb\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed_wrapper -i -e 's/win32.zip) | \[.*\]/win32.zip) | \[5200df3c2bbaf27ced711135e8e235f6733f67128c714565f3617b05a40bcb8e\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's/win32.zip) | \[.*\]/win32.zip) | \[5200df3c2bbaf27ced711135e8e235f6733f67128c714565f3617b05a40bcb8e\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed_wrapper -i -e 's/win64.exe) | \[.*\]/win64.exe) | \[e3026786931f0d8115b75e86c19ae9d45d78b87a5c1e31e9f14362afbd28b6a0\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's/win64.exe) | \[.*\]/win64.exe) | \[e3026786931f0d8115b75e86c19ae9d45d78b87a5c1e31e9f14362afbd28b6a0\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed_wrapper -i -e 's/win64.zip) | \[.*\]/win64.zip) | \[61450c27902e36e382010b54af01a9e70b5351cabc0f89b3c62b7d10b5dc7d32\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
+ sed --version
++ which sed
+ /usr/bin/sed -i -e 's/win64.zip) | \[.*\]/win64.zip) | \[61450c27902e36e382010b54af01a9e70b5351cabc0f89b3c62b7d10b5dc7d32\]/g' /home/pat/github/fluent/fluent-bit-docs/installation/windows.md
```

Hash values taken from release output: https://github.com/fluent/fluent-bit/actions/runs/5089402492/jobs/9147043751#step:5:7
Also manually added 2.1.3 versions to containers.