### PR TITLE
installation: windows: Fix Service creation C:\Program Files via PowerShell

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -272,7 +272,7 @@ Instead of `sc.exe`, PowerShell can be used to manage Windows services.
 Create a Fluent Bit service:
 
 ```text
-PS> New-Service fluent-bit -BinaryPathName "C:\fluent-bit\bin\fluent-bit.exe -c C:\fluent-bit\conf\fluent-bit.conf" -StartupType Automatic
+PS> New-Service fluent-bit -BinaryPathName "`"C:\Program Files\fluent-bit\bin\fluent-bit.exe`" -c `"C:\Program Files\fluent-bit\conf\fluent-bit.conf`"" -StartupType Automatic
 ```
 
 Start the service:

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -272,7 +272,7 @@ Instead of `sc.exe`, PowerShell can be used to manage Windows services.
 Create a Fluent Bit service:
 
 ```text
-PS> New-Service fluent-bit -BinaryPathName "`"C:\Program Files\fluent-bit\bin\fluent-bit.exe`" -c `"C:\Program Files\fluent-bit\conf\fluent-bit.conf`"" -StartupType Automatic
+PS> New-Service fluent-bit -BinaryPathName "`"C:\Program Files\fluent-bit\bin\fluent-bit.exe`" -c `"C:\Program Files\fluent-bit\conf\fluent-bit.conf`"" -StartupType Automatic -Description "This service runs Fluent Bit, a log collector that enables real-time processing and delivery of log data to centralized logging systems."
 ```
 
 Start the service:


### PR DESCRIPTION
As `C:\Program Files\fluent-bit\` is the default install location for fluent-bit it makes sense that the documentation supports this.
The current work-around doesn't make sense when it can easily be resolved by simply escaping the quotation marks.
This should give new users a better experience as the documentation follows a default installation.

Feel free to remove/ignore the -Description commit, I just think it gives a more concise and proper look inline with how most Windows services look and feel.