### PR TITLE
in_someip: Initial input plugin documentation.

### DIFF
--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -29,6 +29,8 @@ $ ./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
 
 In your main configuration file append the following _Input_ & _Output_ sections:
 
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
 ```text
 [INPUT]
     Name someip
@@ -41,6 +43,19 @@ In your main configuration file append the following _Input_ & _Output_ sections
 [OUTPUT]
     Name        stdout
 ```
+{% endtab %}
+
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+  inputs:
+    - name: someip
+      Event: '4,1,32768,1'
+      Event: '4,1,32769,2'
+      RPC: '4,1,1,CgAQAw=='
+```
+{% endtab %}
+{% endtabs %}
 
 ## Testing
 

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -1,0 +1,100 @@
+# SOMEIP
+
+The **someip** input plugin is used to interact with a SOME/IP communication network to subscribe to events and to exchange request/response with SOME/IP services.
+
+This plugin uses the [vsomeip library](https://github.com/COVESA/vsomeip) \(built-in dependency\).
+
+## Configuration Parameters
+
+The plugin supports the following configuration parameters:
+
+| Key          | Description |
+| ------------ | ----------- |
+| Event        | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, "_service ID_, _event ID_, _event group ID 1_, _event group ID 2_, ...". The Event must include at least one _event group ID_, but can be associated with multiple. |
+| RPC          | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, "_service ID_, _service instance_, _method ID_, _request payload_". The request payload should be a should be base64 encoded |
+
+## Getting Started
+
+In order to subscribe to SOME/IP events or send request/receive SOME/IP response, you can run the plugin from the command line or through the configuration file:
+
+### Command Line
+
+The **someip** plugin can be enabled with options from the command line:
+
+```bash
+$ ./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
+```
+
+### Configuration File
+
+In your main configuration file append the following _Input_ & _Output_ sections:
+
+```text
+[INPUT]
+    Name someip
+    Tag  in.someip
+
+    Event 4,1,32768,1
+    Event 4,1,32769,2
+    RPC   4,1,1,CgAQAw==
+
+[OUTPUT]
+    Name        stdout
+```
+
+## Testing
+
+Once Fluent Bit is running, you can send some SOME/IP messages using the SOME/IP test service provided.
+
+```bash
+$ bin/someip_test_service 
+2025-02-06 22:18:06.211337  [info] Parsed vsomeip configuration in 0ms
+...
+Sending event with message Event Number 1
+Sent notification for service 4, event 32768
+Sending event with message Event Number 2
+Sent notification for service 4, event 32768
+```
+
+In [Fluent Bit](http://fluentbit.io) we should see the following output:
+
+```bash
+$ bin/fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
+Fluent Bit v3.2.0
+* Copyright (C) 2015-2024 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+______ _                  _    ______ _ _           _____  _____ 
+|  ___| |                | |   | ___ (_) |         |____ |/ __  \
+| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`' / /'
+|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \  / /  
+| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /./ /___
+\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)_____/
+
+
+[2025/02/06 22:12:23] [ info] [fluent bit] version=3.2.0, commit=239b46be20, pid=51044
+[2025/02/06 22:12:23] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/02/06 22:12:23] [ info] [simd    ] disabled
+[2025/02/06 22:12:23] [ info] [cmetrics] version=0.9.8
+[2025/02/06 22:12:23] [ info] [ctraces ] version=0.5.7
+[2025/02/06 22:12:23] [ info] [input:someip:someip.0] initializing
+[2025/02/06 22:12:23] [ info] [input:someip:someip.0] storage_strategy='memory' (memory only)
+[2025/02/06 22:12:23] [ info] [input:someip:someip.0] Received 1 configured events
+[2025/02/06 22:12:23] [ info] [input:someip:someip.0] No RPC configured.
+...
+2025-02-06 22:18:03.130557  [info] vSomeIP 3.5.1 | (default)
+2025-02-06 22:18:06.223714  [info] Application/Client 0101 is registering.
+2025-02-06 22:18:06.225581  [info] Client [100] is connecting to [101] at /tmp/vsomeip-101 endpoint > 0x79a50c000e30
+2025-02-06 22:18:06.230477  [info] REGISTERED_ACK(0101)
+2025-02-06 22:18:06.236103  [info] Port configuration missing for [4.1]. Service is internal.
+2025-02-06 22:18:06.236923  [info] OFFER(0101): [0004.0001:0.0] (true)
+2025-02-06 22:18:06.240237  [info] SUBSCRIBE ACK(0101): [0004.0001.0001.ffff]
+Received message for service 4 event = 32768
+[0] someip.0: [[1738880288.622425534, {}], {"record type"=>"event", "service"=>4, "instance"=>1, "event"=>32768, "payload"=>"RXZlbnQgTnVtYmVyIDE="}]
+Received message for service 4 event = 32768
+[0] someip.0: [[1738880290.622781511, {}], {"record type"=>"event", "service"=>4, "instance"=>1, "event"=>32768, "payload"=>"RXZlbnQgTnVtYmVyIDI="}]
+...
+```
+
+

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -13,9 +13,9 @@ The plugin supports the following configuration parameters:
 | `Event`       | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
 | `RPC`         | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload". The request payload should be base64 encoded. |
 
