### PR TITLE
Pipeline: input: nginx: style

### DIFF
--- a/pipeline/inputs/nginx.md
+++ b/pipeline/inputs/nginx.md
@@ -1,24 +1,24 @@
-# NGINX Exporter Metrics
+# NGINX Exporter metrics
 
-_NGINX Exporter Metrics_ input plugin scrapes metrics from the NGINX stub status handler.
+The _NGINX Exporter metrics_ input plugin scrapes metrics from the NGINX stub status handler.
 
-## Configuration Parameters
+## Configuration parameters
 
 The plugin supports the following configuration parameters:
 
 | Key | Description | Default |
 | :--- | :--- | :--- |
-| Host | Name of the target host or IP address to check. | localhost |
-| Port | Port of the target nginx service to connect to. | 80 |
-| Status_URL | The URL of the Stub Status Handler. | /status |
-| Nginx_Plus | Turn on NGINX plus mode. | true |
-| Threaded | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs). | `false` |
+| `Host` | Name of the target host or IP address. | `localhost` |
+| `Port` | Port of the target Nginx service to connect to. | `80` |
+| `Status_URL` | The URL of the stub status Handler. | `/status` |
+| `Nginx_Plus` | Turn on NGINX plus mode. | `true` |
+| `Threaded` | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs). | `false` |
 
-## Getting Started
+## Get started
 
 NGINX must be configured with a location that invokes the stub status handler. Here is an example configuration with such a location:
 
