### PR TITLE
pipeline: outputs: dash0: Added Dash0 documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -178,6 +178,7 @@
   * [Azure Log Analytics](pipeline/outputs/azure.md)
   * [Azure Logs Ingestion API](pipeline/outputs/azure_logs_ingestion.md)
   * [Counter](pipeline/outputs/counter.md)
+  * [Dash0](pipeline/outputs/dash0.md)
   * [Datadog](pipeline/outputs/datadog.md)
   * [Dynatrace](pipeline/outputs/dynatrace.md)
   * [Elasticsearch](pipeline/outputs/elasticsearch.md)

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -31,6 +31,7 @@ The following **output** plugins can take advantage of the TLS feature:
 * [Azure Data Explorer (Kusto)](../pipeline/outputs/azure_kusto.md)
 * [Azure Logs Ingestion API](../pipeline/outputs/azure_logs_ingestion.md)
 * [BigQuery](../pipeline/outputs/bigquery.md)
+* [Dash0](../pipeline/outputs/dash0.md)
 * [Datadog](../pipeline/outputs/datadog.md)
 * [Elasticsearch](../pipeline/outputs/elasticsearch.md)
 * [Forward](../pipeline/outputs/forward.md)

--- a/pipeline/outputs/dash0.md
+++ b/pipeline/outputs/dash0.md
@@ -1,0 +1,64 @@
+---
+description: Send logs to Dash0
+---
+
+# Dash0
+
+Stream logs to [Dash0](https://www.dash0.com) by utilizing the [OpenTelemetry plugin](opentelemetry.md) to send data to the Dash0 log ingress.
+
+## Configuration parameters
+
+| Key                        | Description | Default |
+| -------------------------- | ----------- | ------- |
+| `header`                   | The specific header for bearer authorization, where {your-Auth-token-here} is your Dash0 Auth Token. | Authorization Bearer {your-Auth-token-here} |
+| `host`                     | Your Dash0 ingress endpoint. | `ingress.eu-west-1.aws.dash0.com` |
+| `port`                     | TCP port of your Dash0 ingress endpoint. | `443` |
+| `metrics_uri`              | Specify an optional HTTP URI for the target web server listening for metrics | `/v1/metrics` |
+| `logs_uri`                 | Specify an optional HTTP URI for the target web server listening for logs | `/v1/logs` |
+| `traces_uri`               | Specify an optional HTTP URI for the target web server listening for traces | `/v1/traces`  |
+
+### TLS / SSL
+
+The OpenTelemetry output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
+
+## Getting started
+
+To get started with sending logs to Dash0:
+
+1. Get an [Auth Token](https://www.dash0.com/documentation/dash0/key-concepts/auth-tokens) from **Settings** > **Auth Tokens**.
+1. In your main Fluent Bit configuration file, append the following `Output` section:
+
+   {% tabs %}
+   {% tab title="fluent-bit.conf" %}
+   ```text
+   [OUTPUT]
+      Name         opentelemetry
+      Match        *
+      Host         ingress.eu-west-1.aws.dash0.com
+      Port         443
+      Header       Authorization Bearer auth_vdOxPqcvSlBkhVQV95wU9TGXh2Fdjliq
+      Metrics_uri  /v1/metrics
+      Logs_uri     /v1/logs
+      Traces_uri   /v1/traces
+   ```
+   {% endtab %}
+
+   {% tab title="fluent-bit.yaml" %}
+   ```yaml
+   [OUTPUT]
+      Name:         opentelemetry
+      Match:        *
+      Host:         ingress.eu-west-1.aws.dash0.com
+      Port:         443
+      Header:       Authorization Bearer auth_vdOxPqcvSlBkhVQV95wU9TGXh2Fdjliq
+      Metrics_uri:  /v1/metrics
+      Logs_uri:     /v1/logs
+      Traces_uri:   /v1/traces
+   ```
+   {% endtab %}
+   {% endtabs %}
+
+## References
+
+- [Dash0 documentation](https://www.dash0.com/documentation/dash0)

--- a/pipeline/outputs/elasticsearch.md
+++ b/pipeline/outputs/elasticsearch.md
@@ -56,8 +56,8 @@ be compared to the `database` and `table` concepts.
 
 ### TLS / SSL
 
-Elasticsearch output plugin supports TLS/SSL. For more details about the properties
-available and general configuration, refer to[TLS/SSL](../../administration/transport-security.md).
+The Elasticsearch output plugin supports TLS/SSL. 
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ### `write_operation`
 

--- a/pipeline/outputs/gelf.md
+++ b/pipeline/outputs/gelf.md
@@ -26,7 +26,8 @@ According to [GELF Payload Specification](https://go2docs.graylog.org/5-0/gettin
 
 ### TLS / SSL
 
-GELF output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The GELF output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Notes
 

--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -37,7 +37,8 @@ The **http** output plugin allows to flush your records into a HTTP endpoint. Fo
 
 ### TLS / SSL
 
-HTTP output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The HTTP output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Getting Started
 

--- a/pipeline/outputs/influxdb.md
+++ b/pipeline/outputs/influxdb.md
@@ -24,7 +24,8 @@ The **influxdb** output plugin, allows to flush your records into a [InfluxDB](h
 
 ### TLS / SSL
 
-InfluxDB output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The InfluxDB output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Getting Started
 

--- a/pipeline/outputs/kafka-rest-proxy.md
+++ b/pipeline/outputs/kafka-rest-proxy.md
@@ -19,7 +19,8 @@ The **kafka-rest** output plugin, allows to flush your records into a [Kafka RES
 
 ### TLS / SSL
 
-Kafka REST Proxy output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The Kafka REST Proxy output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Getting Started
 

--- a/pipeline/outputs/oci-logging-analytics.md
+++ b/pipeline/outputs/oci-logging-analytics.md
@@ -37,7 +37,8 @@ The following parameters are to set the Logging Analytics resources that must be
 
 ## TLS/SSL
 
-OCI Logging Analytics output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The OCI Logging Analytics output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Getting Started
 

--- a/pipeline/outputs/opensearch.md
+++ b/pipeline/outputs/opensearch.md
@@ -52,7 +52,8 @@ The following instructions assumes that you have a fully operational OpenSearch 
 
 ### TLS / SSL
 
-OpenSearch output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The OpenSearch output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ### write\_operation
 

--- a/pipeline/outputs/skywalking.md
+++ b/pipeline/outputs/skywalking.md
@@ -15,7 +15,8 @@ The **Apache SkyWalking** output plugin, allows to flush your records to a [Apac
 
 ### TLS / SSL
 
-Apache SkyWalking output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The Apache SkyWalking output plugin supports TLS/SSL.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Getting Started
 

--- a/pipeline/outputs/splunk.md
+++ b/pipeline/outputs/splunk.md
@@ -41,7 +41,8 @@ Content and Splunk metadata \(fields\) handling configuration properties:
 
 ### TLS / SSL
 
-Splunk output plugin supports TLS/SSL, for more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+The Splunk output plugin supports TLS/SSL. 
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Getting Started
 

--- a/pipeline/outputs/syslog.md
+++ b/pipeline/outputs/syslog.md
@@ -36,7 +36,7 @@ You must be aware of the structure of your original record so you can configure 
 ### TLS / SSL
 
 The Syslog output plugin supports TLS/SSL.
-For more details about the properties available and general configuration, please refer to the [TLS/SSL](../../administration/transport-security.md) section.
+For more details about the properties available and general configuration, see [TLS/SSL](../../administration/transport-security.md).
 
 ## Examples
 

--- a/vale-styles/FluentBit/Spelling-exceptions.txt
+++ b/vale-styles/FluentBit/Spelling-exceptions.txt
@@ -25,6 +25,7 @@ coroutines
 Crowdstrike
 CRDs
 DaemonSet
+Dash0
 Datadog
 Datagen
 datapoint


### PR DESCRIPTION
Added documentation on how to send logs to dash0 based on the OpenTelemetry output plugin.