### PR TITLE
Fixed text standardization for classic config in OTel input plugin.

### DIFF
--- a/pipeline/inputs/opentelemetry.md
+++ b/pipeline/inputs/opentelemetry.md
@@ -80,7 +80,7 @@ pipeline:
 {% endtab %}
 {% tab title="fluent-bit.conf" %}
 
-```python
+```text
 [INPUT]
     name opentelemetry
     listen 127.0.0.1


### PR DESCRIPTION
Fixed text standardization for classic config in OTel input plugin. Fixed one I missed in original issue #1845.