### PR TITLE
in_node_exporter_metrics: add examples for yaml configuration

### DIFF
--- a/pipeline/inputs/node-exporter-metrics.md
+++ b/pipeline/inputs/node-exporter-metrics.md
@@ -87,6 +87,8 @@ The following table describes the available collectors as part of this plugin. A
 
 In the following configuration file, the input plugin _node_exporter_metrics collects _metrics every 2 seconds and exposes them through our [Prometheus Exporter](../outputs/prometheus-exporter.md) output plugin on HTTP/TCP port 2021.
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```
 # Node Exporter Metrics + Prometheus Exporter
 # -------------------------------------------
@@ -114,6 +116,35 @@ In the following configuration file, the input plugin _node_exporter_metrics col
 
         
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+# Node Exporter Metrics + Prometheus Exporter
+# -------------------------------------------
+# The following example collect host metrics on Linux and expose
+# them through a Prometheus HTTP end-point.
+#
+# After starting the service try it with:
+#
+# $ curl http://127.0.0.1:2021/metrics
+#
+service:
+    flush: 1
+    log_level: info
+pipeline:
+    inputs:
+        - name: node_exporter_metrics
+          tag:  node_metrics
+          scrape_interval: 2
+    outputs:
+        - name: prometheus_exporter
+          match: node_metrics
+          host: 0.0.0.0
+          port: 2021
+```
+{% endtab %}
+{% endtabs %}
 
 You can test the expose of the metrics by using _curl:_
 


### PR DESCRIPTION
This patch is to add an example in yaml for in_node_exporter_metrics .