### PR TITLE
Fixed missing opening curly brackets on tabs construct in the multiline parsing doc. Fixes reopened #1757.

### DIFF
--- a/administration/configuring-fluent-bit/multiline-parsing.md
+++ b/administration/configuring-fluent-bit/multiline-parsing.md
@@ -282,7 +282,7 @@ The following example retrieves `date` and `message` from concatenated logs.
 
 Example files content:
 
-% tabs %}
+{% tabs %}
 
 {% tab title="fluent-bit.yaml" %}
 


### PR DESCRIPTION
Fixed missing opening curly brackets on tabs construct in the multiline parsing doc. Fixes reopened #1757.