### PR TITLE
aws-credentials: update credential page with pod identity information

### DIFF
--- a/administration/aws-credentials.md
+++ b/administration/aws-credentials.md
@@ -45,6 +45,11 @@ See [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/user
 Credentials are fetched for the ECS task's role. See
 [Amazon ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html).
 
+## EKS Pod Identity credentials
+
+Credentials are fetched using pod identity endpoint. See
+[Learn how EKS Pod Identity grants pods access to AWS services](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+
 ## EC2 instance profile credentials (IMDS)
 
 Fetches credentials for the EC2 instance profile's role. See

--- a/administration/aws-credentials.md
+++ b/administration/aws-credentials.md
@@ -47,7 +47,7 @@ Credentials are fetched for the ECS task's role. See
 
 ## EKS Pod Identity credentials
 
-Credentials are fetched using pod identity endpoint. See
+Credentials are fetched using  a pod identity endpoint. See
 [Learn how EKS Pod Identity grants pods access to AWS services](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
 
 ## EC2 instance profile credentials (IMDS)


### PR DESCRIPTION
Adds the documentation for the new pod identity credential used for AWS plugins: https://github.com/fluent/fluent-bit/pull/10114