### PR TITLE
filter_type_converter: add examples for yaml configuration

### DIFF
--- a/pipeline/filters/type-converter.md
+++ b/pipeline/filters/type-converter.md
@@ -37,6 +37,8 @@ The plugin outputs uint values and filter_type_converter converts them into stri
 
 ### Convert uint to string
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```python
 [INPUT]
     Name mem
@@ -52,6 +54,26 @@ The plugin outputs uint values and filter_type_converter converts them into stri
     Name stdout
     Match *
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+    inputs:
+        - name: mem
+    filters:
+        - name: type_converter
+          match: '*'
+          uint_key:
+            - Mem.total Mem.total_str string
+            - Mem.used  Mem.used_str  string
+            - Mem.free  Mem.free_str  string
+    outputs:
+        - name: stdout
+          match: '*'
+```
+{% endtab %}
+{% endtabs %}
 
 You can also run the filter from command line.
 


### PR DESCRIPTION
This patch is to add an example in yaml for filter_type_converter.