### PR TITLE
Added documentation for uri parameter to outputs/loki

### DIFF
--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -13,6 +13,7 @@ Be aware there is a separate Golang output plugin provided by [Grafana](https://
 | Key | Description | Default |
 | :--- | :--- | :--- |
 | host | Loki hostname or IP address. Do not include the subpath, i.e. `loki/api/v1/push`, but just the base hostname/URL.  | 127.0.0.1 |
+| uri | Specify a custom HTTP URI. It must start with forward slash.| /loki/api/v1/push |
 | port | Loki TCP port | 3100 |
 | http\_user | Set HTTP basic authentication user name |  |
 | http\_passwd | Set HTTP basic authentication password |  |

--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -15,6 +15,7 @@ Be aware there is a separate Golang output plugin provided by [Grafana](https://
 | host | Loki hostname or IP address. Do not include the subpath, i.e. `loki/api/v1/push`, but just the base hostname/URL.  | 127.0.0.1 |
 | uri | Specify a custom HTTP URI. It must start with forward slash.| /loki/api/v1/push |
 | port | Loki TCP port | 3100 |
+| tls | Use TLS authentication | off |
 | http\_user | Set HTTP basic authentication user name |  |
 | http\_passwd | Set HTTP basic authentication password |  |
 | bearer\_token | Set bearer token authentication token value. |  |


### PR DESCRIPTION
I opened https://github.com/fluent/fluent-bit/issues/8348 thinking that there was no option to set uri/path for the loki output plugin, but when checking how to implement it I found out it already exists

https://github.com/fluent/fluent-bit/blob/cd497e38dc8e4e958756b449aab34801da486ad2/plugins/out_loki/loki.c#L1741-L1748