### PR TITLE
hot-reload: add config file option (2.1 backport)

### DIFF
--- a/administration/hot-reload.md
+++ b/administration/hot-reload.md
@@ -4,19 +4,19 @@ description: Enable hot reload through SIGHUP signal or an HTTP endpoint
 
 # Hot Reload
 
-Fluent Bit supports the hot reloading feature when enabled via the command line with `-Y` or `--enable-hot-reload` option.
+Fluent Bit supports the hot reloading feature when enabled via the configuration file or command line with `-Y` or `--enable-hot-reload` option.
 
 ## Getting Started
 
 To get started with reloading via HTTP, the first step is to enable the HTTP Server from the configuration file:
 
-```
+```toml
 [SERVICE]
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
     HTTP_PORT    2020
-
-# Other stuff of plugin configurations
+    Hot_Reload   On
+...
 ```
 
 The above configuration snippet will enable the HTTP endpoint for hot reloading.
@@ -32,11 +32,10 @@ Hot reloading can be kicked via HTTP endpoints that are:
 
 If users don't enable the hot reloading feature, hot reloading via these endpoints will not work.
 
-For using curl to reload fluent-bit, users must specify an empty request body as:
+For using curl to reload Fluent Bit, users must specify an empty request body as:
 
-
-```text
-$ curl -X POST -d {} localhost:2020/api/v2/reload
+```shell
+curl -X POST -d '{}' localhost:2020/api/v2/reload
 ```
 
 ### Via Signal
@@ -48,4 +47,3 @@ Hot reloading also can be kicked via `SIGHUP`.
 ## Limitations
 
 The hot reloading feature is currently working on Linux and macOS. Windows is not supported yet.
-


### PR DESCRIPTION
Hot reload updates to support config file option - backport of #1226 