### PR TITLE
filter_rewrite_tag: add examples for yaml configuration

### DIFF
--- a/pipeline/filters/rewrite-tag.md
+++ b/pipeline/filters/rewrite-tag.md
@@ -117,6 +117,8 @@ You can use `true` or `false` to decide the expected behavior. There is no defau
 
 The following configuration example will emit a dummy \(hand-crafted\) record, the filter will rewrite the tag, discard the old record and print the new record to the standard output interface:
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```python
 [SERVICE]
     Flush     1
@@ -137,6 +139,30 @@ The following configuration example will emit a dummy \(hand-crafted\) record, t
     Name   stdout
     Match  from.*
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+service:
+    flush: 1
+    log_level: info
+pipeline:
+    inputs:
+        - name: dummy
+          tag:  test_tag
+          dummy: '{"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}'
+    filters:
+        - name: rewrite_tag
+          match: test_tag
+          rule: $tool ^(fluent)$  from.$TAG.new.$tool.$sub['s1']['s2'].out false
+          emitter_name: re_emitted
+    outputs:
+        - name: stdout
+          match: from.*
+```
+{% endtab %}
+{% endtabs %}
+
 
 The original tag `test_tag` will be rewritten as `from.test_tag.new.fluent.bit.out`:
 


### PR DESCRIPTION
This patch is to add an example in yaml for filter_rewrite_tag.