### PR TITLE
installation: add buildroot-embedded-linux.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -44,6 +44,7 @@
 * [macOS](installation/macos.md)
 * [Windows](installation/windows.md)
 * [Yocto / Embedded Linux](installation/yocto-embedded-linux.md)
+* [Buildroot / Embedded Linux](installation/buildroot-embedded-linux.md)
 
 ## Administration
 

--- a/installation/buildroot-embedded-linux.md
+++ b/installation/buildroot-embedded-linux.md
@@ -1,0 +1,24 @@
+# Buildroot / Embedded Linux
+
+## Installing
+
+To install, just select fluent-bit in your defconfig.
+See the Config.in file for all configuration options.
+
+```defconfig
+BR2_PACKAGE_FLUENT_BIT=y
+```
+
+## Running
+
+The default config file is written to:
+
+```
+/etc/fluent-bit/fluent-bit.conf
+```
+
+Fluent-bit is automatically started by the S99fluent-bit script.
+
+## Support
+
+All configurations with a toolchain that supports threads and dynamic library linking are supported.

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -22,6 +22,7 @@ description: The following serves as a guide on how to install/deploy/upgrade Fl
 | Amazon Linux           | [Amazon Linux 2](linux/amazon-linux.md#install-on-amazon-linux-2), [Amazon Linux 2022](linux/amazon-linux.md#amazon-linux-2022) |
 | Raspbian / Raspberry Pi | [Raspbian 10](linux/raspbian-raspberry-pi.md#raspbian-10-buster), [Raspbian 11](linux/raspbian-raspberry-pi.md#raspbian-11-bullseye) |
 | Yocto / Embedded Linux | [Yocto / Embedded Linux](yocto-embedded-linux.md#fluent-bit-and-other-architectures) |
+| Buildroot / Embedded Linux | [Buildroot / Embedded Linux](buildroot-embedded-linux.md) |
 
 ## Install on Windows (Packages)
 


### PR DESCRIPTION
Code:
https://gitlab.com/buildroot.org/buildroot/-/tree/master/package/fluent-bit

Supported version:
https://release-monitoring.org/project/267335

```
buildroot$ ./utils/test-pkg -p fluent-bit -a
                             arm-aarch64 [ 1/42]: OK
                   bootlin-aarch64-glibc [ 2/42]: OK
               bootlin-arcle-hs38-uclibc [ 3/42]: OK
                    bootlin-armv5-uclibc [ 4/42]: OK
                     bootlin-armv7-glibc [ 5/42]: OK
                   bootlin-armv7m-uclibc [ 6/42]: SKIPPED
                      bootlin-armv7-musl [ 7/42]: OK
                bootlin-m68k-5208-uclibc [ 8/42]: SKIPPED
               bootlin-m68k-68040-uclibc [ 9/42]: OK
             bootlin-microblazeel-uclibc [10/42]: OK
                bootlin-mipsel32r6-glibc [11/42]: OK
                   bootlin-mipsel-uclibc [12/42]: OK
                     bootlin-nios2-glibc [13/42]: OK
                 bootlin-openrisc-uclibc [14/42]: OK
        bootlin-powerpc64le-power8-glibc [15/42]: OK
           bootlin-powerpc-e500mc-uclibc [16/42]: OK
                   bootlin-riscv32-glibc [17/42]: OK
                   bootlin-riscv64-glibc [18/42]: OK
                    bootlin-riscv64-musl [19/42]: OK
                 bootlin-s390x-z13-glibc [20/42]: OK
                      bootlin-sh4-uclibc [21/42]: OK
                   bootlin-sparc64-glibc [22/42]: OK
                    bootlin-sparc-uclibc [23/42]: SKIPPED
                    bootlin-x86-64-glibc [24/42]: OK
                     bootlin-x86-64-musl [25/42]: OK
                   bootlin-x86-64-uclibc [26/42]: OK
                   bootlin-xtensa-uclibc [27/42]: OK
                            br-arm-basic [28/42]: OK
                    br-arm-full-nothread [29/42]: SKIPPED
                      br-arm-full-static [30/42]: SKIPPED
                   br-i386-pentium4-full [31/42]: OK
                br-i386-pentium-mmx-musl [32/42]: OK
                      br-mips64-n64-full [33/42]: OK
                 br-mips64r6-el-hf-glibc [34/42]: OK
               br-powerpc-603e-basic-cpp [35/42]: OK
               br-powerpc64-power7-glibc [36/42]: OK
                       linaro-aarch64-be [37/42]: OK
                          linaro-aarch64 [38/42]: OK
                              linaro-arm [39/42]: OK
                         sourcery-mips64 [40/42]: OK
                           sourcery-mips [41/42]: OK
                          sourcery-nios2 [42/42]: OK
42 builds, 5 skipped, 0 build failed, 0 legal-info failed, 0 show-info failed
```