### PR TITLE
Update environment-variables-section.md

### DIFF
--- a/administration/configuring-fluent-bit/yaml/environment-variables-section.md
+++ b/administration/configuring-fluent-bit/yaml/environment-variables-section.md
@@ -2,7 +2,7 @@
 
 The `env` section lets you define environment variables directly within the configuration file. These variables can then be used to dynamically replace values throughout your configuration using the `${VARIABLE_NAME}` syntax.
 
-**Note:** Variables set in this section cannot be overridden by system environment variables.
+Variables set in this section cannot be overridden by system environment variables.
 
 Values set in the `env` section are case-sensitive. However, as a best practice, Fluent Bit recommends using uppercase names for environment variables. The following example defines two variables, `FLUSH_INTERVAL` and `STDOUT_FMT`, which can be accessed in the configuration using `${FLUSH_INTERVAL}` and `${STDOUT_FMT}`:
 
@@ -37,7 +37,7 @@ Fluent Bit provides a set of predefined environment variables that can be used i
 
 In addition to variables defined in the configuration file or the predefined ones, Fluent Bit can access system environment variables set in the user space. These external variables can be referenced in the configuration using the same `${VARIABLE_NAME}` pattern.
 
-**Note:** Variables set in the `env` section cannot be overridden by system environment variables.
+Variables set in the `env` section cannot be overridden by system environment variables.
 
 For example, to set the `FLUSH_INTERVAL` system environment variable to `2` and use it in your configuration:
 

--- a/administration/configuring-fluent-bit/yaml/environment-variables-section.md
+++ b/administration/configuring-fluent-bit/yaml/environment-variables-section.md
@@ -2,6 +2,8 @@
 
 The `env` section lets you define environment variables directly within the configuration file. These variables can then be used to dynamically replace values throughout your configuration using the `${VARIABLE_NAME}` syntax.
 
+**Note:** Variables set in this section cannot be overridden by system environment variables.
+
 Values set in the `env` section are case-sensitive. However, as a best practice, Fluent Bit recommends using uppercase names for environment variables. The following example defines two variables, `FLUSH_INTERVAL` and `STDOUT_FMT`, which can be accessed in the configuration using `${FLUSH_INTERVAL}` and `${STDOUT_FMT}`:
 
 ```yaml
@@ -34,6 +36,8 @@ Fluent Bit provides a set of predefined environment variables that can be used i
 ## External variables
 
 In addition to variables defined in the configuration file or the predefined ones, Fluent Bit can access system environment variables set in the user space. These external variables can be referenced in the configuration using the same `${VARIABLE_NAME}` pattern.
+
+**Note:** Variables set in the `env` section cannot be overridden by system environment variables.
 
 For example, to set the `FLUSH_INTERVAL` system environment variable to `2` and use it in your configuration:
 


### PR DESCRIPTION
If the config file is this:

```
env:
  ENVIRONMENT: x
  INSTANCE_UID: x

# Main Fluent Bit Configuration
service:
  flush: 1
  grace: 0
  daemon: off
  log_level: debug
  parsers_file: parsers.yaml

# Include input configurations
includes:
  - inputs/*.yaml

# Output to stdout for testing
pipeline:
  filters:
    - name: modify
      match: "*"
      add:
        - environment ${ENVIRONMENT}
        - instance_uid ${INSTANCE_UID}

  outputs:
    - name: stdout
      match: "*"
```

If I run this with `docker run -e ENVIRONMENT=dev ...` it is still reported as "x"