-```
+```text
 server {
     listen       80;
     listen  [::]:80;
@@ -28,7 +28,7 @@ server {
         index  index.html index.htm;
     }
     // configure the stub status handler.
-    location /status {
+    loc.     ation /status {
         stub_status;
     }
 }
@@ -39,7 +39,7 @@ server {
 Another metrics API is available with NGINX Plus. You must first configure a path in
 NGINX Plus.
 
-```
+```text
 server {
 	listen       80;
 	listen  [::]:80;
@@ -57,27 +57,26 @@ server {
 }
 ```
 
-### Command Line
+### Command line
 
 From the command line you can let Fluent Bit generate the checks with the following options:
 
 ```bash
-$ fluent-bit -i nginx_metrics -p host=127.0.0.1 -p port=80 -p status_url=/status -p nginx_plus=off -o stdout
+fluent-bit -i nginx_metrics -p host=127.0.0.1 -p port=80 -p status_url=/status -p nginx_plus=off -o stdout
 ```
 
-To gather metrics from the command line with the NGINX Plus REST API we need to turn on the
-nginx_plus property, like so:
+To gather metrics from the command line with the NGINX Plus REST API you need to turn on the
+`nginx_plus` property:
 
 ```bash
-$ fluent-bit -i nginx_metrics -p host=127.0.0.1 -p port=80 -p nginx_plus=on -p status_url=/api -o stdout
+fluent-bit -i nginx_metrics -p host=127.0.0.1 -p port=80 -p nginx_plus=on -p status_url=/api -o stdout
 ```
-
 
 ### Configuration File
 
-In your main configuration file append the following _Input_ & _Output_ sections:
+In your main configuration file append the following `Input` and `Output` sections:
 
-```ini
+```python
 [INPUT]
     Name          nginx_metrics
     Host          127.0.0.1
@@ -92,8 +91,7 @@ In your main configuration file append the following _Input_ & _Output_ sections
 
 And for NGINX Plus API:
 
-```ini
-[INPUT]
+```python
     Name          nginx_metrics
     Nginx_Plus    on
     Host          127.0.0.1
@@ -105,14 +103,17 @@ And for NGINX Plus API:
     Match  *
 ```
 
+## Test your configuration
 
-
-## Testing
-
-You can quickly test against the NGINX server running on localhost by invoking it directly from the command line:
+You can test against the NGINX server running on localhost by invoking it directly from the command line:
 
 ```bash
-$ fluent-bit -i nginx_metrics -p host=127.0.0.1 -p nginx_plus=off -o stdout -p match=* -f 1
+fluent-bit -i nginx_metrics -p host=127.0.0.1 -p nginx_plus=off -o stdout -p match=* -f 1
+```
+
+Which should return something like the following:
+
+```text
 Fluent Bit v2.x.x
 * Copyright (C) 2019-2020 The Fluent Bit Authors
 * Copyright (C) 2015-2018 Treasure Data
@@ -129,117 +130,6 @@ Fluent Bit v2.x.x
 2021-10-14T19:37:35.229919621Z nginx_up = 1
 ```
 
-## Exported Metrics
+## Exported metrics
 
-This documentation is copied from the
-[NGINX Prometheus Exporter metrics documentation](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/README.md)
-on GitHub.
-
-### Common metrics:
-Name | Type | Description | Labels
-----|----|----|----|
-`nginx_up` | Gauge | Shows the status of the last metric scrape: `1` for a successful scrape and `0` for a failed one | [] |
-
-### Metrics for NGINX OSS:
-#### [Stub status metrics](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginx_connections_accepted` | Counter | Accepted client connections. | [] |
-`nginx_connections_active` | Gauge | Active client connections. | [] |
-`nginx_connections_handled` | Counter | Handled client connections. | [] |
-`nginx_connections_reading` | Gauge | Connections where NGINX is reading the request header. | [] |
-`nginx_connections_waiting` | Gauge | Idle client connections. | [] |
-`nginx_connections_writing` | Gauge | Connections where NGINX is writing the response back to the client. | [] |
-`nginx_http_requests_total` | Counter | Total http requests. | [] |
-
-### Metrics for NGINX Plus:
-#### [Connections](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_connections)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_connections_accepted` | Counter | Accepted client connections | [] |
-`nginxplus_connections_active` | Gauge | Active client connections | [] |
-`nginxplus_connections_dropped` | Counter | Dropped client connections dropped | [] |
-`nginxplus_connections_idle` | Gauge | Idle client connections | [] |
-
-#### [HTTP](https://nginx.org/en/docs/http/ngx_http_api_module.html#http_)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_http_requests_total` | Counter | Total http requests | [] |
-`nginxplus_http_requests_current` | Gauge | Current http requests | [] |
-
-#### [SSL](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_ssl_object)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_ssl_handshakes` | Counter | Successful SSL handshakes | [] |
-`nginxplus_ssl_handshakes_failed` | Counter | Failed SSL handshakes | [] |
-`nginxplus_ssl_session_reuses` | Counter | Session reuses during SSL handshake | [] |
-
-#### [HTTP Server Zones](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_server_zone)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_server_zone_processing` | Gauge | Client requests that are currently being processed | `server_zone` |
-`nginxplus_server_zone_requests` | Counter | Total client requests | `server_zone` |
-`nginxplus_server_zone_responses` | Counter | Total responses sent to clients | `code` (the response status code. The values are: `1xx`, `2xx`, `3xx`, `4xx` and `5xx`), `server_zone` |
-`nginxplus_server_zone_discarded` | Counter | Requests completed without sending a response | `server_zone` |
-`nginxplus_server_zone_received` | Counter | Bytes received from clients | `server_zone` |
-`nginxplus_server_zone_sent` | Counter | Bytes sent to clients | `server_zone` |
-
-#### [Stream Server Zones](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_server_zone)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_stream_server_zone_processing` | Gauge | Client connections that are currently being processed | `server_zone` |
-`nginxplus_stream_server_zone_connections` | Counter | Total connections | `server_zone` |
-`nginxplus_stream_server_zone_sessions` | Counter | Total sessions completed | `code` (the response status code. The values are: `2xx`, `4xx`, and `5xx`), `server_zone` |
-`nginxplus_stream_server_zone_discarded` | Counter | Connections completed without creating a session | `server_zone` |
-`nginxplus_stream_server_zone_received` | Counter | Bytes received from clients | `server_zone` |
-`nginxplus_stream_server_zone_sent` | Counter | Bytes sent to clients | `server_zone` |
-
-#### [HTTP Upstreams](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_upstream)
-
-> Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` = `1.0`, `"draining"` = `2.0`, `"down"` = `3.0`, `"unavail"` = `4.0`, `"checking"` = `5.0`, `"unhealthy"` = `6.0`.
-
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_upstream_server_state` | Gauge | Current state | `server`, `upstream` |
-`nginxplus_upstream_server_active` | Gauge | Active connections | `server`, `upstream` |
-`nginxplus_upstream_server_limit` | Gauge | Limit for connections which corresponds to the max_conns parameter of the upstream server. Zero value means there is no limit | `server`, `upstream` |
-`nginxplus_upstream_server_requests` | Counter | Total client requests | `server`, `upstream` |
-`nginxplus_upstream_server_responses` | Counter | Total responses sent to clients | `code` (the response status code. The values are: `1xx`, `2xx`, `3xx`, `4xx` and `5xx`), `server`, `upstream` |
-`nginxplus_upstream_server_sent` | Counter | Bytes sent to this server | `server`, `upstream` |
-`nginxplus_upstream_server_received` | Counter | Bytes received to this server | `server`, `upstream` |
-`nginxplus_upstream_server_fails` | Counter | Number of unsuccessful attempts to communicate with the server | `server`, `upstream` |
-`nginxplus_upstream_server_unavail` | Counter | How many times the server became unavailable for client requests (state 'unavail') due to the number of unsuccessful attempts reaching the max_fails threshold | `server`, `upstream` |
-`nginxplus_upstream_server_header_time` | Gauge | Average time to get the response header from the server | `server`, `upstream` |
-`nginxplus_upstream_server_response_time` | Gauge | Average time to get the full response from the server | `server`, `upstream` |
-`nginxplus_upstream_keepalives` | Gauge | Idle keepalive connections | `upstream` |
-`nginxplus_upstream_zombies` | Gauge | Servers removed from the group but still processing active client requests | `upstream` |
-
-#### [Stream Upstreams](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_upstream)
-
-> Note: for the `state` metric, the string values are converted to float64 using the
-> following rule: `"up"` = `1.0`, `"down"` = `3.0`, `"unavail"` = `4.0`,
-> `"checking"` = `5.0`, `"unhealthy"` = `6.0`.
-
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_stream_upstream_server_state` | Gauge | Current state | `server`, `upstream` |
-`nginxplus_stream_upstream_server_active` | Gauge | Active connections | `server` , `upstream` |
-`nginxplus_stream_upstream_server_limit` | Gauge | Limit for connections which corresponds to the max_conns parameter of the upstream server. Zero value means there is no limit | `server` , `upstream` |
-`nginxplus_stream_upstream_server_connections` | Counter | Total number of client connections forwarded to this server | `server`, `upstream` |
-`nginxplus_stream_upstream_server_connect_time` | Gauge | Average time to connect to the upstream server | `server`, `upstream`
-`nginxplus_stream_upstream_server_first_byte_time` | Gauge | Average time to receive the first byte of data | `server`, `upstream` |
-`nginxplus_stream_upstream_server_response_time` | Gauge | Average time to receive the last byte of data | `server`, `upstream` |
-`nginxplus_stream_upstream_server_sent` | Counter | Bytes sent to this server | `server`, `upstream` |
-`nginxplus_stream_upstream_server_received` | Counter | Bytes received from this server | `server`, `upstream` |
-`nginxplus_stream_upstream_server_fails` | Counter | Number of unsuccessful attempts to communicate with the server | `server`, `upstream` |
-`nginxplus_stream_upstream_server_unavail` | Counter | How many times the server became unavailable for client connections (state 'unavail') due to the number of unsuccessful attempts reaching the max_fails threshold | `server`, `upstream` |
-`nginxplus_stream_upstream_zombies` | Gauge | Servers removed from the group but still processing active client connections | `upstream`|
-
-#### [Location Zones](https://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_location_zone)
-Name | Type | Description | Labels
-----|----|----|----|
-`nginxplus_location_zone_requests` | Counter | Total client requests | `location_zone` |
-`nginxplus_location_zone_responses` | Counter | Total responses sent to clients | `code` (the response status code. The values are: `1xx`, `2xx`, `3xx`, `4xx` and `5xx`), `location_zone` |
-`nginxplus_location_zone_discarded` | Counter | Requests completed without sending a response | `location_zone` |
-`nginxplus_location_zone_received` | Counter | Bytes received from clients | `location_zone` |
-`nginxplus_location_zone_sent` | Counter | Bytes sent to clients | `location_zone` |
+For a list of available metrics, see the [NGINX Prometheus Exporter metrics documentation](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/README.md) on GitHub.

--- a/vale-styles/FluentBit/Acronyms.yml
+++ b/vale-styles/FluentBit/Acronyms.yml
@@ -53,6 +53,7 @@ exceptions:
   - LLVM
   - LTS
   - NET
+  - NGINX
   - NOTE
   - NVDA
   - OSS

--- a/vale-styles/FluentBit/Spelling-exceptions.txt
+++ b/vale-styles/FluentBit/Spelling-exceptions.txt
@@ -115,6 +115,7 @@ namespace
 namespaces
 netcat
 Nginx
+NGINX
 OAuth
 Okta
 Oniguruma


### PR DESCRIPTION
Updating selected page for style and consistency. Removed copied metrics, and referred to the source. Copying these metrics wholesale isn't necessary when the source of truth is the metrics documentation. Also, it's ethically sketchy to directly copy that work.
