### PR TITLE
add additional libs required to build flb-wamrc

### DIFF
--- a/development/wasm-filter-plugins.md
+++ b/development/wasm-filter-plugins.md
@@ -15,10 +15,10 @@ There are no additional requirements to execute WASM plugins.
 
 `flb-wamrc` is just `flb-` prefixed AOT (Ahead Of Time) compiler that is provided from [wasm-micro-runtime](https://github.com/bytecodealliance/wasm-micro-runtime).
 
-For `flb-wamrc` support, users have to install llvm infrastructure, e.g:
+For `flb-wamrc` support, users have to install llvm infrastructure and some additional libraries (`libmlir`, `libPolly`, `libedit`, and `libpfm`), e.g:
 
 ```text
-# apt install -y llvm
+# apt install -y llvm libmlir-14-dev libclang-common-14-dev libedit-dev libpfm4-dev
 ```
 
 ### For Build WASM programs


### PR DESCRIPTION
This adds missing libraries required to build `flb-wamrc` when using the `-DFLB-WARMC=On` to build `fluent-bit`.

Namely `libmlir`, `libPolly`, `libedit`, and `libpfm`

See https://github.com/fluent/fluent-bit/issues/7580 for more details