### PR TITLE
about: license: fixed grammar in initial line

### DIFF
--- a/about/license.md
+++ b/about/license.md
@@ -4,7 +4,7 @@ description: Strong Commitment to the Openness and Collaboration
 
 # License
 
-[Fluent Bit](http://fluentbit.io), including it core, plugins and tools are distributed under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0):
+[Fluent Bit](http://fluentbit.io), including its core, plugins and tools are distributed under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0):
 
 ```text
                                  Apache License


### PR DESCRIPTION
Fixed grammar in the initial line of "license.md" file.