### PR TITLE
Fix to remove extra line in YAML config nginx input plugin docs. Part of fix for issue #1830.

### DIFF
--- a/pipeline/inputs/nginx.md
+++ b/pipeline/inputs/nginx.md
@@ -87,8 +87,7 @@ pipeline:
           host: 127.0.0.1
           port: 80
           status_URL: /status
-          
-          
+           
     outputs:
         - name: stdout
           match: '*'


### PR DESCRIPTION
Fix to remove extra line in YAML config nginx input plugin docs. Part of fix for issue #1830. Removed an extra line feed in YAML example.