### PR TITLE
out_http: add examples for yaml configuration

### DIFF
--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -61,6 +61,8 @@ $ fluent-bit -i cpu -t cpu -o http://192.168.2.3:80/something -m '*'
 
 In your main configuration file, append the following _Input_ & _Output_ sections:
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```python
 [INPUT]
     Name  cpu
@@ -73,6 +75,23 @@ In your main configuration file, append the following _Input_ & _Output_ section
     Port  80
     URI   /something
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+    inputs:
+        - name: cpu
+          tag:  cpu
+    outputs:
+        - name: http
+          match: '*'
+          host: 192.168.2.3
+          port: 80
+          URI: /something
+```
+{% endtab %}
+{% endtabs %}
 
 By default, the URI becomes tag of the message, the original tag is ignored. To retain the tag, multiple configuration sections have to be made based and flush to different URIs.
 
@@ -80,6 +99,8 @@ Another approach we also support is the sending the original message tag in a co
 
 To configure this behaviour, add this config:
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```
 [OUTPUT]
     Name  http
@@ -90,6 +111,22 @@ To configure this behaviour, add this config:
     Format json
     header_tag  FLUENT-TAG
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+    outputs:
+        - name: http
+          match: '*'
+          host: 192.168.2.3
+          port: 80
+          URI: /something
+          format: json
+          header_tag: FLUENT-TAG
+```
+{% endtab %}
+{% endtabs %}
+
 
 Provided you are using Fluentd as data receiver, you can combine `in_http` and `out_rewrite_tag_filter` to make use of this HTTP header.
 
@@ -113,6 +150,8 @@ Notice how we override the tag, which is from URI path, with our custom header
 
 #### Example : Add a header
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```
 [OUTPUT]
     Name           http
@@ -123,11 +162,29 @@ Notice how we override the tag, which is from URI path, with our custom header
     Header         X-Key-B Value_B
     URI            /something
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+    outputs:
+        - name: http
+          match: '*'
+          host: 127.0.0.1
+          port: 9000
+          header:
+            - X-Key-A Value_A
+            - X-Key-B Value_B
+          URI: /something
+```
+{% endtab %}
+{% endtabs %}
 
 #### Example : Sumo Logic HTTP Collector
 
 Suggested configuration for Sumo Logic using `json_lines` with `iso8601` timestamps. The `PrivateKey` is specific to a configured HTTP collector.
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```
 [OUTPUT]
     Name             http
@@ -139,6 +196,22 @@ Suggested configuration for Sumo Logic using `json_lines` with `iso8601` timesta
     Json_date_key    timestamp
     Json_date_format iso8601
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+    outputs:
+        - name: http
+          match: '*'
+          host: collectors.au.sumologic.com
+          port: 443
+          URI: /receiver/v1/http/[PrivateKey]
+          format: json_lines
+          json_date_key: timestamp
+          json_date_format: iso8601
+```
+{% endtab %}
+{% endtabs %}
 
 A sample Sumo Logic query for the [CPU](../inputs/cpu-metrics.md) input. \(Requires `json_lines` format with `iso8601` date format for the `timestamp` field\).
 


### PR DESCRIPTION
This patch is to add an example in yaml for out_http.