### PR TITLE
pipeline: add note to explicit the limitation of conditional processing by using filter as processor

### DIFF
--- a/pipeline/processors/conditional-processing.md
+++ b/pipeline/processors/conditional-processing.md
@@ -13,7 +13,8 @@ You can turn a standard processor into a conditional processor by adding a
 `condition` block to the processor's YAML configuration settings.
 
 {% hint style="info" %}
-Conditional processing is only available for [YAML configuration files](../../administration/configuring-fluent-bit/yaml/README.md), not [classic configuration files](../../administration/configuring-fluent-bit/classic-mode/README.md).
+- Conditional processing is only available for [YAML configuration files](../../administration/configuring-fluent-bit/yaml/README.md), not [classic configuration files](../../administration/configuring-fluent-bit/classic-mode/README.md).
+- Conditional Processing feature is not supported when using [Filter as Processor](./filters.md).
 {% endhint %}
 
 


### PR DESCRIPTION
The [Conditional Processing](https://docs.fluentbit.io/manual/pipeline/processors/conditional-processing) feature does not work with [Filter as Processor](https://docs.fluentbit.io/manual/pipeline/processors/filters). This is not clearly mentioned in the documentation, which can be confusing for users who expect conditional rules to apply to [Filters](https://docs.fluentbit.io/manual/pipeline/filters) like [Lua](https://docs.fluentbit.io/manual/pipeline/filters/lua) and [Modify](https://docs.fluentbit.io/manual/pipeline/filters/modify) when used as processors.

I reported this limitation in the [fluent-bit GitHub repo](https://github.com/fluent/fluent-bit/issues/10524), including configuration examples and steps to reproduce the issue. Until this feature is supported, the documentation should clarify this gap.

> more details:
> - https://github.com/fluent/fluent-bit/issues/10524