### PR TITLE
Add missing `Match` to make the example self contained

### DIFF
--- a/pipeline/outputs/file.md
+++ b/pipeline/outputs/file.md
@@ -75,6 +75,7 @@ For example, if you set up the configuration as below:
 
 [OUTPUT]
   Name file
+  Match *
   Format template
   Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
 ```


### PR DESCRIPTION
Without the `Match` line nothing would be captured.