### PR TITLE
Clearer version information for Ubuntu

### DIFF
--- a/installation/linux/ubuntu.md
+++ b/installation/linux/ubuntu.md
@@ -1,6 +1,7 @@
 # Ubuntu
 
-Fluent Bit is distributed as **fluent-bit** package and is available for long-term support releases of Ubuntu. The latest supported version is Jammy Jellyfish (22.04).
+Fluent Bit is distributed as **fluent-bit** package and is available for long-term support releases of Ubuntu. 
+The latest officially supported version is Jammy Jellyfish (22.04).
 
 ## Single line install
 

--- a/installation/linux/ubuntu.md
+++ b/installation/linux/ubuntu.md
@@ -1,6 +1,6 @@
 # Ubuntu
 
-Fluent Bit is distributed as **fluent-bit** package and is available for the latest stable Ubuntu system: Jammy Jellyfish.
+Fluent Bit is distributed as **fluent-bit** package and is available for long-term support releases of Ubuntu. The latest supported version is Jammy Jellyfish (22.04).
 
 ## Single line install
 


### PR DESCRIPTION
This clarifies the version information for ubuntu which is outdated since the release of Ubuntu 24.04.

See also https://github.com/fluent/fluent-bit/issues/8775.