### PR TITLE
pipeline: inputs: docker-metrics: add container path config

### DIFF
--- a/pipeline/inputs/docker-metrics.md
+++ b/pipeline/inputs/docker-metrics.md
@@ -16,6 +16,7 @@ The plugin supports the following configuration parameters:
 | Include      | A space-separated list of containers to include |         |
 | Exclude      | A space-separated list of containers to exclude |         |
 | Threaded | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs). | `false` |
+| path.containers | Used to specify the container directory if Docker is configured with a custom "data-root" directory. | `/var/lib/docker/containers` |
 
 If you set neither `Include` nor `Exclude`, the plugin will try to get metrics from _all_ the running containers.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If you are mounting any new file or directory, make sure it is not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS APIs are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
<!--
Add one of the following:
bug
cleanup
dependency update
documentation
feature
improvement
release workflow
testing
-->

documentation

**What does this PR do / Why do we need it?**:

At times the user might need to have their docker [Daemon data directory](https://docs.docker.com/engine/daemon/#daemon-data-directory) setup somewhere else other than the default path. Currently the **Docker Log Based Metrics** plugin does not pick it up automatically and has it [hard coded here](https://github.com/fluent/fluent-bit/blob/a15cc2060ae7cc6404360c5c50665bab29cfe9ab/plugins/in_docker/docker.h#L33C9-L33C32). 

We can simply pass `path.containers` to the config and that will do the trick as the plugin code is also looking at that same [config here](https://github.com/fluent/fluent-bit/blob/a15cc2060ae7cc6404360c5c50665bab29cfe9ab/plugins/in_docker/docker.c#L572)

This can significantly save the end user research time and also opens their eyes to the capability of the docker metrics plugin

**Testing done on this change**:
<!--
Please paste the output from manual and/or integration test results. Please also attach any relevant logs.
-->

This was tested, let's assume my docker `data-root` is set to `/some-path/docker` the bellow config worked, and the plugin was able to access the containers as expected using this config 

```
[INPUT]
    Name                              docker
    tag                               docker.containers
    path.containers                   /some-path/docker/containers
  ```

I have also tried adding `DEFAULT_CONTAINERS_PATH` to `/etc/sysconfig/fluent-bit` [as per this document](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/variables), but that did not work.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
