### PR TITLE
pipeline: outputs: kinesis: add custom port configuration option

### DIFF
--- a/pipeline/outputs/kinesis.md
+++ b/pipeline/outputs/kinesis.md
@@ -25,7 +25,7 @@ See [here](https://github.com/fluent/fluent-bit-docs/tree/43c4fe134611da471e706b
 | log\_key | By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to Kinesis. |
 | role\_arn | ARN of an IAM role to assume \(for cross account access\). |
 | endpoint | Specify a custom endpoint for the Kinesis API. |
-| port | TCP port of the Kinesis Streams service |
+| port | TCP port of the Kinesis Streams service. Defaults to port `443`. |
 | sts\_endpoint | Custom endpoint for the STS API. |
 | auto\_retry\_requests | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to `true`. |
 | external\_id | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID. |

--- a/pipeline/outputs/kinesis.md
+++ b/pipeline/outputs/kinesis.md
@@ -25,6 +25,7 @@ See [here](https://github.com/fluent/fluent-bit-docs/tree/43c4fe134611da471e706b
 | log\_key | By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to Kinesis. |
 | role\_arn | ARN of an IAM role to assume \(for cross account access\). |
 | endpoint | Specify a custom endpoint for the Kinesis API. |
+| port | TCP port of the Kinesis Streams service |
 | sts\_endpoint | Custom endpoint for the STS API. |
 | auto\_retry\_requests | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to `true`. |
 | external\_id | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID. |


### PR DESCRIPTION
This commit introduces a new 'port' configuration option for the Kinesis output plugin. This enhancement allows users to specify a custom TCP port for connecting to the Kinesis Streams service, providing greater flexibility in network configurations.

Key changes:
- Added 'port' option to the configuration documentation
- Updated the Kinesis output plugin to support custom port connections
- Maintained default behavior (port 443) when no custom port is specified

This feature is particularly useful in environments where non-standard ports are required due to network policies or when connecting through proxies that use alternative ports.

The change is backwards compatible, as existing configurations without a specified port will continue to use the default port 443.