### PR TITLE
windows: update to use new Github builds

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -79,17 +79,17 @@ From version 1.9, `td-agent-bit` is a deprecated package and was removed after 1
 
 ## Installation Packages
 
-The latest stable version is 2.1.4.
+The latest stable version is 2.2.0.
 Each version is available via the following download URLs.
 
 | INSTALLERS                                                                                       | SHA256 CHECKSUMS                                                 |
 | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [fluent-bit-2.2.0-win32.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.exe.sha256) |
-| [fluent-bit-2.2.0-win32.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip.sha256) |
-| [fluent-bit-2.2.0-win64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe.sha256) |
-| [fluent-bit-2.2.0-win64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip.sha256) |
-| [fluent-bit-2.2.0-winarm64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.exe.sha256) |
-| [fluent-bit-2.2.0-winarm64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.zip.sha256) |
+| [fluent-bit-2.2.0-win32.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.exe) | [9ba2a84ce66bd899131896b04d37c4b5cb6fe5995f1a756f3a349457e4aff438](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.exe.sha256) |
+| [fluent-bit-2.2.0-win32.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip) | [9d176e3e490f383f5bc5a1c84cd200ee57978f24659bb356e5a6958653c1ec9d](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip.sha256) |
+| [fluent-bit-2.2.0-win64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe) | [f2e46027320e656daff4758690e6d0a2a55b66b48728d1c16cf85988b5260364](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe.sha256) |
+| [fluent-bit-2.2.0-win64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip) | [45baf22505c29d79b14b14471ddd1c2272016781622441037114cb08ee2d0921](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip.sha256) |
+| [fluent-bit-2.2.0-winarm64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.exe) | [6a80f2677224a8cac6400c1e75952dc22b0bccd6e84ac611974daec127ae1b08](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.exe.sha256) |
+| [fluent-bit-2.2.0-winarm64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.zip) | [43470ae91782c706062b62758f1da735d17b227ac8f6cfda5503e3a1a73b14ac](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.zip.sha256) |
 
 **Note these are now using the Github Actions built versions, the legacy AppVeyor builds are still available (AMD 32/64 only) at releases.fluentbit.io but are deprecated.**
 

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -88,8 +88,16 @@ Each version is available via the following download URLs.
 | [fluent-bit-2.2.0-win32.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip.sha256) |
 | [fluent-bit-2.2.0-win64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe.sha256) |
 | [fluent-bit-2.2.0-win64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip.sha256) |
+| [fluent-bit-2.2.0-winarm64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.exe.sha256) |
+| [fluent-bit-2.2.0-winarm64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.zip.sha256) |
 
-**Note these are now using the Github Actions built versions at packages.fluentbit.io, the legacy AppVeyor builds are still available at releases.fluentbit.io for now but are deprecated.**
+**Note these are now using the Github Actions built versions, the legacy AppVeyor builds are still available (AMD 32/64 only) at releases.fluentbit.io but are deprecated.**
+
+MSI installers are also available:
+
+- [fluent-bit-2.2.0-win32.msi](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.msi)
+- [fluent-bit-2.2.0-win64.msi](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.msi)
+- [fluent-bit-2.2.0-winarm64.msi](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-winarm64.msi)
 
 To check the integrity, use `Get-FileHash` cmdlet on PowerShell.
 

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -79,14 +79,17 @@ From version 1.9, `td-agent-bit` is a deprecated package and was removed after 1
 
 ## Installation Packages
 
-The latest stable version is 2.1.4. Each version is available on the Github release as well as at:
+The latest stable version is 2.1.4.
+Each version is available via the following download URLs.
 
 | INSTALLERS                                                                                       | SHA256 CHECKSUMS                                                 |
 | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [fluent-bit-2.2.0-win32.exe](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win32.exe) | [1aa1c9e853856cdb44d4336c8dc0e28da6c4688543662196628170a11364875f](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win32.exe.sha256) |
