### PR TITLE
pipeline: filters: lua: add enable_flb_null

### DIFF
--- a/pipeline/filters/lua.md
+++ b/pipeline/filters/lua.md
@@ -20,6 +20,7 @@ The plugin supports the following configuration parameters:
 | protected\_mode | If enabled, Lua script will be executed in protected mode. It prevents Fluent Bit from crashing when invalid Lua script is executed or the triggered Lua function throws exceptions. Default is true. |
 | time\_as\_table | By default when the Lua script is invoked, the record timestamp is passed as a *floating number* which might lead to precision loss when it is converted back. If you desire timestamp precision, enabling this option will pass the timestamp as a Lua table with keys `sec` for seconds since epoch and `nsec` for nanoseconds. |
 | code | Inline LUA code instead of loading from a path via `script`. |
+| enable_flb_null| If enabled, null will be converted to flb_null in Lua. It is useful to prevent removing key/value since nil is a special value to remove key value from map in Lua. Default is false. |
 
 ## Getting Started <a id="getting_started"></a>
 


### PR DESCRIPTION
This is a doc PR for https://github.com/fluent/fluent-bit/pull/7906

|Value |Description|Default|
|--|--|--|
|`enable_flb_null`|If enabled, null will be converted to flb_null in Lua. It is useful to prevent removing key/value since nil is a special value to remove key value from map in Lua.|false|