### PR TITLE
in_prometheus_remote_write: Add documentation for input plugin of prometheus remote write

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -106,6 +106,7 @@
   * [Process Log Based Metrics](pipeline/inputs/process.md)
   * [Process Exporter Metrics](pipeline/inputs/process-exporter-metrics.md)
   * [Prometheus Scrape Metrics](pipeline/inputs/prometheus-scrape-metrics.md)
+  * [Prometheus Remote Write](pipeline/inputs/prometheus-remote-write.md)
   * [Random](pipeline/inputs/random.md)
   * [Serial Interface](pipeline/inputs/serial-interface.md)
   * [Splunk](pipeline/inputs/splunk.md)

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -65,6 +65,7 @@ The following **input** plugins can take advantage of the TLS feature:
 * [NGINX Exporter Metrics](../pipeline/inputs/nginx.md)
 * [OpenTelemetry](../pipeline/inputs/opentelemetry.md)
 * [Prometheus Scrape Metrics](../pipeline/inputs/prometheus-scrape-metrics.md)
+* [Prometheus Remote Write](../pipeline/inputs/prometheus-remote-write.md)
 * [Splunk (HTTP HEC)](../pipeline/inputs/splunk.md)
 * [Syslog](../pipeline/inputs/syslog.md)
 * [TCP](../pipeline/inputs/tcp.md)

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -15,7 +15,7 @@ This input plugin allows you to ingest a payload in the Prometheus remote-write 
 | buffer\_max\_size   | Specify the maximum buffer size in KB to receive a JSON message.                                                                               | 4M      |
 | buffer\_chunk\_size | This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size.  | 512K    |
 |successful\_response\_code | It allows to set successful response code. `200`, `201` and `204` are supported.| 201 |
-| tag\_from\_uri      | If true, tag will be created from uri. e.g. v1_metrics from /v1/metrics .                                                                      | true    |
+| tag\_from\_uri      | If true, tag will be created from uri. e.g. api\_prom\_push from /api/prom/push .                                                                      | true    |
 
 
 

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -11,7 +11,7 @@ This input plugin allows you to ingest a payload in the Prometheus remote-write 
 | Key           | Description                                                                                                                                    | default |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | listen            | The address to listen on                                                                                                                       | 0.0.0.0 |
-| port              | The port for Fluent Bit to listen on                                                                                                           | 80    |
+| port              | The port for Fluent Bit to listen on                                                                                                           | 8080    |
 | buffer\_max\_size   | Specify the maximum buffer size in KB to receive a JSON message.                                                                               | 4M      |
 | buffer\_chunk\_size | This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size.  | 512K    |
 |successful\_response\_code | It allows to set successful response code. `200`, `201` and `204` are supported.| 201 |

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -4,7 +4,7 @@ description: An input plugin to ingest payloads of Prometheus remote write
 
 # Prometheus Remote Write
 
-The input plugin of Prometheus remote write allows you to ingest payloads of Prometheus remote write protocol.
+This input plugin allows you to ingest a payload in the Prometheus remote-write format, i.e. a remote write sender can transmit data to Fluent Bit.
 
 The OpenTelemetry plugin allows you to ingest telemetry data as per the OTLP specification, from various OpenTelemetry exporters, the OpenTelemetry Collector, or Fluent Bit's OpenTelemetry output plugin.
 

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -15,7 +15,7 @@ This input plugin allows you to ingest a payload in the Prometheus remote-write 
 | buffer\_max\_size   | Specify the maximum buffer size in KB to receive a JSON message.                                                                               | 4M      |
 | buffer\_chunk\_size | This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size.  | 512K    |
 |successful\_response\_code | It allows to set successful response code. `200`, `201` and `204` are supported.| 201 |
-| tag\_from\_uri      | If true, tag will be created from uri. e.g. api\_prom\_push from /api/prom/push .                                                                      | true    |
+| tag\_from\_uri      | If true, tag will be created from uri. e.g. api\_prom\_push from /api/prom/push. This parameter will be prioritized when tag parameter is specified. If specify as false, it needs to specify user specified tag with tag parameter. | true    |
 
 
 

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -53,3 +53,22 @@ pipeline:
 {% endtabs %}
 
 With the above configuration, Fluent Bit will listen on port `8080` for data. You can now send payloads of Prometheus remote write to the endpoints `/api/prom/push`.
