### PR TITLE
out_loki: make it clear setting labels removes the keys from record

### DIFF
--- a/pipeline/outputs/loki.md
+++ b/pipeline/outputs/loki.md
@@ -35,7 +35,7 @@ Be aware there is a separate Golang output plugin provided by [Grafana](https://
 
 ## Labels
 
-Loki store the record logs inside Streams, a stream is defined by a set of labels, at least one label is required.
+Loki stores the record logs inside Streams, a stream is defined by a set of labels, at least one label is required.
 
 Fluent Bit implements a flexible mechanism to set labels by using fixed key/value pairs of text but also allowing to set as labels certain keys that exists as part of the records that are being processed.
 Consider the following JSON record \(pretty printed for readability\):
@@ -87,6 +87,8 @@ When processing that new configuration, the internal labels will be:
 ```text
 job="fluentbit", mystream="stdout"
 ```
+
+Extracting keys to labels through `labels`, `label_keys` or `label_map_path` will remove those keys from the record.
 
 ### Using the `label_keys` property
 


### PR DESCRIPTION
Related to the pull request https://github.com/fluent/fluent-bit/pull/9766 The documentation doesn't make it clear, but the code seems to be trying to work this way.

Also minor typo fix.