### PR TITLE
Adding YAML examples to input plugin collectd doc page. Fixes #1778.

### DIFF
--- a/pipeline/inputs/collectd.md
+++ b/pipeline/inputs/collectd.md
@@ -48,6 +48,9 @@ pipeline:
     Match  *
 ```
 
+{% endtab %}
+{% endtabs %}
+
 With this configuration, Fluent Bit listens to `0.0.0.0:25826`, and outputs incoming datagram packets to `stdout`.
 
 You must set the same `types.db` files that your `collectd` server uses. Otherwise, Fluent Bit might not be able to interpret the payload properly.


### PR DESCRIPTION
Adding YAML examples to input plugin collectd doc page. Fixes #1778.