### PR TITLE
add to cloudwatch readme, supports for localstack

### DIFF
--- a/pipeline/outputs/cloudwatch.md
+++ b/pipeline/outputs/cloudwatch.md
@@ -65,7 +65,7 @@ In your main configuration file append the following _Output_ section:
 
 For an instance of Localstack running at `http://localhost:4566`, the following configuration needs to be added to the `[OUTPUT]` section:
 
-```
+```text
 endpoint localhost
 port 4566
 ```

--- a/pipeline/outputs/cloudwatch.md
+++ b/pipeline/outputs/cloudwatch.md
@@ -61,6 +61,16 @@ In your main configuration file append the following _Output_ section:
     log_stream_prefix from-fluent-bit-
     auto_create_group On
 ```
+#### Intergration with Localstack (Cloudwatch Logs)
+
+For an instance of Localstack running at `http://localhost:4566`, the following configuration needs to be added to the `[OUTPUT]` section:
+
+```
+endpoint localhost
+port 4566
+```
+
+Any testing credentials can be exported as local variables, such as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
 ### Permissions
 


### PR DESCRIPTION
Changes:
- New section: "Integration with Localstack (CloudWatch Logs)" added under the configuration file section.
     -    Configuration parameters for Localstack (endpoint and port).
     -    Instructions for exporting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as local variables for testing.
 
This update ensures that users working with Localstack can easily configure and test CloudWatch Logs output with Fluent Bit.