### PR TITLE
release: update for 2.1.10 (2.1 backport)

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -17,6 +17,8 @@ The following table describes the Linux container tags that are available on Doc
 
 | Tag(s)       | Manifest Architectures    | Description                                                    |
 | ------------ | ------------------------- | -------------------------------------------------------------- |
+| 2.1.10-debug | x86_64, arm64v8, arm32v7 | Debug images |
+| 2.1.10 | x86_64, arm64v8, arm32v7 | Release [v2.1.10](https://fluentbit.io/announcements/v2.1.10/) |
 | 2.1.9-debug | x86_64, arm64v8, arm32v7 | Debug images |
 | 2.1.9 | x86_64, arm64v8, arm32v7 | Release [v2.1.9](https://fluentbit.io/announcements/v2.1.9/) |
 | 2.1.8-debug | x86_64, arm64v8, arm32v7 | Debug images |

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -79,19 +79,19 @@ From version 1.9, `td-agent-bit` is a deprecated package and was removed after 1
 
 ## Installation Packages
 
-The latest stable version is 2.1.4. Each version is available on the Github release as well as at:
+The latest stable version is 2.1.10. Each version is available on the Github release as well as at:
 
 | INSTALLERS                                                                                       | SHA256 CHECKSUMS                                                 |
 | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [fluent-bit-2.1.9-win32.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win32.exe) | [c3c98449a8676d5f3f53ef09647fb71cf7eb63ae8f73260b2ab7394c6a419586](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win32.exe.sha256) |
-| [fluent-bit-2.1.9-win32.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win32.zip) | [1622ed416d1ffca3d3c1721a332fff9e80b8b700db47930d540ca640ecd18f8e](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win32.zip.sha256) |
-| [fluent-bit-2.1.9-win64.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win64.exe) | [30556168954917cd40fa110da88f10bccc59aea7bc1018078522ac0eea90b1b8](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win64.exe.sha256) |
-| [fluent-bit-2.1.9-win64.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win64.zip) | [291660a844d61d225055bfe1da8f10d95a27aa2f6d662db55744d47a716e85ff](https://releases.fluentbit.io/2.1/fluent-bit-2.1.9-win64.zip.sha256) |
+| [fluent-bit-2.1.10-win32.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win32.exe) | [07dd748929b205f6f42120ee2bd3f4393b86f52639ca3285adbb5182721819e3](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win32.exe.sha256) |
+| [fluent-bit-2.1.10-win32.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win32.zip) | [228aaca403f9b43a6720cb6bda1276b276e7f9d8d89d12887690c28cdc566ed7](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win32.zip.sha256) |
+| [fluent-bit-2.1.10-win64.exe](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win64.exe) | [11ec21f39ebc4f940352b96f13cee933d1537f77a0b86beee51f55a8c8712888](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win64.exe.sha256) |
+| [fluent-bit-2.1.10-win64.zip](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win64.zip) | [52e0e313061ffd0de6bc2ae2ada3c48717c45c90b671636e2e0624aebc7120af](https://releases.fluentbit.io/2.1/fluent-bit-2.1.10-win64.zip.sha256) |
 
 To check the integrity, use `Get-FileHash` cmdlet on PowerShell.
 
 ```powershell
-PS> Get-FileHash fluent-bit-2.1.9-win32.exe
+PS> Get-FileHash fluent-bit-2.1.10-win32.exe
 ```
 
 ## Installing from ZIP archive
@@ -101,7 +101,7 @@ Download a ZIP archive from above. There are installers for 32-bit and 64-bit en
 Then you need to expand the ZIP archive. You can do this by clicking "Extract All" on Explorer, or if you're using PowerShell, you can use `Expand-Archive` cmdlet.
 
 ```powershell
-PS> Expand-Archive fluent-bit-2.1.9-win64.zip
+PS> Expand-Archive fluent-bit-2.1.10-win64.zip
 ```
 
 The ZIP package contains the following set of files.


### PR DESCRIPTION
Backport of https://github.com/fluent/fluent-bit-docs/pull/1210/