### PR TITLE
Update K8S installation to remove legacy cri info

### DIFF
--- a/installation/kubernetes.md
+++ b/installation/kubernetes.md
@@ -31,17 +31,13 @@ To obtain this information, a built-in filter plugin called _kubernetes_ talks t
 
 ## Installation <a href="#installation" id="installation"></a>
 
-[Fluent Bit](http://fluentbit.io) should be deployed as a DaemonSet, so on that way it will be available on every node of your Kubernetes cluster.
+[Fluent Bit](http://fluentbit.io) should be deployed as a DaemonSet, so it will be available on every node of your Kubernetes cluster.
 
-The recommended way to deploy Fluent Bit is with the official Helm Chart: https://github.com/fluent/helm-charts
+The recommended way to deploy Fluent Bit is with the official Helm Chart: <https://github.com/fluent/helm-charts>
 
 ### Note for OpenShift
 
-If you are using Red Hat OpenShift you will also need to set up security context constraints (SCC):
-
-```
-$ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-openshift-security-context-constraints.yaml
-```
+If you are using Red Hat OpenShift you will also need to set up security context constraints (SCC) using the relevant option in the helm chart.
 
 ### Installing with Helm Chart
 
@@ -49,13 +45,13 @@ $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernet
 
 To add the Fluent Helm Charts repo use the following command
 
-```
+```shell
 helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
 To validate that the repo was added you can run `helm search repo fluent` to ensure the charts were added. The default chart can then be installed by running the following
 
-```
+```shell
 helm upgrade --install fluent-bit fluent/fluent-bit
 ```
 
@@ -67,38 +63,11 @@ The default chart values include configuration to read container logs, with Dock
 
 The default configuration of Fluent Bit makes sure of the following:
 
-* Consume all containers logs from the running Node.
-* The [Tail input plugin](https://docs.fluentbit.io/manual/v/1.0/input/tail) will not append more than **5MB** into the engine until they are flushed to the Elasticsearch backend. This limit aims to provide a workaround for [backpressure](https://docs.fluentbit.io/manual/v/1.0/configuration/backpressure) scenarios.
+* Consume all containers logs from the running Node and parse them with either the `docker` or `cri` multiline parser.
+* Persist how far it got into each file it is tailing so if a pod is restarted it picks up from where it left off.
 * The Kubernetes filter will enrich the logs with Kubernetes metadata, specifically _labels_ and _annotations_. The filter only goes to the API Server when it cannot find the cached info, otherwise it uses the cache.
 * The default backend in the configuration is Elasticsearch set by the [Elasticsearch Output Plugin](../pipeline/outputs/elasticsearch.md). It uses the Logstash format to ingest the logs. If you need a different Index and Type, please refer to the plugin option and do your own adjustments.
 * There is an option called **Retry\_Limit** set to False, that means if Fluent Bit cannot flush the records to Elasticsearch it will re-try indefinitely until it succeed.
-
-## Container Runtime Interface (CRI) parser
-
-Fluent Bit by default assumes that logs are formatted by the Docker interface standard. However, when using CRI you can run into issues with malformed JSON if you do not modify the parser used. Fluent Bit includes a CRI log parser that can be used instead. An example of the parser is seen below:
-
-```
-# CRI Parser
-[PARSER]
-    # http://rubular.com/r/tjUt3Awgg4
-    Name cri
-    Format regex
-    Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-    Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-```
-
-To use this parser change the Input section for your configuration from `docker` to `cri`
-
-```
-[INPUT]
-    Name tail
-    Path /var/log/containers/*.log
-    Parser cri
-    Tag kube.*
-    Mem_Buf_Limit 5MB
-    Skip_Long_Lines On
-```
 
 ## Windows Deployment
 

--- a/pipeline/filters/kubernetes.md
+++ b/pipeline/filters/kubernetes.md
@@ -83,7 +83,9 @@ To perform processing of the _log_ key, it's **mandatory to enable** the _Merge\
 If _log_ value processing fails, the value is untouched. The order above is not chained, meaning it's exclusive and the filter will try only one of the options above, **not** all of them.
 
 ## Kubernetes Namespace Meta
-Namespace Meta can be enabled via the following settings: 
+
+Namespace Meta can be enabled via the following settings:
+
 * Namespace\_Labels
 * Namespace\_Annotations
 
@@ -94,7 +96,7 @@ Namespace Meta if collected will be stored within a `kubernetes_namespace` recor
 > Namespace meta is not be guaranteed to be in sync as namespace labels & annotations can be adjusted after pod creation. Adjust `Kube_Meta_Namespace_Cache_TTL` to lower caching times to fit your use case.
 
 * Namespace\_Metadata\_Only
-  - Using this feature will instruct fluent-bit to only fetch namespace metadata and to not fetch POD metadata at all. 
+  * Using this feature will instruct fluent-bit to only fetch namespace metadata and to not fetch POD metadata at all.
     POD basic metadata like container id, host, etc will be NOT be added and the Labels and Annotations configuration options which are used specifically for POD Metadata will be ignored.
 
 ## Kubernetes Pod Annotations
@@ -162,7 +164,7 @@ Kubernetes Filter depends on either [Tail](../inputs/tail.md) or [Systemd](../in
     Name    tail
     Tag     kube.*
     Path    /var/log/containers/*.log
-    Parser  docker
+    multiline.parser              docker, cri
 
 [FILTER]
     Name             kubernetes
@@ -223,11 +225,11 @@ You can see on [Rublar.com](https://rubular.com/r/HZz3tYAahj6JCd) web site how t
 
 * [https://rubular.com/r/HZz3tYAahj6JCd](https://rubular.com/r/HZz3tYAahj6JCd)
 
-#### Custom Regex
+### Custom Regex
 
 Under certain and not common conditions, a user would want to alter that hard-coded regular expression, for that purpose the option **Regex\_Parser** can be used \(documented on top\).
 
-##### Custom Tag For Enhanced Filtering
+#### Custom Tag For Enhanced Filtering
 
 One such use case involves splitting logs by namespace, pods, containers or container id.
 The tag is restructured within the tail input using match groups, this can simplify the filtering by those match groups later in the pipeline.
@@ -287,7 +289,7 @@ rules:
       - pods
       - nodes
       - nodes/proxy
-    verbs: 
+    verbs:
       - get
       - list
       - watch
@@ -432,19 +434,23 @@ If you are not seeing metadata added to your kubernetes logs and see the followi
 When Fluent Bit is deployed as a DaemonSet it generally runs with specific roles that allow the application to talk to the Kubernetes API server. If you are deployed in a more restricted environment check that all the Kubernetes roles are set correctly.
 
 You can test this by running the following command (replace `fluentbit-system` with the namespace where your fluentbit is installed)
+
 ```text
 kubectl auth can-i list pods --as=system:serviceaccount:fluentbit-system:fluentbit
 ```
-If set roles are configured correctly, it should simply respond with `yes`. 
 
-For instance, using Azure AKS, running the above command may respond with: 
+If set roles are configured correctly, it should simply respond with `yes`.
+
+For instance, using Azure AKS, running the above command may respond with:
+
 ```text
 no - Azure does not have opinion for this user.
 ```
 
-If you have connectivity to the API server, but still "could not get meta for POD" - debug logging might give you a message with `Azure does not have opinion for this user`. Then the following `subject` may need to be included in the `fluentbit` `ClusterRoleBinding`: 
+If you have connectivity to the API server, but still "could not get meta for POD" - debug logging might give you a message with `Azure does not have opinion for this user`. Then the following `subject` may need to be included in the `fluentbit` `ClusterRoleBinding`:
 
 appended to `subjects` array:
+
 ```yaml
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
@@ -462,4 +468,3 @@ By default the Kube\_URL is set to `https://kubernetes.default.svc:443` . Ensure
 ### I can't see new objects getting metadata
 
 In some cases, you may only see some objects being appended with metadata while other objects are not enriched. This can occur at times when local data is cached and does not contain the correct id for the kubernetes object that requires enrichment. For most Kubernetes objects the Kubernetes API server is updated which will then be reflected in Fluent Bit logs, however in some cases for `Pod` objects this refresh to the Kubernetes API server can be skipped, causing metadata to be skipped.
-


### PR DESCRIPTION
Removing incorrect usage of old style CRI parser that just confused people and creates problems.
Resolved various other niggles.