### PR TITLE
scripts: fix check for container version

### DIFF
--- a/update-release-version-docs.sh
+++ b/update-release-version-docs.sh
@@ -29,7 +29,7 @@ if [[ -z "$MAJOR_VERSION" ]]; then
 fi
 
 # Add Docker after first line in the table
-if grep -q "$NEW_VERSION" "$SCRIPT_DIR"/installation/docker.md; then
+if grep -Fq "$NEW_VERSION" "$SCRIPT_DIR"/installation/docker.md; then
     echo "Found $NEW_VERSION already in the Docker docs so skipping update"
 else
     sed_wrapper -i -e "/| -.*$/a | $NEW_VERSION | x86\_64, arm64v8, arm32v7, s390x | Release [v$NEW_VERSION](https://fluentbit.io/announcements/v$NEW_VERSION/) |" "$SCRIPT_DIR"/installation/docker.md


### PR DESCRIPTION
The 2.2.0 release of Fluent Bit failed to update the container image version: #1252 

https://github.com/fluent/fluent-bit/actions/runs/6810802273/job/18519927519#step:6:22
```shell
+ MAJOR_VERSION=2.2
+ grep -q 2.2.0 /home/runner/work/fluent-bit/fluent-bit/installation/docker.md
+ echo 'Found 2.2.0 already in the Docker docs so skipping update'
Found 2.2.0 already in the Docker docs so skipping update
```

This was resolved in #1268.

The reason for the failure is `grep` using the value passed as a regex rather than a fixed literal string:

```shell
$ grep -F "2.2.0" installation/docker.md
| 2.2.0-debug | x86_64, arm64v8, arm32v7 | Debug images |
| 2.2.0 | x86_64, arm64v8, arm32v7 | Release [v2.2.0](https://fluentbit.io/announcements/v2.2.0/) |
$ grep "2.2.0" installation/docker.md
| 2.2.0-debug | x86_64, arm64v8, arm32v7 | Debug images |
| 2.2.0 | x86_64, arm64v8, arm32v7 | Release [v2.2.0](https://fluentbit.io/announcements/v2.2.0/) |
[{"critical":{"identity":{"docker-reference":"index.docker.io/fluent/fluent-bit"},"image":{"docker-manifest-digest":"sha256:c740f90b07f42823d4ecf4d5e168f32ffb4b8bcd87bc41df8f5e3d14e8272903"},"type":"cosign container image signature"},"optional":{"release":"2.0.6","repo":"fluent/fluent-bit","workflow":"Release from staging"}}]
```

Notice in the second one we match the string `27290` as this is the `2.2.0` regex.