### PR TITLE
installation: switch to YAML config files by default

### DIFF
--- a/installation/upgrade-notes.md
+++ b/installation/upgrade-notes.md
@@ -9,6 +9,15 @@ Note: release notes will be prepared in advance of a Git tag for a release so an
 The tag drives the overall binary release process so release binaries (containers/packages) will appear after a tag and its associated release note.
 This allows users to expect the new release binary to appear and allow/deny/update it as appropriate in their infrastructure.
 
+## Fluent Bit v4.0+
+
+The default configuration file has been switched to use YAML format and a different name (`.yaml` file suffix instead of `.conf`).
+
+This may require updating any custom deployments to either provide a YAML configuration or switch back to using legacy configuration in the arguments to the Fluent Bit binary.
+
+For Linux the Systemd unit will need overriding to specify `-c <legacy config file>`.
+Similarly for containers, Windows and macOS the default launch command is changed to point at the YAML config file by default.
+
 ## Fluent Bit v1.9.9
 
 The `td-agent-bit` package is no longer provided after this release.

--- a/installation/upgrade-notes.md
+++ b/installation/upgrade-notes.md
@@ -13,7 +13,8 @@ This allows users to expect the new release binary to appear and allow/deny/upda
 
 The default configuration file has been switched to use YAML format and a different name (`.yaml` file suffix instead of `.conf`).
 
-This may require updating any custom deployments to either provide a YAML configuration or switch back to using legacy configuration in the arguments to the Fluent Bit binary.
+You may need to update your custom deployments to either use YAML configuration files
+or switch back to using legacy configuration in the arguments to the Fluent Bit binary.
 
 In Linux environments, you must override the systemd unit to specify `-c <legacy config file>`.
 

--- a/installation/upgrade-notes.md
+++ b/installation/upgrade-notes.md
@@ -15,8 +15,10 @@ The default configuration file has been switched to use YAML format and a differ
 
 This may require updating any custom deployments to either provide a YAML configuration or switch back to using legacy configuration in the arguments to the Fluent Bit binary.
 
-For Linux the Systemd unit will need overriding to specify `-c <legacy config file>`.
-Similarly for containers, Windows and macOS the default launch command is changed to point at the YAML config file by default.
+In Linux environments, you must override the systemd unit to specify `-c <legacy config file>`.
+
+Similarly, in Windows and macOS container environments, the default launch command uses YAML configuration files
+by default.
 
 ## Fluent Bit v1.9.9
 

--- a/installation/upgrade-notes.md
+++ b/installation/upgrade-notes.md
@@ -11,7 +11,7 @@ This allows users to expect the new release binary to appear and allow/deny/upda
 
 ## Fluent Bit v4.0+
 
-The default configuration file has been switched to use YAML format and a different name (`.yaml` file suffix instead of `.conf`).
+By default, configuration files use YAML syntax and the `.yaml` file extension. 
 
 You may need to update your custom deployments to either use YAML configuration files
 or switch back to using legacy configuration in the arguments to the Fluent Bit binary.


### PR DESCRIPTION
See https://github.com/fluent/fluent-bit/pull/9837, update to use YAML config by default.

I have not tackled providing YAML config for all installation options in the docs, this is mostly to cover the upgrade impact. Ideally @fluent/chronosphere-tech-writers we can also update all the legacy config in the docs to also have a YAML config example by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Fluent Bit v4.0+ upgrade notes explaining YAML configuration is now the default format. Includes platform-specific guidance for Linux (systemd override required), Windows, and macOS container deployments to ensure configuration compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/1551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->