### PR TITLE
Trivial updates to force GitBook refresh (again)

### DIFF
--- a/concepts/data-pipeline/buffer.md
+++ b/concepts/data-pipeline/buffer.md
@@ -11,7 +11,7 @@ The `buffer` phase already contains the data in an immutable state, meaning that
 ```mermaid
 graph LR
     accTitle: Fluent Bit data pipeline
-    accDescr: The Fluent Bit data pipeline includes input, a parser, a filter, a buffer, routing, and various outputs.
+    accDescr: A diagram of the Fluent Bit data pipeline, which includes input, a parser, a filter, a buffer, routing, and various outputs.
     A[Input] --> B[Parser]
     B --> C[Filter]
     C --> D[Buffer]

--- a/concepts/data-pipeline/filter.md
+++ b/concepts/data-pipeline/filter.md
@@ -9,7 +9,7 @@ In production environments we want to have full control of the data we are colle
 ```mermaid
 graph LR
     accTitle: Fluent Bit data pipeline
-    accDescr: The Fluent Bit data pipeline includes input, a parser, a filter, a buffer, routing, and various outputs.
+    accDescr: A diagram of the Fluent Bit data pipeline, which includes input, a parser, a filter, a buffer, routing, and various outputs.
     A[Input] --> B[Parser]
     B --> C[Filter]
     C --> D[Buffer]

--- a/concepts/data-pipeline/input.md
+++ b/concepts/data-pipeline/input.md
@@ -9,7 +9,7 @@ description: The way to gather data from your sources
 ```mermaid
 graph LR
     accTitle: Fluent Bit data pipeline
-    accDescr: The Fluent Bit data pipeline includes input, a parser, a filter, a buffer, routing, and various outputs.
+    accDescr: A diagram of the Fluent Bit data pipeline, which includes input, a parser, a filter, a buffer, routing, and various outputs.
     A[Input] --> B[Parser]
     B --> C[Filter]
     C --> D[Buffer]

--- a/concepts/data-pipeline/output.md
+++ b/concepts/data-pipeline/output.md
@@ -9,7 +9,7 @@ The output interface allows us to define destinations for the data. Common desti
 ```mermaid
 graph LR
     accTitle: Fluent Bit data pipeline
-    accDescr: The Fluent Bit data pipeline includes input, a parser, a filter, a buffer, routing, and various outputs.
+    accDescr: A diagram of the Fluent Bit data pipeline, which includes input, a parser, a filter, a buffer, routing, and various outputs.
     A[Input] --> B[Parser]
     B --> C[Filter]
     C --> D[Buffer]

--- a/concepts/data-pipeline/parser.md
+++ b/concepts/data-pipeline/parser.md
@@ -9,7 +9,7 @@ Dealing with raw strings or unstructured messages is a constant pain; having a s
 ```mermaid
 graph LR
     accTitle: Fluent Bit data pipeline
-    accDescr: The Fluent Bit data pipeline includes input, a parser, a filter, a buffer, routing, and various outputs.
+    accDescr: A diagram of the Fluent Bit data pipeline, which includes input, a parser, a filter, a buffer, routing, and various outputs.
     A[Input] --> B[Parser]
     B --> C[Filter]
     C --> D[Buffer]

--- a/concepts/data-pipeline/router.md
+++ b/concepts/data-pipeline/router.md
@@ -9,7 +9,7 @@ Routing is a core feature that allows to **route** your data through Filters and
 ```mermaid
 graph LR
     accTitle: Fluent Bit data pipeline
-    accDescr: The Fluent Bit data pipeline includes input, a parser, a filter, a buffer, routing, and various outputs.
+    accDescr: A diagram of the Fluent Bit data pipeline, which includes input, a parser, a filter, a buffer, routing, and various outputs.
     A[Input] --> B[Parser]
     B --> C[Filter]
     C --> D[Buffer]


### PR DESCRIPTION
following up on https://github.com/fluent/fluent-bit-docs/pull/1438 and https://github.com/fluent/fluent-bit-docs/issues/1433: it turns out GitBook doesn't rebuild all pages after a PR, only the pages that were actually changed in the PR. so this is me changing all of the pages with Mermaid diagrams to get GitBook to rebuild those pages, which should (hopefully) in turn fix the Mermaid diagrams on those pages 😅