### PR TITLE
Update hands-on.md to add missing -p read_from_head=true

### DIFF
--- a/stream-processing/getting-started/hands-on.md
+++ b/stream-processing/getting-started/hands-on.md
@@ -72,7 +72,7 @@ $ docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log           \
          -i tail                                                         \
              -p path=/sp-samples-1k.log                                  \
              -p parser=json                                              \
-             -p read_from_head=true                                      \ 
+             -p read_from_head=true                                      \
          -T "SELECT word, num FROM STREAM:tail.0 WHERE country='Chile';" \
          -o null -f 1
 ```
@@ -99,6 +99,7 @@ $ docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log           \
          -i tail                                                         \
              -p path=/sp-samples-1k.log                                  \
              -p parser=json                                              \
+             -p read_from_head=true                                      \
          -T "SELECT AVG(num) FROM STREAM:tail.0 WHERE country='Chile';"  \
          -o null -f 1
 ```
@@ -127,6 +128,7 @@ $ docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log      \
          -i tail                                                    \
              -p path=/sp-samples-1k.log                             \
              -p parser=json                                         \
+             -p read_from_head=true                                 \
          -T "SELECT country, AVG(num) FROM STREAM:tail.0            \
              WINDOW TUMBLING (1 SECOND)                             \
              WHERE country='Chile'                                  \


### PR DESCRIPTION

The current [Hands On! 101](https://docs.fluentbit.io/manual/stream-processing/getting-started/hands-on) is missing the `-p read_from_head=true=` on the "4. Calculate Average Value" example. 

If you run the current example you get
```
[2023/11/24 10:40:10] [ info] [sp] registered task: flb-console:0
[2023/11/24 10:40:10] [ info] [input:tail:tail.0] inotify_fs_add(): inode=5 watch_fd=1 name=/sp-samples-1k.log
```
and not more output. There is no `{"AVG(num)"=>61.230770}`. in the output. 

By adding the `-p read_from_head=true` I get the expected output 

```
[2023/11/24 10:42:02] [ info] [sp] registered task: flb-console:0
[0] [1700822522.779461868, {"AVG(num)"=>61.230770}]
[0] [1700822522.780739544, {"AVG(num)"=>47.842106}]
[0] [1700822522.781954929, {"AVG(num)"=>40.647060}]
[0] [1700822522.783120630, {"AVG(num)"=>56.812500}]
[0] [1700822522.783183144, {"AVG(num)"=>99.000000}]
[2023/11/24 10:42:02] [ info] [input:tail:tail.0] inotify_fs_add(): inode=5 watch_fd=1 name=/sp-samples-1k.log
```
