### PR TITLE
pipeline: inputs: exec-wasi: Fix broken links

### DIFF
--- a/pipeline/inputs/exec-wasi.md
+++ b/pipeline/inputs/exec-wasi.md
@@ -14,8 +14,8 @@ The plugin supports the following configuration parameters:
 | Interval\_Sec | Polling interval \(seconds\). |
 | Interval\_NSec | Polling interval \(nanosecond\). |
 | Wasm\_Heap\_Size | Size of the heap size of Wasm execution. Review [unit sizes](../../administration/configuring-fluent-bit/unit-sizes.md) for allowed values. |
-| Wasm\_Stack\_Size | Size of the stack size of Wasm execution. Review [unit sizes](x../../administration/configuring-fluent-bit/unit-sizes.md) for allowed values. |
-| Buf\_Size | Size of the buffer \(check [unit sizes](../../administration/configuring-fluent-bit/unit-sizes.md for allowed values\) |
+| Wasm\_Stack\_Size | Size of the stack size of Wasm execution. Review [unit sizes](../../administration/configuring-fluent-bit/unit-sizes.md) for allowed values. |
+| Buf\_Size | Size of the buffer \(check [unit sizes](../../administration/configuring-fluent-bit/unit-sizes.md) for allowed values\) |
 | Oneshot | Only run once at startup. This allows collection of data precedent to fluent-bit's startup (bool, default: false) |
 
 ## Configuration Examples


### PR DESCRIPTION
- remove typo x, in Wasm_Stack_Size
- Add closing parenthesis, in Buf_Size