### PR TITLE
update CMake version requirement

### DIFF
--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-- CMake >= 3.0
+- CMake >= 3.12
 - Flex
 - Bison
 - YAML headers


### PR DESCRIPTION
The minimum CMake version actually required to build Fluent Bit is 3.12. Looks like this was missed whenever that requirement changed.