### PR TITLE
Fixing layout and standardizing on YAML configuration for input plugin Fluent Bit Metrics docs. Fixes #1800.

### DIFF
--- a/pipeline/inputs/fluentbit-metrics.md
+++ b/pipeline/inputs/fluentbit-metrics.md
@@ -4,13 +4,13 @@ description:  A plugin to collect Fluent Bit metrics
 
 # Fluent Bit metrics
 
-Fluent Bit exposes [metrics](../../administration/monitoring.md) to let you monitor the internals of your pipeline.
-The collected metrics can be processed similarly to those from the [Prometheus Node Exporter input plugin](node-exporter-metrics.md).
-They can be sent to output plugins including [Prometheus Exporter](../outputs/prometheus-exporter.md), [Prometheus Remote Write](../outputs/prometheus-remote-write.md) or [OpenTelemetry](../outputs/opentelemetry.md)..
+Fluent Bit exposes [metrics](../../administration/monitoring.md) to let you monitor the internals of your pipeline. The collected metrics can be processed similarly to those from the [Prometheus Node Exporter input plugin](node-exporter-metrics.md). They can be sent to output plugins including [Prometheus Exporter](../outputs/prometheus-exporter.md), [Prometheus Remote Write](../outputs/prometheus-remote-write.md) or [OpenTelemetry](../outputs/opentelemetry.md).
 
 {% hint style="info" %}
+
 Metrics collected with Node Exporter Metrics flow through a separate pipeline from logs and current filters don't operate on top of metrics.
-{ % endhint % }
+
+{% endhint %}
 
 ## Configuration
 
@@ -27,9 +27,30 @@ Metrics collected with Node Exporter Metrics flow through a separate pipeline fr
 In the following configuration file, the input plugin `node_exporter_metrics` collects metrics every `2` seconds and exposes them through the [Prometheus Exporter](../outputs/prometheus-exporter.md) output plugin on HTTP/TCP port `2021`.
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+service:
+    flush: 1
+    log_level: info
+    
+pipeline:
+    inputs:
+        - name: fluentbit_metrics
+          tag: internal_metrics
+          scrape_interval: 2
+
+    outputs:
+        - name: prometheus_exporter
+          match: internal_metrics
+          host: 0.0.0.0
+          port: 2021
+```
+
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
 
-```python
+```text
 # Fluent Bit Metrics + Prometheus Exporter
 # -------------------------------------------
 # The following example collects Fluent Bit metrics and exposes
@@ -57,31 +78,10 @@ In the following configuration file, the input plugin `node_exporter_metrics` co
 ```
 
 {% endtab %}
-
-{% tab title="fluent-bit.yaml" %}
-
-```yaml
-service:
-    flush: 1
-    log_level: info
-pipeline:
-    inputs:
-        - name: fluentbit_metrics
-          tag: internal_metrics
-          scrape_interval: 2
-
-    outputs:
-        - name: prometheus_exporter
-          match: internal_metrics
-          host: 0.0.0.0
-          port: 2021
-```
-
-{% endtab %}
 {% endtabs %}
 
 You can test the expose of the metrics by using `curl`:
 
-```bash
-curl http://127.0.0.1:2021/metrics
+```shell
+$ curl http://127.0.0.1:2021/metrics
 ```


### PR DESCRIPTION
Fixing layout and standardizing on YAML configuration for input plugin Fluent Bit Metrics docs. Fixes #1800.
 
- standardize shell command layouts
- fix tab ordering with YAML first.
- classic config in text not python formatting blocks