### PR TITLE
pipeline: outputs: kafka-rest-proxy: document Url_Path parameter

### DIFF
--- a/pipeline/outputs/kafka-rest-proxy.md
+++ b/pipeline/outputs/kafka-rest-proxy.md
@@ -15,6 +15,7 @@ The **kafka-rest** output plugin, allows to flush your records into a [Kafka RES
 | Time\_Key\_Format | Defines the format of the timestamp. | %Y-%m-%dT%H:%M:%S |
 | Include\_Tag\_Key | Append the Tag name to the final record. | Off |
 | Tag\_Key | If Include\_Tag\_Key is enabled, this property defines the key name for the tag. | \_flb-key |
+| Url_Path | Add path prefix to the Kafka REST Proxy API endpoint (e.g.: {Host}:{Port}{Url_Path}/topics/{Topic}) \(optional\) |  |
 
 ### TLS / SSL
 


### PR DESCRIPTION
Documenting the currently undocumented `Url_Path` parameter for the kafka-rest-proxy output.

```
tmp = flb_output_get_property("url_path", ins);
if (tmp) {
    ctx->url_path = flb_strdup(tmp);
    snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/topics/%s", ctx->url_path, ctx->topic);
} else {
    ctx->url_path = NULL;
    snprintf(ctx->uri, sizeof(ctx->uri) - 1, "/topics/%s", ctx->topic);
}
```

https://github.com/fluent/fluent-bit/blob/2631ca199e731ac8ae8f3f3979d8a427a61e7b9b/plugins/out_kafka_rest/kafka_conf.c#L174C5-L174C5