### PR TITLE
[docs][sc-105732] Update the Fluent Bit monitoring page

### DIFF
--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -1,29 +1,35 @@
 ---
+title: Monitor data pipelines
 description: Learn how to monitor your Fluent Bit data pipelines
 ---
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e9ca51eb-7faf-491d-a62e-618a21c94506" />
 
-# Monitoring
+# Monitor data pipelines
 
-Fluent Bit comes with built-it features to allow you to monitor the internals of your pipeline, connect to Prometheus and Grafana, Health checks  and also connectors to use external services for such purposes:
+Fluent Bit includes features for monitoring the internals of your pipeline, and for
+connecting to Prometheus and Grafana, Health checks, and connectors to use external
+services:
 
-* [HTTP Server: JSON and Prometheus Exporter-style metrics](monitoring.md#http-server)
-* [Grafana Dashboards and Alerts](monitoring.md#grafana-dashboard-and-alerts)
-* [Health Checks](monitoring.md#health-check-for-fluent-bit)
-* [Calyptia Cloud: hosted service to monitor and visualize your pipelines](monitoring.md#calyptia-cloud)
+- [HTTP Server: JSON and Prometheus Exporter-style metrics](monitoring.md#http-server)
+- [Grafana Dashboards and Alerts](monitoring.md#grafana-dashboard-and-alerts)
+- [Health Checks](monitoring.md#health-check-for-fluent-bit)
+- [Calyptia Cloud: hosted service to monitor and visualize your pipelines](monitoring.md#calyptia-cloud)
 
-## HTTP Server
+## HTTP server
 
-Fluent Bit comes with a built-in HTTP Server that can be used to query internal information and monitor metrics of each running plugin.
+Fluent Bit includes an HTTP server for querying internal information and monitoring
+metrics of each running plugin.
 
-The monitoring interface can be easily integrated with Prometheus since we support it native format.
+You can integrate the monitoring interface with Prometheus.
 
-### Getting Started
+### Getting started
 
-To get started, the first step is to enable the HTTP Server from the configuration file:
+To get started, enable the HTTP server from the configuration file. The following
+configuration instructs Fluent Bit to start an HTTP server on TCP port `2020` and
+listen on all network interfaces:
 
-```
+```yaml
 [SERVICE]
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
@@ -37,10 +43,15 @@ To get started, the first step is to enable the HTTP Server from the configurati
     Match *
 ```
 
-the above configuration snippet will instruct Fluent Bit to start it HTTP Server on TCP Port 2020 and listening on all network interfaces:
+Apply the configuration file:
 
+```shell
+bin/fluent-bit -c fluent-bit.conf
 ```
-$ bin/fluent-bit -c fluent-bit.conf
+
+Fluent Bit starts and generates output in your terminal:
+
+```shell
 Fluent Bit v1.4.0
 * Copyright (C) 2019-2020 The Fluent Bit Authors
 * Copyright (C) 2015-2018 Treasure Data
@@ -51,10 +62,12 @@ Fluent Bit v1.4.0
 [2020/03/10 19:08:24] [ info] [http_server] listen iface=0.0.0.0 tcp_port=2020
 ```
 
-now with a simple **curl** command is enough to gather some information:
+Use `curl` to gather information about the HTTP server. The following command sends
+the command output to the `jq` program, which outputs human-readable JSON data to the
+terminal.
 
-```
-$ curl -s http://127.0.0.1:2020 | jq
+```curl
+curl -s http://127.0.0.1:2020 | jq
 {
   "fluent-bit": {
     "version": "0.13.0",
@@ -80,132 +93,150 @@ $ curl -s http://127.0.0.1:2020 | jq
 }
 ```
 
-Note that we are sending the _curl_ command output to the _jq_ program which helps to make the JSON data easy to read from the terminal. Fluent Bit doesn't aim to do JSON pretty-printing.
+### REST API interface
 
-### REST API Interface
+Fluent Bit exposes the following endpoints for monitoring.
 
-Fluent Bit aims to expose useful interfaces for monitoring, as of Fluent Bit v0.14 the following end points are available:
+| URI                        | Description   | Data format           |
+| -------------------------- | ------------- | --------------------- |
+| /                          | Fluent Bit build information. | JSON |
+| /api/v1/uptime             | Return uptime information in seconds. | JSON |
+| /api/v1/metrics            | Display internal metrics per loaded plugin. | JSON                  |
+| /api/v1/metrics/prometheus | Display internal metrics per loaded plugin in Prometheus Server format. | Prometheus Text 0.0.4 |
+| /api/v1/storage            | Get internal metrics of the storage layer / buffered data. This option is enabled only if in the `SERVICE` section of the property `storage.metrics` is enabled. | JSON |
+| /api/v1/health             | Display the Fluent Bit health check result. | String |
+| /api/v2/metrics            | Display internal metrics per loaded plugin. | [cmetrics text format](https://github.com/fluent/cmetrics) |
+| /api/v2/metrics/prometheus | Display internal metrics per loaded plugin ready in Prometheus Server format. | Prometheus Text 0.0.4 |
+| /api/v2/reload             | Execute hot reloading or get the status of hot reloading. See the [hot-reloading documentation](hot-reload.md). | JSON |
 
-| URI                        | Description                                                                                                                                                        | Data Format           |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| /                          | Fluent Bit build information                                                                                                                                       | JSON                  |
-| /api/v1/uptime             | Get uptime information in seconds and human readable format                                                                                                        | JSON                  |
-| /api/v1/metrics            | Internal metrics per loaded plugin                                                                                                                                 | JSON                  |
-| /api/v1/metrics/prometheus | Internal metrics per loaded plugin ready to be consumed by a Prometheus Server                                                                                     | Prometheus Text 0.0.4 |
-| /api/v1/storage            | Get internal metrics of the storage layer / buffered data. This option is enabled only if in the `SERVICE` section the property `storage.metrics` has been enabled | JSON                  |
-| /api/v1/health             | Fluent Bit health check result                                                                                                                                     | String                |
-| /api/v2/metrics            | Internal metrics per loaded plugin                                                                                                                                 | [cmetrics text format](https://github.com/fluent/cmetrics) |
-| /api/v2/metrics/prometheus | Internal metrics per loaded plugin ready to be consumed by a Prometheus Server                                                                                     | Prometheus Text 0.0.4 |
-| /api/v2/reload             | Execute hot reloading or get the status of hot reloading. For more details, please refer to the [hot-reloading documentation](hot-reload.md).                                 | JSON                  |
+### v1 metrics
 
-### Metric Descriptions
+#### `/api/v1/metrics/prometheus` endpoint
 
-#### For v1 metrics
+The following descriptions apply to metrics outputted in Prometheus format by the
+`/api/v1/metrics/prometheus` endpoint.
 
-The following are detailed descriptions for the metrics outputted in prometheus format by `/api/v1/metrics/prometheus`.
+The following terms are key to understanding how Fluent Bit processes metrics:
 
-The following definitions are key to understand:
-* record: a single message collected from a source, such as a single long line in a file. 
-* chunk: Fluent Bit input plugin instances ingest log records and store them in chunks.  A batch of records in a chunk are tracked together as a single unit; the Fluent Bit engine attempts to fit records into chunks of at most 2 MB, but the size can vary at runtime. Chunks are then sent to an output. An output plugin instance can either successfully send the full chunk to the destination and mark it as successful, or it can fail the chunk entirely if an unrecoverable error is encountered, or it can ask for the chunk to be retried.
+- **Record**: a single message collected from a source, such as a single long line in
+  a file.
+- **Chunk**: log records ingested and stored by Fluent Bit input plugin instances. A
+  batch of records in a chunk are tracked together as a single unit.
 
-| Metric Name                            | Labels                                          | Description                                                                                                                                                                                                                                                                                  | Type    | Unit    |
-|----------------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------|
-| fluentbit_input_bytes_total            | name: the name or alias for the input instance  | The number of bytes of log records that this input instance has successfully ingested                                                                                                                                                                                                        | counter | bytes   |
-| fluentbit_input_records_total          | name: the name or alias for the input instance  | The number of log records this input has successfully ingested                                                                                                                                                                                                                               | counter | records |
-| fluentbit_output_dropped_records_total | name: the name or alias for the output instance | The number of log records that have been dropped by the output. This means they met an unrecoverable error or retries expired for their chunk.                                                                                                                                               | counter | records |
-| fluentbit_output_errors_total          | name: the name or alias for the output instance | The number of chunks that have faced an error (either unrecoverable or retriable). This is the number of times a chunk has failed, and does not correspond with the number of error messages you see in the Fluent Bit log output.                                                           | counter | chunks  |
-| fluentbit_output_proc_bytes_total      | name: the name or alias for the output instance | The number of bytes of log records that this output instance has *successfully* sent. This is the total byte size of all unique chunks sent by this output. If a record is not sent due to some error, then it will not count towards this metric.                                           | counter | bytes   |
-| fluentbit_output_proc_records_total    | name: the name or alias for the output instance | The number of log records that this output instance has *successfully* sent. This is the total record count of all unique chunks sent by this output. If a record is not successfully sent, it does not count towards this metric.                                                           | counter | records |
-| fluentbit_output_retried_records_total | name: the name or alias for the output instance | The number of log records that experienced a retry. Note that this is calculated at the chunk level, the count increased when an entire chunk is marked for retry. An output plugin may or may not perform multiple actions that generate many error messages when uploading a single chunk. | counter | records |
-| fluentbit_output_retries_failed_total  | name: the name or alias for the output instance | The number of times that retries expired for a chunk. Each plugin configures a Retry_Limit which applies to chunks. Once the Retry_Limit has been reached for a chunk it is discarded and this metric is incremented.                                                                        | counter | chunks  |
-| fluentbit_output_retries_total         | name: the name or alias for the output instance | The number of times this output instance requested a retry for a chunk.                                                                                                                                                                                                                      | counter | chunks  |
-| fluentbit_uptime                       |                                                 | The number of seconds that Fluent Bit has been running.                                                                                                                                                                                                                                      | counter | seconds |
-| process_start_time_seconds             |                                                 | The Unix Epoch time stamp for when Fluent Bit started.                                                                                                                                                                                                                                       | gauge   | seconds |
+  The Fluent Bit engine attempts to fit records into chunks of at most `2 MB`, but
+  the size can vary at runtime. Chunks are then sent to an output. An output plugin
+  instance can either successfully send the full chunk to the destination and mark it
+  as successful, or it can fail the chunk entirely if an unrecoverable error is
+  encountered, or it can ask for the chunk to be retried.
 
+| Metric name                            | Labels                                          | Description | Type    | Unit    |
+|----------------------------------------|-------------------------------------------------|-------------|---------|---------|
+| `fluentbit_input_bytes_total`          | name: the name or alias for the input instance  | The number of bytes of log records that this input instance has ingested successfully. | counter | bytes   |
+| `fluentbit_input_records_total`        | name: the name or alias for the input instance  | The number of log records this input ingested successfully. | counter | records |
+| `fluentbit_output_dropped_records_total` | name: the name or alias for the output instance | The number of log records dropped by the output. These records hit an unrecoverable error or retries expired for their chunk. | counter | records |
+| `fluentbit_output_errors_total`        | name: the name or alias for the output instance | The number of chunks with an error that's either unrecoverable or unable to retry. This metric represents the number of times a chunk failed, and doesn't correspond with the number of error messages visible in the Fluent Bit log output. | counter | chunks  |
+| `fluentbit_output_proc_bytes_total`      | name: the name or alias for the output instance | The number of bytes of log records that this output instance sent successfully. This metric represents the total byte size of all unique chunks sent by this output. If a record is not sent due to some error, it doesn't count towards this metric. | counter | bytes   |
+| `fluentbit_output_proc_records_total`    | name: the name or alias for the output instance | The number of log records that this output instance sent successfully. This metric represents the total record count of all unique chunks sent by this output. If a record is not sent successfully, it doesn't count towards this metric. | counter | records |
+| `fluentbit_output_retried_records_total` | name: the name or alias for the output instance | The number of log records that experienced a retry. This metric is calculated at the chunk level, the count increased when an entire chunk is marked for retry. An output plugin might perform multiple actions that generate many error messages when uploading a single chunk. | counter | records |
+| `fluentbit_output_retries_failed_total` | name: the name or alias for the output instance | The number of times that retries expired for a chunk. Each plugin configures a `Retry_Limit`, which applies to chunks. When the `Retry_Limit` is exceeded, the chunk is discarded and this metric is incremented. | counter | chunks  |
+| `fluentbit_output_retries_total`         | name: the name or alias for the output instance | The number of times this output instance requested a retry for a chunk. | counter | chunks  |
+| `fluentbit_uptime` | | The number of seconds that Fluent Bit has been running. | counter | seconds |
+| `process_start_time_seconds` | | The Unix Epoch timestamp for when Fluent Bit started. | gauge   | seconds |
 
-The following are detailed descriptions for the metrics outputted in JSON format by `/api/v1/storage`.
+#### `/api/v1/storage` endpoint
 
+The following descriptions apply to metrics outputted in JSON format by the
+`/api/v1/storage` endpoint.
 
-| Metric Key                                  | Description                                                                                                                                                              | Unit    |
-|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| chunks.total_chunks                         | The total number of chunks of records that Fluent Bit is currently buffering                                                                                             | chunks  |
-| chunks.mem_chunks                           | The total number of chunks that are buffered in memory at this time. Note that chunks can be both in memory and on the file system at the same time.                     | chunks  |
-| chunks.fs_chunks                            | The total number of chunks saved to the filesystem.                                                                                                                      | chunks  |
-| chunks.fs_chunks_up                         | A chunk is "up" if it is in memory. So this is the count of chunks that are both in filesystem and in memory.                                                            | chunks  |
-| chunks.fs_chunks_down                       | The count of chunks that are "down" and thus are only in the filesystem.                                                                                                 | chunks  |
-|                                             |                                                                                                                                                                          |         |
-| input_chunks.{plugin name}.status.overlimit | Is this input instance over its configured Mem_Buf_Limit?                                                                                                                | boolean |
-| input_chunks.{plugin name}.status.mem_size  | The size of memory that this input is consuming to buffer logs in chunks.                                                                                                | bytes   |
-| input_chunks.{plugin name}.status.mem_limit | The buffer memory limit (Mem_Buf_Limit) that applies to this input plugin.                                                                                               | bytes   |
-|                                             |                                                                                                                                                                          |         |
-| input_chunks.{plugin name}.chunks.total     | The current total number of chunks owned by this input instance.                                                                                                         | chunks  |
-| input_chunks.{plugin name}.chunks.up        | The current number of chunks that are "up" in memory for this input. Chunks that are "up" will also be in the filesystem layer as well if filesystem storage is enabled. | chunks  |
-| input_chunks.{plugin name}.chunks.down      | The current number of chunks that are "down" in the filesystem for this input.                                                                                           | chunks  |
-| input_chunks.{plugin name}.chunks.busy      | "Busy" chunks are chunks that are being processed/sent by outputs and are not eligible to have new data appended.                                                        | chunks  |
-| input_chunks.{plugin name}.chunks.busy_size | The sum of the byte size of each chunk which is currently marked as busy.                                                                                                | bytes   |
+| Metric Key                                    | Description   | Unit    |
+|-----------------------------------------------|---------------|---------|
+| `chunks.total_chunks`                         | The total number of chunks of records that Fluent Bit is currently buffering. | chunks  |
+| `chunks.mem_chunks`                           | The total number of chunks that are currently buffered in memory. Chunks can be both in memory and on the file system at the same time. | chunks  |
+| `chunks.fs_chunks`                            | The total number of chunks saved to the filesystem. | chunks  |
+| `chunks.fs_chunks_up`                         | The count of chunks that are both in file system and in memory. | chunks  |
+| `chunks.fs_chunks_down`                       | The count of chunks that are only in the file system. | chunks  |
+| `input_chunks.{plugin name}.status.overlimit` | Indicates whether the input instance exceeded its configured `Mem_Buf_Limit.` | boolean |
+| `input_chunks.{plugin name}.status.mem_size`  | The size of memory that this input is consuming to buffer logs in chunks. | bytes   |
+| `input_chunks.{plugin name}.status.mem_limit` | The buffer memory limit (`Mem_Buf_Limit`) that applies to this input plugin. | bytes   |
+| `input_chunks.{plugin name}.chunks.total`     | The current total number of chunks owned by this input instance. | chunks  |
+| `input_chunks.{plugin name}.chunks.up`        | The current number of chunks that are in memory for this input. If file system storage is enabled, chunks that are "up" are also stored in the filesystem layer. | chunks  |
+| `input_chunks.{plugin name}.chunks.down`      | The current number of chunks that are "down" in the filesystem for this input. | chunks  |
+| `input_chunks.{plugin name}.chunks.busy`      | Chunks are that are being processed or sent by outputs and are not eligible to have new data appended. | chunks  |
+| `input_chunks.{plugin name}.chunks.busy_size` | The sum of the byte size of each chunk which is currently marked as busy. | bytes   |
 
-#### For v2 metrics
+### v2 metrics
 
-The following are detailed descriptions for the metrics outputted in prometheus format by `/api/v2/metrics/prometheus` or `/api/v2/metrics`.
+#### `/api/v2/metrics/prometheus` or `/api/v2/metrics` endpoint
 
-The following definitions are key to understand:
-* record: a single message collected from a source, such as a single long line in a file.
-* chunk: Fluent Bit input plugin instances ingest log records and store them in chunks.  A batch of records in a chunk are tracked together as a single unit; the Fluent Bit engine attempts to fit records into chunks of at most 2 MB, but the size can vary at runtime. Chunks are then sent to an output. An output plugin instance can either successfully send the full chunk to the destination and mark it as successful, or it can fail the chunk entirely if an unrecoverable error is encountered, or it can ask for the chunk to be retried.
+The following descriptions apply to metrics outputted in Prometheus format by the
+`/api/v2/metrics/prometheus` or `/api/v2/metrics` endpoints.
 
-| Metric Name                                | Labels                                                                  | Description                                                                                                                                                                                                                                                                                  | Type    | Unit    |
-|--------------------------------------------|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------|
-| fluentbit\_input\_bytes\_total             | name: the name or alias for the input instance                          | The number of bytes of log records that this input instance has successfully ingested                                                                                                                                                                                                        | counter | bytes   |
-| fluentbit\_input\_records\_total           | name: the name or alias for the input instance                          | The number of log records this input has successfully ingested                                                                                                                                                                                                                               | counter | records |
-| fluentbit\_filter\_bytes\_total            | name: the name or alias for the filter instance                         | The number of bytes of log records that this filter instance has successfully ingested                                                                                                                                                                                                       | counter | bytes   |
-| fluentbit\_filter\_records\_total          | name: the name or alias for the filter instance                         | The number of log records this filter has successfully ingested                                                                                                                                                                                                                              | counter | records |
-| fluentbit\_filter\_added\_records\_total   | name: the name or alias for the filter instance                         | The number of log records that have been added by the filter. This means they added into the data pipeline.                                                                                                                                                                                  | counter | records |
-| fluentbit\_filter\_drop\_records\_total    | name: the name or alias for the filter instance                         | The number of log records that have been dropped by the filter. This means they were removed from the data pipeline.                                                                                                                                                                         | counter | records |
-| fluentbit\_output\_dropped\_records\_total | name: the name or alias for the output instance                         | The number of log records that have been dropped by the output. This means they met an unrecoverable error or retries expired for their chunk.                                                                                                                                               | counter | records |
-| fluentbit\_output\_errors\_total           | name: the name or alias for the output instance                         | The number of chunks that have faced an error (either unrecoverable or retriable). This is the number of times a chunk has failed, and does not correspond with the number of error messages you see in the Fluent Bit log output.                                                           | counter | chunks  |
-| fluentbit\_output\_proc\_bytes\_total      | name: the name or alias for the output instance                         | The number of bytes of log records that this output instance has *successfully* sent. This is the total byte size of all unique chunks sent by this output. If a record is not sent due to some error, then it will not count towards this metric.                                           | counter | bytes   |
-| fluentbit\_output\_proc\_records\_total    | name: the name or alias for the output instance                         | The number of log records that this output instance has *successfully* sent. This is the total record count of all unique chunks sent by this output. If a record is not successfully sent, it does not count towards this metric.                                                           | counter | records |
-| fluentbit\_output\_retried\_records\_total | name: the name or alias for the output instance                         | The number of log records that experienced a retry. Note that this is calculated at the chunk level, the count increased when an entire chunk is marked for retry. An output plugin may or may not perform multiple actions that generate many error messages when uploading a single chunk. | counter | records |
-| fluentbit\_output\_retries\_failed\_total  | name: the name or alias for the output instance                         | The number of times that retries expired for a chunk. Each plugin configures a Retry\_Limit which applies to chunks. Once the Retry\_Limit has been reached for a chunk it is discarded and this metric is incremented.                                                                      | counter | chunks  |
-| fluentbit\_output\_retries\_total          | name: the name or alias for the output instance                         | The number of times this output instance requested a retry for a chunk.                                                                                                                                                                                                                      | counter | chunks  |
-| fluentbit\_uptime                          | hostname: the hostname on running fluent-bit                            | The number of seconds that Fluent Bit has been running.                                                                                                                                                                                                                                      | counter | seconds |
-| fluentbit\_process\_start\_time\_seconds   | hostname: the hostname on running fluent-bit                            | The Unix Epoch time stamp for when Fluent Bit started.                                                                                                                                                                                                                                       | gauge   | seconds |
-| fluentbit\_build\_info                     | hostname: the hostname, version: the version of fluent-bit, os: OS type | Build version information. The returned value is originated from initializing the Unix Epoch time stamp of config context.                                                                                                                                                                   | gauge   | seconds |
-| fluentbit\_hot\_reloaded\_times            | hostname: the hostname on running fluent-bit                            | Collect the count of hot reloaded times.                                                                                                                                                                                                                                                     | gauge   | seconds |
+The following terms are key to understanding how Fluent Bit processes metrics:
 
-The following are detailed descriptions for the metrics which is collected by storage layer.
+- **Record**: a single message collected from a source, such as a single long line in
+  a file.
+- **Chunk**: log records ingested and stored by Fluent Bit input plugin instances. A
+  batch of records in a chunk are tracked together as a single unit.
 
+  The Fluent Bit engine attempts to fit records into chunks of at most `2 MB`, but
+  the size can vary at runtime. Chunks are then sent to an output. An output plugin
+  instance can either successfully send the full chunk to the destination and mark it
+  as successful, or it can fail the chunk entirely if an unrecoverable error is
+  encountered, or it can ask for the chunk to be retried.
 
-| Metric Name                                     | Labels                                          | Description                                                                                                                                                              | Type    | Unit    |
-|-------------------------------------------------|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------|
-| fluentbit\_input\_chunks.storage\_chunks        | None                                            | The total number of chunks of records that Fluent Bit is currently buffering                                                                                             | gauge   | chunks  |
-| fluentbit\_storage\_mem\_chunk                  | None                                            | The total number of chunks that are buffered in memory at this time. Note that chunks can be both in memory and on the file system at the same time.                     | gauge   | chunks  |
-| fluentbit\_storage\_fs\_chunks                  | None                                            | The total number of chunks saved to the filesystem.                                                                                                                      | gauge   | chunks  |
-| fluentbit\_storage\_fs\_chunks\_up              | None                                            | A chunk is "up" if it is in memory. So this is the count of chunks that are both in filesystem and in memory.                                                            | gauge   | chunks  |
-| fluentbit\_storage\_fs\_chunks\_down            | None                                            | The count of chunks that are "down" and thus are only in the filesystem.                                                                                                 | gauge   | chunks  |
-| fluentbit\_storage\_fs\_chunks\_busy            | None                                            | The total number of chunks are in a busy state.                                                                                                                          | gauge   | chunks  |
-| fluentbit\_storage\_fs\_chunks\_busy\_bytes     | None                                            | The total bytes of chunks are in a busy state.                                                                                                                           | gauge   | bytes   |
-|                                                 |                                                 |                                                                                                                                                                          |         |         |
-| fluentbit\_input\_storage\_overlimit            | name: the name or alias for the input instance  | Is this input instance over its configured Mem\_Buf\_Limit?                                                                                                              | gauge   | boolean |
-| fluentbit\_input\_storage\_memory\_bytes        | name: the name or alias for the input instance  | The size of memory that this input is consuming to buffer logs in chunks.                                                                                                | gauge   | bytes   |
-|                                                 |                                                 |                                                                                                                                                                          |         |         |
-| fluentbit\_input\_storage\_chunks               | name: the name or alias for the input instance  | The current total number of chunks owned by this input instance.                                                                                                         | gauge   | chunks  |
-| fluentbit\_input\_storage\_chunks\_up           | name: the name or alias for the input instance  | The current number of chunks that are "up" in memory for this input. Chunks that are "up" will also be in the filesystem layer as well if filesystem storage is enabled. | gauge   | chunks  |
-| fluentbit\_input\_storage\_chunks\_down         | name: the name or alias for the input instance  | The current number of chunks that are "down" in the filesystem for this input.                                                                                           | gauge   | chunks  |
-| fluentbit\_input\_storage\_chunks\_busy         | name: the name or alias for the input instance  | "Busy" chunks are chunks that are being processed/sent by outputs and are not eligible to have new data appended.                                                        | gauge   | chunks  |
-| fluentbit\_input\_storage\_chunks\_busy\_bytes  | name: the name or alias for the input instance  | The sum of the byte size of each chunk which is currently marked as busy.                                                                                                | gauge   | bytes   |
-|                                                 |                                                 |                                                                                                                                                                          |         |         |
-| fluentbit\_output\_upstream\_total\_connections | name: the name or alias for the output instance | The sum of the connection count of each output plugins.                                                                                                                  | gauge   | bytes   |
-| fluentbit\_output\_upstream\_busy\_connections  | name: the name or alias for the output instance | The sum of the connection count in a busy state of each output plugins.                                                                                                  | gauge   | bytes   |
+| Metric Name                                | Labels                                                                  | Description | Type    | Unit    |
+|--------------------------------------------|-------------------------------------------------------------------------|-------------|---------|---------|
+| `fluentbit_input_bytes_total`            | name: the name or alias for the input instance  | The number of bytes of log records that this input instance has ingested successfully. | counter | bytes   |
+| `fluentbit_input_records_total`          | name: the name or alias for the input instance  | The number of log records this input ingested successfully. | counter | records |
+| `fluentbit_filter_bytes_total`           | name: the name or alias for the filter instance | The number of bytes of log records that this filter instance has ingested successfully. | counter | bytes   |
+| `fluentbit_filter_records_total`         | name: the name or alias for the filter instance | The number of log records this filter has ingested successfully. | counter | records |
+| `fluentbit_filter_added_records_total`   | name: the name or alias for the filter instance | The number of log records added by the filter into the data pipeline. | counter | records |
+| `fluentbit_filter_drop_records_total`    | name: the name or alias for the filter instance | The number of log records dropped by the filter and removed from the data pipeline. | counter | records |
+| `fluentbit_output_dropped_records_total` | name: the name or alias for the output instance | The number of log records dropped by the output. These records hit an unrecoverable error or retries expired for their chunk. | counter | records |
+| `fluentbit_output_errors_total`          | name: the name or alias for the output instance | The number of chunks with an error that's either unrecoverable or unable to retry. This metric represents the number of times a chunk failed, and doesn't correspond with the number of error messages visible in the Fluent Bit log output. | counter | chunks  |
+| `fluentbit_output_proc_bytes_total`      | name: the name or alias for the output instance | The number of bytes of log records that this output instance sent successfully. This metric represents the total byte size of all unique chunks sent by this output. If a record is not sent due to some error, it doesn't count towards this metric. | counter | bytes   |
+| `fluentbit_output_proc_records_total`    | name: the name or alias for the output instance | The number of log records that this output instance sent successfully. This metric represents the total record count of all unique chunks sent by this output. If a record is not sent successfully, it doesn't count towards this metric. | counter | records |
+| `fluentbit_output_retried_records_total` | name: the name or alias for the output instance | The number of log records that experienced a retry. This metric is calculated at the chunk level, the count increased when an entire chunk is marked for retry. An output plugin might perform multiple actions that generate many error messages when uploading a single chunk. | counter | records |
+| `fluentbit_output_retries_failed_total` | name: the name or alias for the output instance | The number of times that retries expired for a chunk. Each plugin configures a `Retry_Limit`, which applies to chunks. When the `Retry_Limit` is exceeded, the chunk is discarded and this metric is incremented. | counter | chunks  |
+| `fluentbit_output_retries_total`        | name: the name or alias for the output instance | The number of times this output instance requested a retry for a chunk. | counter | chunks  |
+| `fluentbit_uptime`                      | hostname: the hostname on running Fluent Bit | The number of seconds that Fluent Bit has been running. | counter | seconds |
+| `fluentbit_process_start_time_seconds`  | hostname: the hostname on running Fluent Bit | The Unix Epoch time stamp for when Fluent Bit started. | gauge   | seconds |
+| `fluentbit_build_info`                  | hostname: the hostname, version: the version of Fluent Bit, os: OS type | Build version information. The returned value is originated from initializing the Unix Epoch time stamp of configuration context. | gauge   | seconds |
+| `fluentbit_hot_reloaded_times`          | hostname: the hostname on running Fluent Bit | Collect the count of hot reloaded times. | gauge   | seconds |
 
-### Uptime Example
+#### Storage layer
+
+The following are detailed descriptions for the metrics collected by the storage
+layer.
+
+| Metric Name                                 | Labels                       | Description   | Type    | Unit    |
+|---------------------------------------------|------------------------------|---------------|---------|---------|
+| `fluentbit_input_chunks.storage_chunks`     | None                         | The total number of chunks of records that Fluent Bit is currently buffering. | gauge | chunks |
+| `fluentbit_storage_mem_chunk`               | None                         | The total number of chunks that are currently buffered in memory. Chunks can be both in memory and on the file system at the same time. | gauge | chunks |
+| `fluentbit_storage_fs_chunks`               | None                         | The total number of chunks saved to the file system. | gauge | chunks |
+| `fluentbit_storage_fs_chunks_up`            | None                         | The count of chunks that are both in file system and in memory. | gauge | chunks |
+| `fluentbit_storage_fs_chunks_down`          | None                         | The count of chunks that are only in the file system. | gauge | chunks |
+| `fluentbit_storage_fs_chunks_busy`          | None                         | The total number of chunks are in a busy state. | gauge | chunks |
+| `fluentbit_storage_fs_chunks_busy_bytes`    | None                         | The total bytes of chunks are in a busy state. | gauge | bytes |
+| `fluentbit_input_storage_overlimit`         | name: the name or alias for the input instance  | Indicates whether the input instance exceeded its configured `Mem_Buf_Limit.` | gauge | boolean |
+| `fluentbit_input_storage_memory_bytes`      | name: the name or alias for the input instance  | The size of memory that this input is consuming to buffer logs in chunks. | gauge | bytes |
+| `fluentbit_input_storage_chunks`            | name: the name or alias for the input instance  | The current total number of chunks owned by this input instance. | gauge | chunks |
+| `fluentbit_input_storage_chunks_up`         | name: the name or alias for the input instance  | The current number of chunks that are in memory for this input. If file system storage is enabled, chunks that are "up" are also stored in the filesystem layer. | gauge | chunks |
+| `fluentbit_input_storage_chunks_down`       | name: the name or alias for the input instance  | The current number of chunks that are "down" in the filesystem for this input. | gauge | chunks |
+| `fluentbit_input_storage_chunks_busy`       | name: the name or alias for the input instance  | Chunks are that are being processed or sent by outputs and are not eligible to have new data appended. | gauge | chunks |
+| `fluentbit_input_storage_chunks_busy_bytes` | name: the name or alias for the input instance  | The sum of the byte size of each chunk which is currently marked as busy. | gauge | bytes |
+| `fluentbit_output_upstream_total_connections` | name: the name or alias for the output instance | The sum of the connection count of each output plugins. | gauge | bytes |
+| `fluentbit_output_upstream_busy_connections` | name: the name or alias for the output instance | The sum of the connection count in a busy state of each output plugins.                                                                                                  | gauge   | bytes   |
+
+### Uptime example
 
 Query the service uptime with the following command:
 
-```
+```curl
 $ curl -s http://127.0.0.1:2020/api/v1/uptime | jq
 ```
 
-it should print a similar output like this:
+The command prints a similar output like this:
 
 ```javascript
 {
@@ -214,7 +245,7 @@ it should print a similar output like this:
 }
 ```
 
-### Metrics Examples
+### Metrics example
 
 Query internal metrics in JSON format with the following command:
 
@@ -222,7 +253,7 @@ Query internal metrics in JSON format with the following command:
 $ curl -s http://127.0.0.1:2020/api/v1/metrics | jq
 ```
 
-it should print a similar output like this:
+The command prints a similar output like this:
 
 ```javascript
 {
@@ -244,7 +275,7 @@ it should print a similar output like this:
 }
 ```
 
-### Metrics in Prometheus format
+### Query metrics in Prometheus format
 
 Query internal metrics in Prometheus Text 0.0.4 format:
 
@@ -252,9 +283,9 @@ Query internal metrics in Prometheus Text 0.0.4 format:
 $ curl -s http://127.0.0.1:2020/api/v1/metrics/prometheus
 ```
 
-this time the same metrics will be in Prometheus format instead of JSON:
+This command returns the same metrics in Prometheus format instead of JSON:
 
-```
+```text
 fluentbit_input_records_total{name="cpu.0"} 57 1509150350542
 fluentbit_input_bytes_total{name="cpu.0"} 18069 1509150350542
 fluentbit_output_proc_records_total{name="stdout.0"} 54 1509150350542
@@ -264,13 +295,17 @@ fluentbit_output_retries_total{name="stdout.0"} 0 1509150350542
 fluentbit_output_retries_failed_total{name="stdout.0"} 0 1509150350542
 ```
 
-### Configuring Aliases
+### Configure aliases
 
-By default configured plugins on runtime get an internal name in the format _plugin_name.ID_. For monitoring purposes, this can be confusing if many plugins of the same type were configured. To make a distinction each configured input or output section can get an _alias_ that will be used as the parent name for the metric.
+By default, configured plugins on runtime get an internal name in the format
+`_plugin_name.ID_`. For monitoring purposes, this can be confusing if many plugins of
+the same type were configured. To make a distinction each configured input or output
+section can get an _alias_ that will be used as the parent name for the metric.
 
-The following example set an alias to the INPUT section which is using the [CPU](../pipeline/inputs/cpu-metrics.md) input plugin:
+The following example sets an alias to the `INPUT` section of the configuration file,
+which is using the [CPU](../pipeline/inputs/cpu-metrics.md) input plugin:
 
-```
+```yaml
 [SERVICE]
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
@@ -286,7 +321,8 @@ The following example set an alias to the INPUT section which is using the [CPU]
     Match *
 ```
 
-Now when querying the metrics we get the aliases in place instead of the plugin name:
+When querying the related metrics, the aliases are returned instead of the plugin
+name:
 
 ```javascript
 {
@@ -308,15 +344,22 @@ Now when querying the metrics we get the aliases in place instead of the plugin 
 }
 ```
 
-## Grafana Dashboard and Alerts
+## Grafana dashboard and alerts
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=0b83cb05-4f52-4853-83cc-f4539b64044d" />
 
-Fluent Bit's exposed [prometheus style metrics](https://docs.fluentbit.io/manual/administration/monitoring) can be leveraged to create dashboards and alerts.
+You can create Grafana dashboards and alerts using Fluent Bit's exposed Prometheus
+style metrics.
 
-The provided [example dashboard](https://github.com/fluent/fluent-bit-docs/tree/8172a24d278539a1420036a9434e9f56d987a040/monitoring/dashboard.json) is heavily inspired by [Banzai Cloud](https://banzaicloud.com)'s [logging operator dashboard](https://grafana.com/grafana/dashboards/7752) but with a few key differences such as the use of the `instance` label (see [why here](https://www.robustperception.io/controlling-the-instance-label)), stacked graphs and a focus on Fluent Bit metrics.
+The provided [example dashboard](https://github.com/fluent/fluent-bit-docs/tree/8172a24d278539a1420036a9434e9f56d987a040/monitoring/dashboard.json)
+is heavily inspired by [Banzai Cloud](https://banzaicloud.com)'s
+[logging operator dashboard](https://grafana.com/grafana/dashboards/7752) with a few
+key differences, such as the use of the `instance` label, stacked graphs, and a focus
+on Fluent Bit metrics. See
+[this blog post](https://www.robustperception.io/controlling-the-instance-label)
+for more information.
 
-![dashboard](../.gitbook/assets/dashboard.png)
+![dashboard](/.gitbook/assets/dashboard.png)
 
 ### Alerts
 
@@ -326,34 +369,43 @@ Sample alerts are available [here](https://github.com/fluent/fluent-bit-docs/tre
 
 Fluent bit now supports four new configs to set up the health check.
 
-| Config Name            | Description                                                                                                                                                                                                                                                                                                                             | Default Value |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------- |
-| Health_Check           | enable Health check feature                                                                                                                                                                                                                                                                                                             | Off           |
-| HC_Errors_Count        | the error count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for output error: ` [2022/02/16 10:44:10] [ warn] [engine] failed to flush chunk '1-1645008245.491540684.flb', retry in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3 (out_id=3)`            | 5             |
-| HC_Retry_Failure_Count | the retry failure count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for retry failure: `[2022/02/16 20:11:36] [ warn] [engine] chunk '1-1645042288.260516436.flb' cannot be retried: task_id=0, input=tcp.3 > output=cloudwatch_logs.1 `                                    | 5             |
-| HC_Period              | The time period by second to count the error and retry failure data point                                                                                                                                                                                                                                                               | 60            |
+| Configuration name     | Description | Default       |
+| ---------------------- | ------------| ------------- |
+| `Health_Check`           | enable Health check feature | Off |
+| `HC_Errors_Count`       | the error count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for output error: `[2022/02/16 10:44:10] [ warn] [engine] failed to flush chunk '1-1645008245.491540684.flb', retry in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3 (out_id=3)` | 5 |
+| `HC_Retry_Failure_Count` | the retry failure count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for retry failure: `[2022/02/16 20:11:36] [ warn] [engine] chunk '1-1645042288.260516436.flb' cannot be retried: task_id=0, input=tcp.3 > output=cloudwatch_logs.1` | 5 |
+| `HC_Period` | The time period by second to count the error and retry failure data point | 60 |
 
-*Note: Not every error log means an error nor be counted, the errors retry failures count only on specific errors which is the example in config table description*
+Not every error log means an error to be counted. The error retry failures count only
+on specific errors, which is the example in configuration table description.
 
-So the feature works as: Based on the HC_Period customer setup, if the real error number is over `HC_Errors_Count` or retry failure is over `HC_Retry_Failure_Count`, fluent bit will be considered as unhealthy. The health endpoint will return HTTP status 500 and String `error`. Otherwise it's healthy, will return HTTP status 200 and string `ok`
+Based on the `HC_Period` setting, if the real error number is over `HC_Errors_Count`,
+or retry failure is over `HC_Retry_Failure_Count`, Fluent Bit is considered
+unhealthy. The health endpoint returns an HTTP status `500` and an `error` message.
+Otherwise, the endpoint returns HTTP status `200` and an `ok` message.
 
-The equation is: 
+The equation to calculate this behavior is:
+
+```text
+health status = (HC_Errors_Count > HC_Errors_Count config value) OR
+(HC_Retry_Failure_Count > HC_Retry_Failure_Count config value) IN
+the HC_Period interval
 ```
-health status = (HC_Errors_Count > HC_Errors_Count config value) OR (HC_Retry_Failure_Count > HC_Retry_Failure_Count config value) IN the HC_Period interval
-```
-*Note: the HC_Errors_Count and HC_Retry_Failure_Count only count for output plugins and count a sum for errors and retry failures from all output plugins which is running.*
 
-See the config example:
+The `HC_Errors_Count` and `HC_Retry_Failure_Count` only count for output plugins and
+count a sum for errors and retry failures from all running output plugins.
 
-```
+The following configuration file example shows how to define these settings:
+
+```yaml
 [SERVICE]
     HTTP_Server  On
     HTTP_Listen  0.0.0.0
     HTTP_PORT    2020
-    Health_Check On 
-    HC_Errors_Count 5 
-    HC_Retry_Failure_Count 5 
-    HC_Period 5 
+    Health_Check On
+    HC_Errors_Count 5
+    HC_Retry_Failure_Count 5
+    HC_Period 5
 
 [INPUT]
     Name  cpu
@@ -363,53 +415,23 @@ See the config example:
     Match *
 ```
 
-The command to call health endpoint
+Use the following command to call the health endpoint:
 
 ```bash
-$ curl -s http://127.0.0.1:2020/api/v1/health
+curl -s http://127.0.0.1:2020/api/v1/health
 ```
 
-Based on the fluent bit status, the result will be:
+With the example config, the health status is determined by the following equation:
 
-* HTTP status 200 and "ok" in response to healthy status
-* HTTP status 500 and "error" in response for unhealthy status
-
-With the example config, the health status is determined by following equation:
-```
+```text
 Health status = (HC_Errors_Count > 5) OR (HC_Retry_Failure_Count > 5) IN 5 seconds
 ```
-If (HC_Errors_Count > 5) OR (HC_Retry_Failure_Count > 5) IN 5 seconds is TRUE, then it's unhealthy.
 
-If (HC_Errors_Count > 5) OR (HC_Retry_Failure_Count > 5) IN 5 seconds is FALSE, then it's healthy.
+- If this equation evaluates to `TRUE`, then Fluent Bit is unhealthy.
+- If this equation evaluates to `FALSE`, then Fluent Bit is healthy.
 
+## Telemetry Pipeline
 
-## Calyptia
-
-[Calyptia](https://calyptia.com/free-trial) is a hosted service that allows you to monitor your Fluent Bit agents including data flow, metrics and configurations.
-
-![](../.gitbook/assets/image-19-.png)
-
-### Get Started with Calyptia Cloud
-
-Register your Fluent Bit agent will take **less than one minute**, steps:
-
-* Go to the calyptia core console and sign-in
-* On the left menu click on settings and generate/copy your API key
-
-In your Fluent Bit configuration file, append the following configuration section:
-
-```
-[CUSTOM]
-    name     calyptia
-    api_key  <YOUR_API_KEY>
-```
-
-Make sure to replace your API key in the configuration.\
-\
-After a few seconds upon restart your Fluent Bit agent, the Calyptia Cloud Dashboard will list your agent. Metrics will take around 30 seconds to shows up.
-
-![](../.gitbook/assets/agent.png)
-
-###  Contact Calyptia
-
-If  want to get in touch with Calyptia team, just send an email to [hello@calyptia.com](mailto:hello@calyptia.com)
+[Telemetry Pipeline](https://chronosphere.io/platform/telemetry-pipeline/) is a
+hosted service that allows you to monitor your Fluent Bit agents including data flow,
+metrics, and configurations.

--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -7,9 +7,9 @@ description: Learn how to monitor your Fluent Bit data pipelines
 
 # Monitor data pipelines
 
-Fluent Bit includes features for monitoring the internals of your pipeline, and for
-connecting to Prometheus and Grafana, Health checks, and connectors to use external
-services:
+Fluent Bit includes features for monitoring the internals of your pipeline, in
+addition to connecting to Prometheus and Grafana, Health checks, and connectors to
+use external services:
 
 - [HTTP Server: JSON and Prometheus Exporter-style metrics](monitoring.md#http-server)
 - [Grafana Dashboards and Alerts](monitoring.md#grafana-dashboard-and-alerts)
@@ -111,6 +111,8 @@ Fluent Bit exposes the following endpoints for monitoring.
 
 ### v1 metrics
 
+The following descriptions apply to v1 metric endpoints.
+
 #### `/api/v1/metrics/prometheus` endpoint
 
 The following descriptions apply to metrics outputted in Prometheus format by the
@@ -165,6 +167,8 @@ The following descriptions apply to metrics outputted in JSON format by the
 | `input_chunks.{plugin name}.chunks.busy_size` | The sum of the byte size of each chunk which is currently marked as busy. | bytes   |
 
 ### v2 metrics
+
+The following descriptions apply to v2 metric endpoints.
 
 #### `/api/v2/metrics/prometheus` or `/api/v2/metrics` endpoint
 


### PR DESCRIPTION
This PR updates the [Fluent Bit monitoring page](https://docs.fluentbit.io/manual/administration/monitoring) for style and consistency with Chronosphere guidelines.