### PR TITLE
in_docker: add examples for yaml configuration

### DIFF
--- a/pipeline/inputs/docker-metrics.md
+++ b/pipeline/inputs/docker-metrics.md
@@ -27,6 +27,8 @@ If you set neither `Include` nor `Exclude`, the plugin will try to get metrics f
 
 Here is an example configuration that collects metrics from two docker instances (`6bab19c3a0f9` and `14159be4ca2c`).
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```python
 [INPUT]
     Name         docker
@@ -35,6 +37,21 @@ Here is an example configuration that collects metrics from two docker instances
     Name   stdout
     Match  *
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+    inputs:
+        - name: docker
+          include: 6bab19c3a0f9 14159be4ca2c
+
+    outputs:
+        - name: stdout
+          match: '*'
+```
+{% endtab %}
+{% endtabs %}
 
 This configuration will produce records like below.
 


### PR DESCRIPTION
This patch is to add an example in yaml for in_docker.