### PR TITLE
Vale: Add HeadingPunctuation test to error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,7 @@ The following tests are at a `error` level and will prevent merging:
 - [Emdash](https://github.com/errata-ai/Google/blob/master/Google/EmDash.yml)
 - [Endash](https://github.com/errata-ai/Google/blob/master/Google/EmDash.yml)
 - [Exclamation](https://github.com/errata-ai/Google/blob/master/Google/Exclamation.yml)
+- [HeadingPunctuation](https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings)
 - [NonStandardQuotes](https://github.com/fluent/fluent-bit-docs/blob/master/vale-styles/FluentBit/NonStandardQuotes.yml):
   [Use standard quotes](https://developers.google.com/style/quotation-marks#straight-and-curly-quotation-marks).
   By default, Google Docs and Microsoft Word turn standard straight quotes into "smart"

--- a/administration/configuring-fluent-bit/yaml/configuration-file.md
+++ b/administration/configuring-fluent-bit/yaml/configuration-file.md
@@ -240,7 +240,7 @@ This functionality is only exposed in YAML configuration and not in classic conf
 
 [Processor example](configuration-file.md#example-using-processors)
 
-### Example: Using processors.
+### Example: Using processors
 
 The following configuration file example demonstrates the use of processors to change the log record in the input plugin section by adding a new key "hostname" with the value "monox", and we use lua to append the tag to the log record. Also in the ouput plugin section we added a new key named "output" with the value "new data". All these without the need of routing the logs further in the pipeline.
 

--- a/vale-styles/FluentBit/HeadingPunctuation.yml
+++ b/vale-styles/FluentBit/HeadingPunctuation.yml
@@ -2,7 +2,7 @@ extends: existence
 message: "Don't put a period at the end of a heading."
 link: 'https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings'
 nonword: true
-level: suggestion
+level: error
 scope: heading
 action:
   name: edit


### PR DESCRIPTION
Sets the vale HeadingPunctuation test to error, corrects the one instance where this was a problem, and adds the test info to the contributions file.