### PR TITLE
sqllite typo in windows-event-log-winevtlog example config

### DIFF
--- a/pipeline/inputs/windows-event-log-winevtlog.md
+++ b/pipeline/inputs/windows-event-log-winevtlog.md
@@ -42,7 +42,7 @@ pipeline:
       - name: winevtlog
         channels: Setup,Windows PowerShell
         interval_sec: 1
-        db: winevtlog.sqllite
+        db: winevtlog.sqlite
     outputs:
       - name: stdout
         match: '*'


### PR DESCRIPTION
As far as I can find it was the only place where it's spelled like this