### PR TITLE
in_elasticsearch: add examples for yaml configuration

### DIFF
--- a/pipeline/inputs/elasticsearch.md
+++ b/pipeline/inputs/elasticsearch.md
@@ -35,6 +35,8 @@ $ fluent-bit -i elasticsearch -p port=9200 -o stdout
 
 In your main configuration file append the following _Input_ & _Output_ sections:
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```python
 [INPUT]
     name elasticsearch
@@ -45,10 +47,28 @@ In your main configuration file append the following _Input_ & _Output_ sections
     name stdout
     match *
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+    inputs:
+        - name: elasticsearch
+          listen: 0.0.0.0
+          port: 9200
+
+    outputs:
+        - name: stdout
+          match: '*'
+```
+{% endtab %}
+{% endtabs %}
 
 As described above, the plugin will handle ingested Bulk API requests.
 For large bulk ingestions, you may have to increase buffer size with **buffer_max_size** and **buffer_chunk_size** parameters:
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```python
 [INPUT]
     name elasticsearch
@@ -61,6 +81,24 @@ For large bulk ingestions, you may have to increase buffer size with **buffer_ma
     name stdout
     match *
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+    inputs:
+        - name: elasticsearch
+          listen: 0.0.0.0
+          port: 9200
+          buffer_max_size: 20M
+          buffer_chunk_size: 5M
+
+    outputs:
+        - name: stdout
+          match: '*'
+```
+{% endtab %}
+{% endtabs %}
 
 #### Ingesting from beats series
 


### PR DESCRIPTION
This patch is to add an example in yaml for in_elasticsearch.