-## Getting Started
+## Get Started
 
-In order to subscribe to SOME/IP events or send request/receive SOME/IP response, you can run the plugin from the command line or through the configuration file:
+To subscribe to SOME/IP events or send request/receive SOME/IP response, run the plugin from the command line or through the configuration file:
 
 ### Command Line
 

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -17,13 +17,12 @@ The plugin supports the following configuration parameters:
 
 To subscribe to SOME/IP events or send request/receive SOME/IP response, run the plugin from the command line or through the configuration file:
 
-### Command Line
+### Command line
 
-The **someip** plugin can be enabled with options from the command line:
+The _someip_ plugin can be enabled with options from the command line:
 
 ```bash
-$ ./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
-```
+./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
 
 ### Configuration File
 

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -1,25 +1,25 @@
 # SOMEIP
 
-The _someip_ input plugin is used to interact with a SOME/IP communication network to subscribe to events and to exchange request/response with SOME/IP services.
+The `someip` input plugin is used to interact with a `SOME/IP` communication network to subscribe to events and to exchange request/response with `SOME/IP` services.
 
-This plugin uses the [vsomeip library](https://github.com/COVESA/vsomeip) (built-in dependency).
+This plugin uses the [`vsomeip`](https://github.com/COVESA/vsomeip) library (built-in dependency).
 
-## Configuration Parameters
+## Configuration parameters
 
 The plugin supports the following configuration parameters:
 
 | Key          | Description |
 | ------------ | ----------- |
-| `event`       | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
-| `rpc`         | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload`. The request payload should be base64 encoded. |
+| `event`       | `SOME/IP` event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
+| `rpc`         | `SOME/IP` request to send when service is available. The configuration can have multiple RPC entries, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload`. The request payload should be base64 encoded. |
 
-## Get Started
+## Get started
 
-To subscribe to SOME/IP events or send request/receive SOME/IP response, run the plugin from the command line or through the configuration file:
+To subscribe to `SOME/IP` events or send request/receive `SOME/IP` response, run the plugin from the command line or through the configuration file:
 
 ### Command line
 
-The _someip_ plugin can be enabled with options from the command line:
+The `someip` plugin can be enabled with options from the command line:
 
 ```shell
 ./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
@@ -59,7 +59,7 @@ pipeline:
 
 ## Testing
 
-Once Fluent Bit is running, you can send some SOME/IP messages using the SOME/IP test service provided.
+Once Fluent Bit is running, you can send some `SOME/IP` messages using the `SOME/IP` test service provided.
 
 ```shell
 $ bin/someip_test_service
@@ -71,7 +71,7 @@ Sending event with message Event Number 2
 Sent notification for service 4, event 32768
 ```
 
-In [Fluent Bit](http://fluentbit.io) we should see the following output:
+The following output displays in [Fluent Bit](http://fluentbit.io):
 
 ```shell
 $ bin/fluent-bit -i someip -p Event=4,1,32768,1 -o stdout

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -10,8 +10,8 @@ The plugin supports the following configuration parameters:
 
 | Key          | Description |
 | ------------ | ----------- |
-| `event`       | `SOME/IP` event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
-| `rpc`         | `SOME/IP` request to send when service is available. The configuration can have multiple RPC entries, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload`. The request payload should be base64 encoded. |
+| `event`       | `SOME/IP` event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma-separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
+| `rpc`         | `SOME/IP` request to send when service is available. The configuration can have multiple RPC entries, one on each line. An RPC is composed as a comma-separated list with, `service_ID, service_instance, method_ID, request_payload`. The request payload should be base64 encoded. |
 
 ## Get started
 
@@ -71,7 +71,7 @@ Sending event with message Event Number 2
 Sent notification for service 4, event 32768
 ```
 
-The following output displays in [Fluent Bit](http://fluentbit.io):
+The following output displays in [Fluent Bit](https://fluentbit.io):
 
 ```shell
 $ bin/fluent-bit -i someip -p Event=4,1,32768,1 -o stdout

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -29,6 +29,14 @@ The _someip_ plugin can be enabled with options from the command line:
 In your main configuration file append the following sections:
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+```yaml
+pipeline:
+  inputs:
+    - name: someip
+      Event: '4,1,32768,1'
+      Event: '4,1,32769,2'
+      RPC: '4,1,1,CgAQAw=='
 {% tab title="fluent-bit.conf" %}
 ```text
 [INPUT]
@@ -41,18 +49,6 @@ In your main configuration file append the following sections:
 
 [OUTPUT]
     Name        stdout
-```
-{% endtab %}
-
-{% tab title="fluent-bit.yaml" %}
-```yaml
-pipeline:
-  inputs:
-    - name: someip
-      Event: '4,1,32768,1'
-      Event: '4,1,32769,2'
-      RPC: '4,1,1,CgAQAw=='
-```
 {% endtab %}
 {% endtabs %}
 

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -10,8 +10,8 @@ The plugin supports the following configuration parameters:
 
 | Key          | Description |
 | ------------ | ----------- |
-| `Event`       | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
-| `RPC`         | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload". The request payload should be base64 encoded. |
+| `event`       | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
+| `rpc`         | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload`. The request payload should be base64 encoded. |
 
 ## Get Started
 
@@ -21,8 +21,9 @@ To subscribe to SOME/IP events or send request/receive SOME/IP response, run the
 
 The _someip_ plugin can be enabled with options from the command line:
 
-```bash
+```shell
 ./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
+```
 
 ### Configuration file
 
@@ -34,9 +35,12 @@ In your main configuration file append the following sections:
 pipeline:
   inputs:
     - name: someip
-      Event: '4,1,32768,1'
-      Event: '4,1,32769,2'
-      RPC: '4,1,1,CgAQAw=='
+      event:
+        - '4,1,32768,1'
+        - '4,1,32769,2'
+      rpc: '4,1,1,CgAQAw=='
+```
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
 ```text
 [INPUT]
@@ -49,6 +53,7 @@ pipeline:
 
 [OUTPUT]
     Name        stdout
+```
 {% endtab %}
 {% endtabs %}
 
@@ -56,8 +61,8 @@ pipeline:
 
 Once Fluent Bit is running, you can send some SOME/IP messages using the SOME/IP test service provided.
 
-```bash
-$ bin/someip_test_service 
+```shell
+$ bin/someip_test_service
 2025-02-06 22:18:06.211337  [info] Parsed vsomeip configuration in 0ms
 ...
 Sending event with message Event Number 1
@@ -68,7 +73,7 @@ Sent notification for service 4, event 32768
 
 In [Fluent Bit](http://fluentbit.io) we should see the following output:
 
-```bash
+```shell
 $ bin/fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
 Fluent Bit v3.2.0
 * Copyright (C) 2015-2024 The Fluent Bit Authors
@@ -106,5 +111,3 @@ Received message for service 4 event = 32768
 [0] someip.0: [[1738880290.622781511, {}], {"record type"=>"event", "service"=>4, "instance"=>1, "event"=>32768, "payload"=>"RXZlbnQgTnVtYmVyIDI="}]
 ...
 ```
-
-

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -10,8 +10,8 @@ The plugin supports the following configuration parameters:
 
 | Key          | Description |
 | ------------ | ----------- |
-| Event        | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, "_service ID_, _event ID_, _event group ID 1_, _event group ID 2_, ...". The Event must include at least one _event group ID_, but can be associated with multiple. |
-| RPC          | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, "_service ID_, _service instance_, _method ID_, _request payload_". The request payload should be a should be base64 encoded |
+| `Event`       | SOME/IP event to subscribe to. The configuration can have multiple events, one on each line. An event is identified by a comma separated list with, `service_ID, event_ID, event_group_ID_1, event_group_ID_2, ...`. The event must include at least one `event_group_ID`, but can be associated with multiple. |
+| `RPC`         | SOME/IP request to send when service is available. The configuration can have multiple RPCs, one on each line. An RPC is composed as a comma separated list with, `service_ID, service_instance, method_ID, request_payload". The request payload should be base64 encoded. |
 
 ## Getting Started
 

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -2,7 +2,7 @@
 
 The _someip_ input plugin is used to interact with a SOME/IP communication network to subscribe to events and to exchange request/response with SOME/IP services.
 
-This plugin uses the [vsomeip library](https://github.com/COVESA/vsomeip) \(built-in dependency\).
+This plugin uses the [vsomeip library](https://github.com/COVESA/vsomeip) (built-in dependency).
 
 ## Configuration Parameters
 

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -24,9 +24,9 @@ The _someip_ plugin can be enabled with options from the command line:
 ```bash
 ./fluent-bit -i someip -p Event=4,1,32768,1 -o stdout
 
-### Configuration File
+### Configuration file
 
-In your main configuration file append the following _Input_ & _Output_ sections:
+In your main configuration file append the following sections:
 
 {% tabs %}
 {% tab title="fluent-bit.conf" %}

--- a/pipeline/inputs/someip.md
+++ b/pipeline/inputs/someip.md
@@ -1,6 +1,6 @@
 # SOMEIP
 
-The **someip** input plugin is used to interact with a SOME/IP communication network to subscribe to events and to exchange request/response with SOME/IP services.
+The _someip_ input plugin is used to interact with a SOME/IP communication network to subscribe to events and to exchange request/response with SOME/IP services.
 
 This plugin uses the [vsomeip library](https://github.com/COVESA/vsomeip) \(built-in dependency\).
 


### PR DESCRIPTION
Adds the documentation for the new in_someip plugin:
  https://github.com/fluent/fluent-bit/pull/9570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a documentation page for the SOME/IP input plugin: overview, supported configuration options (Event and RPC), step-by-step getting‑started examples for CLI and config-file usage (YAML and .conf), and a testing walkthrough with a sample test service, representative startup logs, and example received-event payloads (including base64 examples).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->