### PR TITLE
Fix a few links + update link guidance in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,11 +113,11 @@ request may suggest changes accordingly.
 
 ### URLs
 
-When cross-linking to a page in this repository, use a full relative path whenever
+When cross-linking to a page in this repository, use a full absolute path whenever
 possible. For example:
 
 ```text
-[LTSV](pipeline/parsers/ltsv.md) and [Logfmt](pipeline/parsers/logfmt.md)
+[LTSV](../pipeline/parsers/ltsv.md) and [Logfmt](../pipeline/parsers/logfmt.md)
 ```
 
 ### Vale

--- a/local-testing/logging-pipeline.md
+++ b/local-testing/logging-pipeline.md
@@ -4,7 +4,7 @@ You can test logging pipelines locally to observe how they handles log messages.
 
 ## Create a configuration file
 
-Start by creating a [Fluent Bit configuration file](/administration/configuring-fluent-bit/classic-mode/configuration-file) to test.
+Start by creating a [Fluent Bit configuration file](../administration/configuring-fluent-bit/classic-mode/configuration-file) to test.
 
 {% code title="fluent-bit.conf" %}
 ```text

--- a/local-testing/validating-your-data-and-structure.md
+++ b/local-testing/validating-your-data-and-structure.md
@@ -37,7 +37,7 @@ record --> stdout
 
 Add data validation between each step to ensure your data structure is correct.
 
-This example uses the [Expect](/pipeline/filters/expect) filter.
+This example uses the [Expect](../pipeline/filters/expect) filter.
 
 ```mermaid
 flowchart LR
@@ -99,7 +99,7 @@ The following Fluent Bit configuration file configures a pipeline to consume the
     match       *
 ```
 
-If the JSON parser fails or is missing in the [Tail](/pipeline/inputs/tail) input (`parser json`), the Expect filter triggers the `exit` action.
+If the JSON parser fails or is missing in the [Tail](../pipeline/inputs/tail) input (`parser json`), the Expect filter triggers the `exit` action.
 
 To extend the pipeline, add a Grep filter to match records that map `label` containing a key called `name` with value the `abc`, and add an Expect filter to re-validate that condition:
 


### PR DESCRIPTION
a few of the links I updated in my last couple PRs broke... turns out the guidance in CONTRIBUTING.md doesn't quite work. (yay gitbook.) updated that to a hopefully more reliable guideline.