### PR TITLE
Fixing Docker tag descriptions are backwards in docker.md

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -17,12 +17,12 @@ The following table describes the Linux container tags that are available on Doc
 
 | Tag(s)       | Manifest Architectures    | Description                                                    |
 | ------------ | ------------------------- | -------------------------------------------------------------- |
-| 2.1.4 | x86_64, arm64v8, arm32v7 | Debug images |
-| 2.1.4-debug | x86_64, arm64v8, arm32v7 | Release [v2.1.4](https://fluentbit.io/announcements/v2.1.4/) |
-| 2.1.3 | x86_64, arm64v8, arm32v7 | Debug images |
-| 2.1.3-debug | x86_64, arm64v8, arm32v7 | Release [v2.1.3](https://fluentbit.io/announcements/v2.1.3/) |
-| 2.1.2 | x86_64, arm64v8, arm32v7 | Debug images |
-| 2.1.2-debug | x86_64, arm64v8, arm32v7 | Release [v2.1.2](https://fluentbit.io/announcements/v2.1.2/) |
+| 2.1.4 | x86_64, arm64v8, arm32v7 |  Release [v2.1.4](https://fluentbit.io/announcements/v2.1.4/) |
+| 2.1.4-debug | x86_64, arm64v8, arm32v7 | v2.1.x releases (production + debug)    |
+| 2.1.3 | x86_64, arm64v8, arm32v7 | Release [v2.1.3](https://fluentbit.io/announcements/v2.1.3/) |
+| 2.1.3-debug | x86_64, arm64v8, arm32v7 | v2.1.x releases (production + debug)    |
+| 2.1.2 | x86_64, arm64v8, arm32v7 |  Release [v2.1.2](https://fluentbit.io/announcements/v2.1.2/) |
+| 2.1.2-debug | x86_64, arm64v8, arm32v7 | v2.1.x releases (production + debug)    |
 | 2.1.1        | x86\_64, arm64v8, arm32v7 | Release [v2.1.1](https://fluentbit.io/announcements/v2.1.1/)   |
 | 2.1.1-debug  | x86\_64, arm64v8, arm32v7 | v2.1.x releases (production + debug)                           |
 | 2.1.0        | x86\_64, arm64v8, arm32v7 | Release [v2.1.0](https://fluentbit.io/announcements/v2.1.0/)   |


### PR DESCRIPTION
Fix for [!1330](https://github.com/fluent/fluent-bit-docs/issues/1130)

> Here, the table rows for production and debug image tags have descriptions which are reversed:
> 
> https://github.com/fluent/fluent-bit-docs/blob/master/installation/docker.md
> 
> i.e.:
> 
> Tag(s)	Manifest Architectures	Description
> 2.1.4	x86_64, arm64v8, arm32v7	Debug images
> 2.1.4-debug	x86_64, arm64v8, arm32v7	Release v2.1.4
>  