### PR TITLE
supported-platorms: remove old targets no longer built

### DIFF
--- a/installation/supported-platforms.md
+++ b/installation/supported-platforms.md
@@ -10,17 +10,15 @@ Fluent Bit supports the following operating systems and architectures:
 |  | [CentOS 8](linux/redhat-centos.md) | x86_64, Arm64v8 |
 |  | [CentOS 7](linux/redhat-centos.md) | x86_64, Arm64v8 |
 |  | [Rocky Linux 8](linux/redhat-centos.md) | x86_64, Arm64v8 |
+|  | [Rocky Linux 9](linux/redhat-centos.md) | x86_64, Arm64v8 |
 |  | [Alma Linux 8](linux/redhat-centos.md) | x86_64, Arm64v8 |
+|  | [Alma Linux 9](linux/redhat-centos.md) | x86_64, Arm64v8 |
 |  | [Debian 12 (Bookworm)](linux/debian.md) | x86_64, Arm64v8 |
 |  | [Debian 11 (Bullseye)](linux/debian.md) | x86_64, Arm64v8 |
 |  | [Debian 10 (Buster)](linux/debian.md) | x86_64, Arm64v8 |
 |  | [Ubuntu 24.04 (Noble Numbat)](linux/ubuntu.md) | x86_64, Arm64v8 |
 |  | [Ubuntu 22.04 (Jammy Jellyfish)](linux/ubuntu.md) | x86_64, Arm64v8 |
-|  | [Ubuntu 20.04 (Focal Fossa)](linux/ubuntu.md) | x86_64, Arm64v8 |
-|  | [Ubuntu 18.04 (Bionic Beaver)](linux/ubuntu.md) | x86_64, Arm64v8 |
-|  | [Ubuntu 16.04 (Xenial Xerus)](linux/ubuntu.md) | x86_64 |
-|  | [Raspbian 11 (Bullseye)](linux/raspbian-raspberry-pi.md) | Arm32v7 |
-|  | [Raspbian 10 (Buster)](linux/raspbian-raspberry-pi.md) | Arm32v7 |
+|  | [Raspbian 12 (Bookworm)](linux/raspbian-raspberry-pi.md) | Arm32v7 |
 | macOS | * | x86_64, Apple M1 |
 | Windows | [Windows Server 2019](windows.md) | x86_64, x86 |
 |  | [Windows 10 1903](windows.md) | x86_64, x86 |


### PR DESCRIPTION
Removing targets no longer built and adding RHEL-compatible 8/9 ones.

See https://github.com/fluent/fluent-bit/issues/10333 as well as the list of targets actually managed.