+
+## Examples
+
+### Communicate with TLS
+
+Communicating with TLS, you will need to use the tls related parameters:
+
+```
+[INPUT]
+	Name prometheus_remote_write
+	Listen 127.0.0.1
+	Port 8080
+	Uri /api/prom/push
+	Tls On
+	tls.crt_file /path/to/certificate.crt
+	tls.key_file /path/to/certificate.key
+```
+
+Then, enabled TLS configuration and able to ingest payloads of metrics with Prometheus' remote write protocol.

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -1,0 +1,57 @@
+---
+description: An input plugin to ingest payloads of Prometheus remote write
+---
+
+# Prometheus Remote Write
+
+The input plugin of Prometheus remote write allows you to ingest payloads of Prometheus remote write protocol.
+
+The OpenTelemetry plugin allows you to ingest telemetry data as per the OTLP specification, from various OpenTelemetry exporters, the OpenTelemetry Collector, or Fluent Bit's OpenTelemetry output plugin.
+
+## Configuration <a href="#configuration" id="configuration"></a>
+
+| Key           | Description                                                                                                                                    | default |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| listen            | The address to listen on                                                                                                                       | 0.0.0.0 |
+| port              | The port for Fluent Bit to listen on                                                                                                           | 80    |
+| buffer\_max\_size   | Specify the maximum buffer size in KB to receive a JSON message.                                                                               | 4M      |
+| buffer\_chunk\_size | This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size.  | 512K    |
+|successful\_response\_code | It allows to set successful response code. `200`, `201` and `204` are supported.| 201 |
+| tag\_from\_uri      | If true, tag will be created from uri. e.g. v1_metrics from /v1/metrics .                                                                      | true    |
+
+
+
+A sample config file to get started will look something like the following:
+
+
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
+```
+[INPUT]
+	name prometheus_remote_write
+	listen 127.0.0.1
+	port 8080
+	uri /api/prom/push
+
+[OUTPUT]
+	name stdout
+	match *
+```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+    inputs:
+        - name: prometheus_remote_write
+          listen: 127.0.0.1
+          port: 8080
+          uri: /api/prom/push
+    outputs:
+        - name: stdout
+          match: '*'
+```
+{% endtab %}
+{% endtabs %}
+
+With the above configuration, Fluent Bit will listen on port `8080` for data. You can now send payloads of Prometheus remote write to the endpoints `/api/prom/push`.

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -58,6 +58,8 @@ With the above configuration, Fluent Bit will listen on port `8080` for data. Yo
 
 ### Communicate with TLS
 
+Prometheus Remote Write input plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+
 Communicating with TLS, you will need to use the tls related parameters:
 
 ```

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -52,7 +52,8 @@ pipeline:
 {% endtab %}
 {% endtabs %}
 
-With the above configuration, Fluent Bit will listen on port `8080` for data. You can now send payloads of Prometheus remote write to the endpoints `/api/prom/push`.
+With the above configuration, Fluent Bit will listen on port `8080` for data.
+You can now send payloads in Prometheus remote write format to the endpoint `/api/prom/push`.
 
 ## Examples
 
@@ -73,4 +74,4 @@ Communicating with TLS, you will need to use the tls related parameters:
 	tls.key_file /path/to/certificate.key
 ```
 
-Then, enabled TLS configuration and able to ingest payloads of metrics with Prometheus' remote write protocol.
+Now, you should be able to send data over TLS to the remote write input.

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -15,7 +15,7 @@ This input plugin allows you to ingest a payload in the Prometheus remote-write 
 | buffer\_max\_size   | Specify the maximum buffer size in KB to receive a JSON message.                                                                               | 4M      |
 | buffer\_chunk\_size | This sets the chunk size for incoming incoming JSON messages. These chunks are then stored/managed in the space available by buffer_max_size.  | 512K    |
 |successful\_response\_code | It allows to set successful response code. `200`, `201` and `204` are supported.| 201 |
-| tag\_from\_uri      | If true, tag will be created from uri. e.g. api\_prom\_push from /api/prom/push. This parameter will be prioritized when tag parameter is specified. If specify as false, it needs to specify user specified tag with tag parameter. | true    |
+| tag\_from\_uri      | If true, tag will be created from uri, e.g. api\_prom\_push from /api/prom/push, and any tag specified in the config will be ignored. If false then a tag must be provided in the config for this input. | true    |
 
 
 

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -6,9 +6,7 @@ description: An input plugin to ingest payloads of Prometheus remote write
 
 This input plugin allows you to ingest a payload in the Prometheus remote-write format, i.e. a remote write sender can transmit data to Fluent Bit.
 
-The OpenTelemetry plugin allows you to ingest telemetry data as per the OTLP specification, from various OpenTelemetry exporters, the OpenTelemetry Collector, or Fluent Bit's OpenTelemetry output plugin.
-
-## Configuration <a href="#configuration" id="configuration"></a>
+## Configuration
 
 | Key           | Description                                                                                                                                    | default |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------- |


### PR DESCRIPTION
Corresponding to https://github.com/fluent/fluent-bit/pull/8725.