### PR TITLE
pipeline/inputs/tail: fix YAML examples

### DIFF
--- a/pipeline/inputs/tail.md
+++ b/pipeline/inputs/tail.md
@@ -81,7 +81,7 @@ If you are running Fluent Bit to process logs coming from containers like Docker
 ```yaml
 pipeline:
   inputs:
-    - tail:
+    - name: tail
       path: /var/log/containers/*.log
       multiline.parser: docker, cri
 ```
@@ -146,9 +146,9 @@ In your main configuration file append the following _Input_ & _Output_ sections
 ```yaml
 pipeline:
   inputs:
-    - tail:
+    - name: tail
       path: /var/log/syslog
-      
+
   outputs:
     - stdout:
       match: *


### PR DESCRIPTION
YAML examples in the `tail` input plugin are invalid, and produce an error `section 'input' is missing the 'name' property`, which a colleague of mine got tripped up on.

This PR fixes.