### PR TITLE
Bump minimum bison version to 3

### DIFF
--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -6,7 +6,7 @@
 
 - CMake >= 3.12
 - Flex
-- Bison
+- Bison >= 3
 - YAML headers
 - OpenSSL headers
 


### PR DESCRIPTION
This (and PR #1164) bit me when trying to build on SLES12.5 which has bison 2.7-6 by default