### PR TITLE
Adding YAML examples to developers wasm filter plugin docs. Fixes #1768.

### DIFF
--- a/development/wasm-filter-plugins.md
+++ b/development/wasm-filter-plugins.md
@@ -114,6 +114,7 @@ pipeline:
         match: 'dummy.*'
         wasm_path: /path/to/built_filter.wasm
         function_name: super_awesome_filter
+        # Note: run Fluent Bit from the 'wasm_path' location.
         accessible_paths: /path/to/fluent-bit
         
     outputs:


### PR DESCRIPTION
Adding YAML examples to developers wasm filter plugin docs. Fixes #1768.