-| [fluent-bit-2.2.0-win32.zip](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win32.zip) | [7e496a63cd710040dc36c1ba11e60a9a46b384fdd455c82fbab7143ccd06b725](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win32.zip.sha256) |
-| [fluent-bit-2.2.0-win64.exe](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win64.exe) | [1cea437d0ee93eb6b6ea4410ba0bef8c196711ef1a09687760bfd96aa63183ff](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win64.exe.sha256) |
-| [fluent-bit-2.2.0-win64.zip](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win64.zip) | [723d7e138d19055476dc361e86e2fd57de5d2490837cde707f512a707b27ad40](https://releases.fluentbit.io/2.2/fluent-bit-2.2.0-win64.zip.sha256) |
+| [fluent-bit-2.2.0-win32.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.exe.sha256) |
+| [fluent-bit-2.2.0-win32.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win32.zip.sha256) |
+| [fluent-bit-2.2.0-win64.exe](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.exe.sha256) |
+| [fluent-bit-2.2.0-win64.zip](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip) | [xx](https://packages.fluentbit.io/windows/fluent-bit-2.2.0-win64.zip.sha256) |
+
+**Note these are now using the Github Actions built versions at packages.fluentbit.io, the legacy AppVeyor builds are still available at releases.fluentbit.io for now but are deprecated.**
 
 To check the integrity, use `Get-FileHash` cmdlet on PowerShell.
 

--- a/update-release-version-docs.sh
+++ b/update-release-version-docs.sh
@@ -40,8 +40,8 @@ WIN_32_EXE_HASH=${WIN_32_EXE_HASH:?}
 WIN_32_ZIP_HASH=${WIN_32_ZIP_HASH:?}
 WIN_64_EXE_HASH=${WIN_64_EXE_HASH:?}
 WIN_64_ZIP_HASH=${WIN_64_ZIP_HASH:?}
-WIN_64_ARM_EXE_HASH=${WIN_64_ARM_EXE_HASH:?}
-WIN_64_ARM_ZIP_HASH=${WIN_64_ARM_ZIP_HASH:?}
+WIN_64_ARM_EXE_HASH=${WIN_64_ARM_EXE_HASH:-}
+WIN_64_ARM_ZIP_HASH=${WIN_64_ARM_ZIP_HASH:-}
 
 sed_wrapper -i -e "s/The latest stable version is .*$/The latest stable version is $NEW_VERSION./g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/fluent-bit-[0-9\.]*-win/fluent-bit-$NEW_VERSION-win/g" "$SCRIPT_DIR"/installation/windows.md
@@ -50,5 +50,10 @@ sed_wrapper -i -e "s/win32.exe) | \[.*\]/win32.exe) | \[$WIN_32_EXE_HASH\]/g" "$
 sed_wrapper -i -e "s/win32.zip) | \[.*\]/win32.zip) | \[$WIN_32_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/win64.exe) | \[.*\]/win64.exe) | \[$WIN_64_EXE_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/win64.zip) | \[.*\]/win64.zip) | \[$WIN_64_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
-sed_wrapper -i -e "s/winarm64.exe) | \[.*\]/winarm64.exe) | \[$WIN_64_ARM_EXE_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
-sed_wrapper -i -e "s/winarm64.zip) | \[.*\]/winarm64.zip) | \[$WIN_64_ARM_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
+if [[ -n "$WIN_64_ARM_EXE_HASH" ]]; then
+  sed_wrapper -i -e "s/winarm64.exe) | \[.*\]/winarm64.exe) | \[$WIN_64_ARM_EXE_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
+fi
+
+if [[ -n "$WIN_64_ARM_ZIP_HASH" ]]; then
+  sed_wrapper -i -e "s/winarm64.zip) | \[.*\]/winarm64.zip) | \[$WIN_64_ARM_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
+fi

--- a/update-release-version-docs.sh
+++ b/update-release-version-docs.sh
@@ -41,10 +41,8 @@ WIN_32_ZIP_HASH=${WIN_32_ZIP_HASH:?}
 WIN_64_EXE_HASH=${WIN_64_EXE_HASH:?}
 WIN_64_ZIP_HASH=${WIN_64_ZIP_HASH:?}
 
-sed_wrapper -i -e "s/The latest stable version is .*,/The latest stable version is $NEW_VERSION/g" "$SCRIPT_DIR"/installation/windows.md
+sed_wrapper -i -e "s/The latest stable version is .*$/The latest stable version is $NEW_VERSION./g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/fluent-bit-[0-9\.]*-win/fluent-bit-$NEW_VERSION-win/g" "$SCRIPT_DIR"/installation/windows.md
-
-sed_wrapper -i -e "s|releases.fluentbit.io/[0-9\.]*/|releases.fluentbit.io/$MAJOR_VERSION/|g" "$SCRIPT_DIR"/installation/windows.md
 
 sed_wrapper -i -e "s/win32.exe) | \[.*\]/win32.exe) | \[$WIN_32_EXE_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/win32.zip) | \[.*\]/win32.zip) | \[$WIN_32_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md

--- a/update-release-version-docs.sh
+++ b/update-release-version-docs.sh
@@ -40,6 +40,8 @@ WIN_32_EXE_HASH=${WIN_32_EXE_HASH:?}
 WIN_32_ZIP_HASH=${WIN_32_ZIP_HASH:?}
 WIN_64_EXE_HASH=${WIN_64_EXE_HASH:?}
 WIN_64_ZIP_HASH=${WIN_64_ZIP_HASH:?}
+WIN_64_ARM_EXE_HASH=${WIN_64_ARM_EXE_HASH:?}
+WIN_64_ARM_ZIP_HASH=${WIN_64_ARM_ZIP_HASH:?}
 
 sed_wrapper -i -e "s/The latest stable version is .*$/The latest stable version is $NEW_VERSION./g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/fluent-bit-[0-9\.]*-win/fluent-bit-$NEW_VERSION-win/g" "$SCRIPT_DIR"/installation/windows.md
@@ -48,3 +50,5 @@ sed_wrapper -i -e "s/win32.exe) | \[.*\]/win32.exe) | \[$WIN_32_EXE_HASH\]/g" "$
 sed_wrapper -i -e "s/win32.zip) | \[.*\]/win32.zip) | \[$WIN_32_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/win64.exe) | \[.*\]/win64.exe) | \[$WIN_64_EXE_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
 sed_wrapper -i -e "s/win64.zip) | \[.*\]/win64.zip) | \[$WIN_64_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
+sed_wrapper -i -e "s/winarm64.exe) | \[.*\]/winarm64.exe) | \[$WIN_64_ARM_EXE_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md
+sed_wrapper -i -e "s/winarm64.zip) | \[.*\]/winarm64.zip) | \[$WIN_64_ARM_ZIP_HASH\]/g" "$SCRIPT_DIR"/installation/windows.md


### PR DESCRIPTION
Resolves https://github.com/fluent/fluent-bit/issues/6937 by updating to specify the packages.fluentbit.io versions built from Github directly. These include YAML support and other improvements, the legacy AppVeyor builds are available still at releases.fluentbit.io but are deprecated.

Updated version script as well to include ARM hashes and MSI packages.
Also fixes an issue with not replacing the old version.

This needs a CI update on the Fluent Bit release process to provide the correct hashes (and for ARM too) - currently it provides the AppVeyor ones: https://github.com/fluent/fluent-bit/blob/323f343996e877c7f122d2c4e075c00c4aac7377/.github/workflows/staging-release.yaml#L882-L892