### PR TITLE
Docker: how to use a configuration file

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -18,13 +18,16 @@ Use the following command to start Fluent Bit while using a configuration file:
 {% tabs %}
 {% tab title="fluent-bit.conf" %}
 ```shell
-docker run -ti -v ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf cr.fluentbit.io/fluent/fluent-bit
+docker run -ti -v ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf \
+  cr.fluentbit.io/fluent/fluent-bit
 ```
 {% endtab %}
 
 {% tab title="fluent-bit.yaml" %}
 ```shell
-docker run -ti -v ./fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml cr.fluentbit.io/fluent/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
+docker run -ti -v ./fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml \
+  cr.fluentbit.io/fluent/fluent-bit \
+  -c /fluent-bit/etc/fluent-bit.yaml
 ```
 {% endtab %}
 {% endtabs %}

--- a/installation/docker.md
+++ b/installation/docker.md
@@ -11,6 +11,21 @@ Use the following command to start Docker with Fluent Bit:
 docker run -ti cr.fluentbit.io/fluent/fluent-bit
 ```
 
+### Use a configuration file
+
+Use the following command to start Fluent Bit while using a configuration file:
+
+{% tabs %}
+{% tab title="fluent-bit.conf" %}
+```shell
+docker run -ti -v ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf cr.fluentbit.io/fluent/fluent-bit
+```
+
+{% tab title="fluent-bit.yaml" %}
+```shell
+docker run -ti -v ./fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml cr.fluentbit.io/fluent/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
+```
+
 ## Tags and versions
 
 The following table describes the Linux container tags that are available on Docker

--- a/installation/docker.md
+++ b/installation/docker.md
@@ -20,11 +20,15 @@ Use the following command to start Fluent Bit while using a configuration file:
 ```shell
 docker run -ti -v ./fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf cr.fluentbit.io/fluent/fluent-bit
 ```
+{% endtab %}
 
 {% tab title="fluent-bit.yaml" %}
 ```shell
 docker run -ti -v ./fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml cr.fluentbit.io/fluent/fluent-bit -c /fluent-bit/etc/fluent-bit.yaml
 ```
+{% endtab %}
+{% endtabs %}
+
 
 ## Tags and versions
 


### PR DESCRIPTION
Hello! 

I was testing Fluent Bit earlier this week, and struggled with getting the new YAML configuration file to work with Docker. 
Just mounting the volume doesn't work, the default `fluent-bit.conf` in the image takes precedence over the YAML file, which took me a while to troubleshoot. 

For example:
```yaml
# fluent-bit.yaml
pipeline:
  inputs:
    - name: dummy
      dummy: '{"from": "yaml"}'

  outputs:
    - name: stdout
```
Running `docker run -ti -v ./fluent-bit.yaml:/fluent-bit/etc/fluent-bit.yaml cr.fluentbit.io/fluent/fluent-bit` does not load the YAML file. 

Mounting the .conf file works though.
Maybe this will help those who tried the same thing as I did.

Let me know if you think anything needs changing or if you believe there is a better way to do this. Thanks!