### PR TITLE
Update CloudWatch plugin's required IAM permissions

### DIFF
--- a/pipeline/outputs/cloudwatch.md
+++ b/pipeline/outputs/cloudwatch.md
@@ -137,7 +137,8 @@ The following AWS IAM permissions are required to use this plugin:
     "Action": [
       "logs:CreateLogStream",
       "logs:CreateLogGroup",
-      "logs:PutLogEvents"
+      "logs:PutLogEvents",
+      "logs:PutRetentionPolicy"
     ],
     "Resource": "*"
   }]


### PR DESCRIPTION
Without this policy it won't be possible to use custom retention period