### PR TITLE
Fix broken link in parsers-section.md

### DIFF
--- a/administration/configuring-fluent-bit/yaml/parsers-section.md
+++ b/administration/configuring-fluent-bit/yaml/parsers-section.md
@@ -20,4 +20,4 @@ parsers:
 
 You can define multiple parsers sections, either within the main configuration file or distributed across included files.
 
-For more detailed information on parser options and advanced configurations, please refer to the [Configuring Parsers]() section.
+For more detailed information on parser options and advanced configurations, please refer to the [Configuring Parsers](../../../pipeline/parsers/configuring-parser.md) section.


### PR DESCRIPTION
The link does not work. I've found a suitable page, so I've updated the link.