### PR TITLE
Trivial update to force GitBook refresh

### DIFF
--- a/concepts/data-pipeline/buffer.md
+++ b/concepts/data-pipeline/buffer.md
@@ -6,7 +6,7 @@ description: Data processing with reliability
 
 Previously defined in the [Buffering](../buffering.md) concept section, the `buffer` phase in the pipeline aims to provide a unified and persistent mechanism to store your data, either using the primary in-memory model or using the filesystem based mode.
 
-The `buffer` phase already contains the data in an immutable state, meaning, no other filter can be applied.
+The `buffer` phase already contains the data in an immutable state, meaning that no other filter can be applied.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
I enabled a setting within the GitBook UI (not GitHub) to resolve [this issue](https://github.com/fluent/fluent-bit-docs/issues/1433), but it looks like the changes won't go into effect until the docs site gets built again. this is a trivial update to force the docs site to rebuild :) 