### PR TITLE
Update OpenTelemetry input docs to be more clear about GRPC support

### DIFF
--- a/pipeline/inputs/opentelemetry.md
+++ b/pipeline/inputs/opentelemetry.md
@@ -52,11 +52,11 @@ __OTLP/GRPC__
 
 The OpenTelemetry input plugin supports the following telemetry data types:
 
-|     Type    |   HTTP1/JSON  |  HTTP1/Protobuf | HTTP2/GRPC |
-| ----------- | ------------- | --------------- | ---------- |
-|    Logs     |     Stable    |      Stable     |   Stable   |
-|    Metrics  | Unimplemented |      Stable     |   Stable   |
-|    Traces   | Unimplemented |      Stable     |   Stable   |
+| Type    | HTTP1/JSON | HTTP1/Protobuf | HTTP2/GRPC |
+| ------- | ---------- | -------------- | ---------- |
+| Logs    | Stable | Stable | Stable |
+| Metrics | Unimplemented | Stable | Stable |
+| Traces  | Unimplemented | Stable | Stable |
 
 A sample config file to get started will look something like the following:
 

--- a/pipeline/inputs/opentelemetry.md
+++ b/pipeline/inputs/opentelemetry.md
@@ -50,13 +50,13 @@ __OTLP/GRPC__
 
 ## Getting started
 
-The OpenTelemetry plugin currently supports the following telemetry data types:
+The OpenTelemetry input plugin currently supports the following telemetry data types:
 
-|     Type    |    HTTP/JSON  |   HTTP/Protobuf |
-| ----------- | ------------- | --------------- |
-|    Logs     |     Stable    |      Stable     |
-|    Metrics  | Unimplemented |      Stable     |
-|    Traces   | Unimplemented |      Stable     |
+|     Type    |   HTTP1/JSON  |  HTTP1/Protobuf | HTTP2/GRPC |
+| ----------- | ------------- | --------------- | ---------- |
+|    Logs     |     Stable    |      Stable     |   Stable   |
+|    Metrics  | Unimplemented |      Stable     |   Stable   |
+|    Traces   | Unimplemented |      Stable     |   Stable   |
 
 A sample config file to get started will look something like the following:
 

--- a/pipeline/inputs/opentelemetry.md
+++ b/pipeline/inputs/opentelemetry.md
@@ -50,7 +50,7 @@ __OTLP/GRPC__
 
 ## Getting started
 
-The OpenTelemetry input plugin currently supports the following telemetry data types:
+The OpenTelemetry input plugin supports the following telemetry data types:
 
 |     Type    |   HTTP1/JSON  |  HTTP1/Protobuf | HTTP2/GRPC |
 | ----------- | ------------- | --------------- | ---------- |


### PR DESCRIPTION
Previously this table only included the different HTTP1 input types.