### PR TITLE
 "pipeline: outputs: influxdb: updated influxdb and elasticsearch redirection link"

### DIFF
--- a/administration/memory-management.md
+++ b/administration/memory-management.md
@@ -8,7 +8,7 @@ In order to that we will assume that the input plugins have set the **Mem\_Buf\_
 
 Input plugins append data independently, so in order to do an estimation, a limit should be imposed through the **Mem\_Buf\_Limit** option. If the limit was set to _10MB_ we need to estimate that in the worse case, the output plugin likely could use _20MB_.
 
-Fluent Bit has an internal binary representation for the data being processed, but when this data reaches an output plugin, it will likely create its own representation in a new memory buffer for processing. The best examples are the [InfluxDB](https://github.com/fluent/fluent-bit-docs/tree/b78cfe98123e74e165f2b6669229da009258f34e/output/influxdb.md) and [Elasticsearch](https://github.com/fluent/fluent-bit-docs/tree/b78cfe98123e74e165f2b6669229da009258f34e/output/elasticsearch.md) output plugins, both need to convert the binary representation to their respective custom JSON formats before it can be sent to the backend servers.
+Fluent Bit has an internal binary representation for the data being processed, but when this data reaches an output plugin, it will likely create its own representation in a new memory buffer for processing. The best examples are the [InfluxDB](https://github.com/fluent/fluent-bit-docs/blob/master/pipeline/outputs/influxdb.md) and [Elasticsearch](https://github.com/fluent/fluent-bit-docs/blob/master/pipeline/outputs/elasticsearch.md) output plugins, both need to convert the binary representation to their respective custom JSON formats before it can be sent to the backend servers.
 
 So, if we impose a limit of _10MB_ for the input plugins and consider the worse case scenario of the output plugin consuming _20MB_ extra, as a minimum we need \(_30MB_ x 1.2\) = **36MB**.
 

--- a/administration/memory-management.md
+++ b/administration/memory-management.md
@@ -8,7 +8,8 @@ In order to that we will assume that the input plugins have set the **Mem\_Buf\_
 
 Input plugins append data independently, so in order to do an estimation, a limit should be imposed through the **Mem\_Buf\_Limit** option. If the limit was set to _10MB_ we need to estimate that in the worse case, the output plugin likely could use _20MB_.
 
-Fluent Bit has an internal binary representation for the data being processed, but when this data reaches an output plugin, it will likely create its own representation in a new memory buffer for processing. The best examples are the [InfluxDB](https://github.com/fluent/fluent-bit-docs/blob/master/pipeline/outputs/influxdb.md) and [Elasticsearch](https://github.com/fluent/fluent-bit-docs/blob/master/pipeline/outputs/elasticsearch.md) output plugins, both need to convert the binary representation to their respective custom JSON formats before it can be sent to the backend servers.
+Fluent Bit has an internal binary representation for the data being processed, but when this data reaches an output plugin, it will likely create its own representation in a new memory buffer for processing. 
+The best examples are the [InfluxDB](../pipeline/outputs/influxdb.md) and [Elasticsearch](../pipeline/outputs/elasticsearch.md) output plugins, both need to convert the binary representation to their respective custom JSON formats before it can be sent to the backend servers.
 
 So, if we impose a limit of _10MB_ for the input plugins and consider the worse case scenario of the output plugin consuming _20MB_ extra, as a minimum we need \(_30MB_ x 1.2\) = **36MB**.
 


### PR DESCRIPTION
"https://docs.fluentbit.io/manual/administration/memory-management"

IN the above link, when clicked on the _influxdb_ and _elasticsearch_ link, **Error 404** was shown.

![image](https://github.com/fluent/fluent-bit-docs/assets/88871793/96ac2c73-74bf-457d-8865-239a5dc1c076)
