### PR TITLE
Fixing shell usage and YAML config for random input plugin docs. Fixes #1854.

### DIFF
--- a/pipeline/inputs/random.md
+++ b/pipeline/inputs/random.md
@@ -21,17 +21,34 @@ In order to start generating random samples, you can run the plugin from the com
 
 From the command line you can let Fluent Bit generate the samples with the following options:
 
-```bash
+```shell
 $ fluent-bit -i random -o stdout
 ```
 
 ### Configuration File
 
-In your main configuration file append the following _Input_ & _Output_ sections:
+In your main configuration file append the following:
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+        - name: random
+          samples: -1
+          interval_sec: 1
+          interval_nsec: 0
+
+    outputs:
+        - name: stdout
+          match: '*'
+```
+
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
-```python
+
+```text
 [INPUT]
     Name          random
     Samples      -1
@@ -42,37 +59,40 @@ In your main configuration file append the following _Input_ & _Output_ sections
     Name   stdout
     Match  *
 ```
-{% endtab %}
 
-{% tab title="fluent-bit.yaml" %}
-```yaml
-pipeline:
-    inputs:
-        - name: random
-          samples: -1
-          interval_sec: 1
-          interval_nsec: 0
-    outputs:
-        - name: stdout
-          match: '*'
-```
 {% endtab %}
 {% endtabs %}
-
 
 ## Testing
 
 Once Fluent Bit is running, you will see the reports in the output interface similar to this:
 
-```bash
+```shell
 $ fluent-bit -i random -o stdout
-Fluent Bit v1.x.x
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
+
+Fluent Bit v4.0.3
+* Copyright (C) 2015-2025 The Fluent Bit Authors
 * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
 * https://fluentbit.io
 
-[2016/10/07 20:27:34] [ info] [engine] started
+______ _                  _    ______ _ _             ___  _____
+|  ___| |                | |   | ___ (_) |           /   ||  _  |
+| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
+|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
+| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
+\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/
+
+
+[2025/07/01 14:44:47] [ info] [fluent bit] version=4.0.3, commit=f5f5f3c17d, pid=1
+[2025/07/01 14:44:47] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/07/01 14:44:47] [ info] [simd    ] disabled
+[2025/07/01 14:44:47] [ info] [cmetrics] version=1.0.3
+[2025/07/01 14:44:47] [ info] [ctraces ] version=0.6.6
+[2025/07/01 14:44:47] [ info] [input:mem:mem.0] initializing
+[2025/07/01 14:44:47] [ info] [input:mem:mem.0] storage_strategy='memory' (memory only)
+[2025/07/01 14:44:47] [ info] [sp] stream processor started
+[2025/07/01 14:44:47] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
+[2025/07/01 14:44:47] [ info] [output:stdout:stdout.0] worker #0 started
 [0] random.0: [1475893654, {"rand_value"=>1863375102915681408}]
 [1] random.0: [1475893655, {"rand_value"=>425675645790600970}]
 [2] random.0: [1475893656, {"rand_value"=>7580417447354808203}]


### PR DESCRIPTION
Fixing shell usage and YAML config for random input plugin docs. Fixes #1854.

- standardize shell command layouts
- classic config in text not python formatting blocks