### PR TITLE
Fixing error in YAML examples for multiline parsing yaml doc.

### DIFF
--- a/administration/configuring-fluent-bit/multiline-parsing.md
+++ b/administration/configuring-fluent-bit/multiline-parsing.md
@@ -189,9 +189,10 @@ multiline_parsers:
       rules:
         - state: start_state
           regex: '/([a-zA-Z]+ \d+ \d+\:\d+\:\d+)(.*)/'
-          next_state:  cont
+          next_state: cont
         - state: cont
           regex: '/^\s+at.*/'
+          next_state: cont
 ```
 
 


### PR DESCRIPTION
Fixing error in YAML examples for multiline parsing yaml doc.

Was missing a rule attribute.