### PR TITLE
Vale: remove exclamations, turn test to error, add new error tests to…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,9 @@ at the `suggestion` level and won't block merging.
 
 The following tests are at a `error` level and will prevent merging:
 
+- [Emdash](https://github.com/errata-ai/Google/blob/master/Google/EmDash.yml)
+- [Endash](https://github.com/errata-ai/Google/blob/master/Google/EmDash.yml)
+- [Exclamation](https://github.com/errata-ai/Google/blob/master/Google/Exclamation.yml)
 - [NonStandardQuotes](https://github.com/fluent/fluent-bit-docs/blob/master/vale-styles/FluentBit/NonStandardQuotes.yml):
   [Use standard quotes](https://developers.google.com/style/quotation-marks#straight-and-curly-quotation-marks).
   By default, Google Docs and Microsoft Word turn standard straight quotes into "smart"

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -230,7 +230,7 @@
 * [Getting Started](stream-processing/getting-started/README.md)
   * [Fluent Bit + SQL](stream-processing/getting-started/fluent-bit-sql.md)
   * [Check Keys and NULL values](stream-processing/getting-started/check-keys-null-values.md)
-  * [Hands On! 101](stream-processing/getting-started/hands-on.md)
+  * [Hands On 101](stream-processing/getting-started/hands-on.md)
 
 ## Fluent Bit for Developers <a href="#development" id="development"></a>
 

--- a/pipeline/filters/kubernetes.md
+++ b/pipeline/filters/kubernetes.md
@@ -405,8 +405,6 @@ spec:
 
 The key point is to set `hostNetwork` to `true` and `dnsPolicy` to `ClusterFirstWithHostNet` that fluent bit DaemonSet could call Kubelet locally. Otherwise it could not resolve the dns for kubelet.
 
-Now you are good to use this new feature!
-
 ### Verify that the Use\_Kubelet option is working
 
 Basically you should see no difference about your experience for enriching your log files with Kubernetes metadata.

--- a/vale-styles/FluentBit/Exclamation.yml
+++ b/vale-styles/FluentBit/Exclamation.yml
@@ -2,6 +2,6 @@ extends: existence
 message: "Don't use exclamation points in text."
 link: 'https://developers.google.com/style/exclamation-points'
 nonword: true
-level: suggestion
+level: error
 tokens:
   - '\w!(?:\s|$)'


### PR DESCRIPTION
… contrib file

Removes exclamation points in text per style guidelines, turns the test to error,  and adds the tests I've turned on to the contributing file.