### PR TITLE
installation: macos: Remove Apple silicon restrictions

### DIFF
--- a/installation/macos.md
+++ b/installation/macos.md
@@ -1,7 +1,6 @@
 # macOS
 
-Fluent Bit is compatible with latest Apple macOS system on x86_64 and Apple Silicon M1 architectures.
-At the moment there is only an official supported package on x86_64 but you can build it from source as well by following the instructions below.
+Fluent Bit is compatible with latest Apple macOS system on x86_64 and Apple Silicon architectures.
 
 ## Installation Packages
 


### PR DESCRIPTION
This is because recent GHA's macos-latest is replaced with Apple Silicon based worker.
We don't need to mention Apple Silicon restriction.