### PR TITLE
Update stackdriver.md with warning about Workers option

### DIFF
--- a/pipeline/outputs/stackdriver.md
+++ b/pipeline/outputs/stackdriver.md
@@ -184,7 +184,17 @@ Do following check:
 * If the log entry does not contain the local_resource_id field, does the tag of the log match for format?
 *   If tag_prefix is configured, does the prefix of tag specified in the input plugin match the tag_prefix?
 
-    **Other implementations**
+### caught signal (SIGSEGV)
+
+> Github reference: [#7552](https://github.com/fluent/fluent-bit/issues/7552)
+
+When the number of Workers is greater than 1, fluent-bit may interimittently crash.
+
+```
+[2023/06/07 08:15:30] [engine] caught signal (SIGSEGV)
+```
+
+## Other implementations
 
 Stackdriver officially supports a [logging agent based on Fluentd](https://cloud.google.com/logging/docs/agent).
 

--- a/pipeline/outputs/stackdriver.md
+++ b/pipeline/outputs/stackdriver.md
@@ -184,7 +184,7 @@ Do following check:
 * If the log entry does not contain the local_resource_id field, does the tag of the log match for format?
 *   If tag_prefix is configured, does the prefix of tag specified in the input plugin match the tag_prefix?
 
-### caught signal (SIGSEGV)
+### Occasional Crashing with >1 `Workers`
 
 > Github reference: [#7552](https://github.com/fluent/fluent-bit/issues/7552)
 

--- a/pipeline/outputs/stackdriver.md
+++ b/pipeline/outputs/stackdriver.md
@@ -188,7 +188,7 @@ Do following check:
 
 > Github reference: [#7552](https://github.com/fluent/fluent-bit/issues/7552)
 
-When the number of Workers is greater than 1, fluent-bit may interimittently crash.
+When the number of Workers is greater than 1, Fluent Bit may interimittently crash.
 
 ```
 [2023/06/07 08:15:30] [engine] caught signal (SIGSEGV)

--- a/pipeline/outputs/stackdriver.md
+++ b/pipeline/outputs/stackdriver.md
@@ -190,10 +190,6 @@ Do following check:
 
 When the number of Workers is greater than 1, Fluent Bit may interimittently crash.
 
-```
-[2023/06/07 08:15:30] [engine] caught signal (SIGSEGV)
-```
-
 ## Other implementations
 
 Stackdriver officially supports a [logging agent based on Fluentd](https://cloud.google.com/logging/docs/agent).


### PR DESCRIPTION
Adding this info about this issue because I lost a bunch of time trying to chase down intermittent restarts of my fluent-bit pods (v.2.2.0). 

Even if it defaults to 1 in newer versions, someone may override it, as was my case. 

Until the underlying issue is fixed, I think it's helpful to warn others about this.