### PR TITLE
Fix default labels value for Loki

### DIFF
--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -21,7 +21,7 @@ Be aware there is a separate Golang output plugin provided by [Grafana](https://
 | bearer\_token | Set bearer token authentication token value. |  |
 | header | Add additional arbitrary HTTP header key/value pair. Multiple headers can be set. |  |
 | tenant\_id | Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent. |  |
-| labels | Stream labels for API request. It can be multiple comma separated of strings specifying  `key=value` pairs. In addition to fixed parameters, it also allows to add custom record keys \(similar to `label_keys` property\). More details in the Labels section. | job=fluentbit |
+| labels | Stream labels for API request. It can be multiple comma separated of strings specifying  `key=value` pairs. In addition to fixed parameters, it also allows to add custom record keys \(similar to `label_keys` property\). More details in the Labels section. | job=fluent-bit |
 | label\_keys | Optional list of record keys that will be placed as stream labels. This configuration property is for records key only. More details in the Labels section. |  |
 | label\_map\_path | Specify the label map file path. The file defines how to extract labels from each record. More details in the Labels section. | |
 | remove\_keys | Optional list of keys to remove. | |


### PR DESCRIPTION
In code it's actually "fluent-bit" not "fluentbit" as documented: https://github.com/fluent/fluent-bit/blob/master/plugins/out_loki/loki.c#L454