### PR TITLE
This commit add supports for TLS/SSL to the below inputs plugin

### DIFF
--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -50,6 +50,8 @@ The following **input** plugins can take advantage of the TLS feature:
 * [TCP](../pipeline/inputs/tcp.md)
 * [HTTP](../pipeline/inputs/http.md)
 * [OpenTelemetry](../pipeline/inputs/opentelemetry.md)
+* [Forward](../pipeline/inputs/forward.md)
+* [Syslog](../pipeline/inputs/syslog.md)
 
 In addition, other plugins implements a sub-set of TLS support, meaning, with restricted configuration:
 

--- a/pipeline/inputs/forward.md
+++ b/pipeline/inputs/forward.md
@@ -18,6 +18,10 @@ The plugin supports the following configuration parameters:
 | Tag_Prefix          | Prefix incoming tag with the defined value.|  |
 | Tag                 | Override the tag of the forwarded events with the defined value.|  |
 
+### TLS / SSL
+
+Forward input plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [Transport Security](../../administration/transport-security.md) section.
+
 ## Getting Started
 
 In order to receive Forward messages, you can run the plugin from the command line or through the configuration file as shown in the following examples.

--- a/pipeline/inputs/syslog.md
+++ b/pipeline/inputs/syslog.md
@@ -1,6 +1,6 @@
 # Syslog
 
-_Syslog_ input plugins allows to collect Syslog messages through a Unix socket server \(UDP or TCP\) or over the network using TCP or UDP.
+_Syslog_ input plugins allows to collect Syslog messages through a Unix socket server \(UDP or TCP\) or over the network using TCP, UDP.
 
 ## Configuration Parameters
 
@@ -23,6 +23,10 @@ The plugin supports the following configuration parameters:
 
 * When using Syslog input plugin, Fluent Bit requires access to the _parsers.conf_ file, the path to this file can be specified with the option _-R_ or through the _Parsers\_File_ key on the \[SERVICE\] section \(more details below\).
 * When _udp_ or _unix\_udp_ is used, the buffer size to receive messages is configurable **only** through the _Buffer\_Chunk\_Size_ option which defaults to 32kb.
+
+### TLS / SSL
+
+Syslog input plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the [Transport Security](../../administration/transport-security.md) section.
 
 ## Getting Started
 


### PR DESCRIPTION
Input Plugins:
          pipeline:inputs:forward.md
          pipeline:inputs:syslog.md
And updates the list of supported plugins for TLS/SSL
          administration:transport-security.md
Signed-off-by: RicardoAAD <ricardo@calyptia.com>