### PR TITLE
added links for Microsoft Fabric Real Time Analytics

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -57,6 +57,7 @@ redirects:
     output/cloudwatch:     ./pipeline/outputs/cloudwatch.md
     output/datadog:        ./pipeline/outputs/datadog.md
     output/es:             ./pipeline/outputs/elasticsearch.md
+    output/fabric:         ./pipeline/outputs/azure_kusto.md
     output/file:           ./pipeline/outputs/file.md
     output/firehose:       ./pipeline/outputs/firehose.md
     output/flowcounter:    ./pipeline/outputs/flowcounter.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -179,6 +179,7 @@
   * [Kafka REST Proxy](pipeline/outputs/kafka-rest-proxy.md)
   * [LogDNA](pipeline/outputs/logdna.md)
   * [Loki](pipeline/outputs/loki.md)
+  * [Microsoft Fabric](pipeline/outputs/azure\_kusto.md)
   * [NATS](pipeline/outputs/nats.md)
   * [New Relic](pipeline/outputs/new-relic.md)
   * [NULL](pipeline/outputs/null.md)

--- a/pipeline/outputs/azure_kusto.md
+++ b/pipeline/outputs/azure_kusto.md
@@ -4,7 +4,7 @@ description: Send logs to Azure Data Explorer (Kusto)
 
 # Azure Data Explorer (Kusto)
 
-The Kusto output plugin allows to ingest your logs into an [Azure Data Explorer](https://azure.microsoft.com/en-us/services/data-explorer/) cluster, via the [Queued Ingestion](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/netfx/about-kusto-ingest#queued-ingestion) mechanism.
+The Kusto output plugin allows to ingest your logs into an [Azure Data Explorer](https://azure.microsoft.com/en-us/services/data-explorer/) cluster, via the [Queued Ingestion](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/netfx/about-kusto-ingest#queued-ingestion) mechanism. This output plugin can also be used to ingest logs into an [Eventhouse](https://blog.fabric.microsoft.com/en-us/blog/eventhouse-overview-handling-real-time-data-with-microsoft-fabric/) cluster in Microsoft Fabric Real Time Analytics.
 
 ## Creating a Kusto Cluster and Database
 

--- a/pipeline/outputs/azure_kusto.md
+++ b/pipeline/outputs/azure_kusto.md
@@ -6,12 +6,20 @@ description: Send logs to Azure Data Explorer (Kusto)
 
 The Kusto output plugin allows to ingest your logs into an [Azure Data Explorer](https://azure.microsoft.com/en-us/services/data-explorer/) cluster, via the [Queued Ingestion](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/netfx/about-kusto-ingest#queued-ingestion) mechanism. This output plugin can also be used to ingest logs into an [Eventhouse](https://blog.fabric.microsoft.com/en-us/blog/eventhouse-overview-handling-real-time-data-with-microsoft-fabric/) cluster in Microsoft Fabric Real Time Analytics.
 
-## Creating a Kusto Cluster and Database
+## For ingesting into Azure Data Explorer:  Creating a Kusto Cluster and Database
 
 You can create an Azure Data Explorer cluster in one of the following ways:
 
 - [Create a free-tier cluster](https://dataexplorer.azure.com/freecluster)
 - [Create a fully-featured cluster](https://docs.microsoft.com/en-us/azure/data-explorer/create-cluster-database-portal)
+
+## For ingesting into Microsoft Fabric Real Time Analytics : Creating an Eventhouse Cluster and KQL Database
+
+You can create an Eventhouse cluster and a KQL database follow the following steps:
+
+- [Create an Eventhouse cluster](https://docs.microsoft.com/en-us/azure/data-explorer/eventhouse/create-eventhouse-cluster)
+- [Create a KQL database](https://docs.microsoft.com/en-us/azure/data-explorer/eventhouse/create-database)
+
 
 ## Creating an Azure Registered Application
 


### PR DESCRIPTION
Microsoft Fabric Real Time Analytics is a SAAS offering in Microsoft Fabric while Azure Kusto is a PAAS offering in Azure. Microsoft Fabric Real Time Analytics has eventhouse(Kusto) for data storage. Hence we are using the same output plugin we have for Azure Kusto to send log data to Microsoft Fabric Real Time Analytics.

For more details please refer to the following documentations
https://learn.microsoft.com/en-us/fabric/real-time-analytics/overview
https://learn.microsoft.com/en-us/fabric/real-time-analytics/realtime-analytics-compare