### PR TITLE
plugin_proxy: Document event types for golang output plugin proxy

### DIFF
--- a/development/golang-output-plugins.md
+++ b/development/golang-output-plugins.md
@@ -149,3 +149,7 @@ Note: No need to specify a plugins configuration file from command line.
 ```text
 fluent-bit -c fluent-bit.conf
 ```
+
+## Event Types Supported
+
+Currently, the supported event types for the output plugin are `logs` and `metrics`. These types are declared in the [flb_plugin_proxy.c](https://github.com/fluent/fluent-bit/blob/master/src/flb_plugin_proxy.c) file in the `flb_proxy_register_output` function. The `fluent-bit-go` decoder will decode both types.

--- a/development/golang-output-plugins.md
+++ b/development/golang-output-plugins.md
@@ -152,4 +152,6 @@ fluent-bit -c fluent-bit.conf
 
 ## Event Types Supported
 
-Currently, the supported event types for the output plugin are `logs` and `metrics`. These types are declared in the [flb_plugin_proxy.c](https://github.com/fluent/fluent-bit/blob/master/src/flb_plugin_proxy.c) file in the `flb_proxy_register_output` function. The `fluent-bit-go` decoder will decode both types.
+Currently, the supported event types for the output plugin are `logs` and `metrics`.
+These types are declared in the [flb_plugin_proxy.c](https://github.com/fluent/fluent-bit/blob/master/src/flb_plugin_proxy.c) file in the `flb_proxy_register_output` function.
+The `fluent-bit-go` decoder will decode both types.


### PR DESCRIPTION
This update is for these PRs:
- https://github.com/fluent/fluent-bit/pull/9735
- https://github.com/fluent/fluent-bit-go/pull/79