### PR TITLE
Added all missing YAML examples an standardized Filters docs. Fixes #1882.

### DIFF
--- a/pipeline/filters/checklist.md
+++ b/pipeline/filters/checklist.md
@@ -17,7 +17,37 @@ The plugin supports the following configuration parameters
 
 ## Example configuration
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+        - name: tail
+          tag: test1
+          path: test1.log
+          read_from_head: true
+          parser: json
+    
+    filters:
+        - name: checklist
+          match: test1
+          file: ip_list.txt
+          lookup_key: $remote_addr
+          record:
+              - ioc abc
+              - badurl null
+          log_level: debug
+    
+    outputs:
+        - name: stdout
+          match: test1
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
     name           tail
     tag            test1
@@ -38,6 +68,9 @@ The plugin supports the following configuration parameters
     name       stdout
     match      test1
 ```
+
+{% endtab %}
+{% endtabs %}
 
 The following configuration reads a file `test1.log` that includes the following values:
 

--- a/pipeline/filters/modify.md
+++ b/pipeline/filters/modify.md
@@ -94,49 +94,24 @@ which outputs data similar to the following:
 
 Using the command line mode requires quotes parse the wildcard properly. The use of a configuration file is recommended.
 
-```text
-bin/fluent-bit -i mem \
-  -p 'tag=mem.local' \
-  -F modify \
-  -p 'Add=Service1 SOMEVALUE' \
-  -p 'Add=Service2 SOMEVALUE3' \
-  -p 'Add=Mem.total2 TOTALMEM2' \
-  -p 'Rename=Mem.free MEMFREE' \
-  -p 'Rename=Mem.used MEMUSED' \
-  -p 'Rename=Swap.total SWAPTOTAL' \
-  -p 'Add=Mem.total TOTALMEM' \
-  -m '*' \
-  -o stdout
+```shell
+$ ./fluent-bit -i mem \
+              -p 'tag=mem.local' \
+              -F modify \
+              -p 'Add=Service1 SOMEVALUE' \
+              -p 'Add=Service2 SOMEVALUE3' \
+              -p 'Add=Mem.total2 TOTALMEM2' \
+              -p 'Rename=Mem.free MEMFREE' \
+              -p 'Rename=Mem.used MEMUSED' \
+              -p 'Rename=Swap.total SWAPTOTAL' \
+              -p 'Add=Mem.total TOTALMEM' \
+              -m '*' \
+              -o stdout
 ```
 
 ### Configuration file
 
 {% tabs %}
-{% tab title="fluent-bit.conf" %}
-
-```python
-[INPUT]
-    Name mem
-    Tag  mem.local
-
-[OUTPUT]
-    Name  stdout
-    Match *
-
-[FILTER]
-    Name modify
-    Match *
-    Add Service1 SOMEVALUE
-    Add Service3 SOMEVALUE3
-    Add Mem.total2 TOTALMEM2
-    Rename Mem.free MEMFREE
-    Rename Mem.used MEMUSED
-    Rename Swap.total SWAPTOTAL
-    Add Mem.total TOTALMEM
-```
-
-{% endtab %}
-
 {% tab title="fluent-bit.yaml" %}
 
 ```yaml
@@ -144,6 +119,7 @@ pipeline:
     inputs:
         - name: mem
           tag: mem.local
+
     filters:
         - name: modify
           match: '*'
@@ -156,9 +132,34 @@ pipeline:
             - Mem.free MEMFREE
             - Mem.used MEMUSED
             - Swap.total SWAPTOTAL
+
     outputs:
         - name: stdout
           match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+    Name mem
+    Tag  mem.local
+
+[FILTER]
+    Name modify
+    Match *
+    Add Service1 SOMEVALUE
+    Add Service3 SOMEVALUE3
+    Add Mem.total2 TOTALMEM2
+    Rename Mem.free MEMFREE
+    Rename Mem.used MEMUSED
+    Rename Swap.total SWAPTOTAL
+    Add Mem.total TOTALMEM
+
+[OUTPUT]
+    Name  stdout
+    Match *
 ```
 
 {% endtab %}
@@ -181,48 +182,6 @@ The output of both the command line and configuration invocations should be iden
 ### Use a configuration file
 
 {% tabs %}
-{% tab title="fluent-bit.conf" %}
-
-```python
-[INPUT]
-    Name mem
-    Tag  mem.local
-    Interval_Sec 1
-
-[FILTER]
-    Name    modify
-    Match   mem.*
-
-    Condition Key_Does_Not_Exist cpustats
-    Condition Key_Exists Mem.used
-
-    Set cpustats UNKNOWN
-
-[FILTER]
-    Name    modify
-    Match   mem.*
-
-    Condition Key_Value_Does_Not_Equal cpustats KNOWN
-
-    Add sourcetype memstats
-
-[FILTER]
-    Name    modify
-    Match   mem.*
-
-    Condition Key_Value_Equals cpustats UNKNOWN
-
-    Remove_wildcard Mem
-    Remove_wildcard Swap
-    Add cpustats_more STILL_UNKNOWN
-
-[OUTPUT]
-    Name           stdout
-    Match          *
-```
-
-{% endtab %}
-
 {% tab title="fluent-bit.yaml" %}
 
 ```yaml
@@ -231,27 +190,66 @@ pipeline:
         - name: mem
           tag: mem.local
           interval_sec: 1
+
     filters:
         - name: modify
           match: mem.*
           Condition:
-            - Key_Does_Not_Exist cpustats
-            - Key_Exists Mem.used
+              - Key_Does_Not_Exist cpustats
+              - Key_Exists Mem.used
           Set: cpustats UNKNOWN
+
         - name: modify
           match: mem.*
           Condition: Key_Value_Does_Not_Equal cpustats KNOWN
           Add: sourcetype memstats
+
         - name: modify
           match: mem.*
           Condition: Key_Value_Equals cpustats UNKNOWN
           Remove_wildcard:
-            - Mem
-            - Swap
+              - Mem
+              - Swap
           Add: cpustats_more STILL_UNKNOWN
+    
     outputs:
         - name: stdout
           match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+    Name mem
+    Tag  mem.local
+    Interval_Sec 1
+
+[FILTER]
+    Name    modify
+    Match   mem.*
+    Condition Key_Does_Not_Exist cpustats
+    Condition Key_Exists Mem.used
+    Set cpustats UNKNOWN
+
+[FILTER]
+    Name    modify
+    Match   mem.*
+    Condition Key_Value_Does_Not_Equal cpustats KNOWN
+    Add sourcetype memstats
+
+[FILTER]
+    Name    modify
+    Match   mem.*
+    Condition Key_Value_Equals cpustats UNKNOWN
+    Remove_wildcard Mem
+    Remove_wildcard Swap
+    Add cpustats_more STILL_UNKNOWN
+
+[OUTPUT]
+    Name           stdout
+    Match          *
 ```
 
 {% endtab %}
@@ -272,33 +270,6 @@ pipeline:
 ### Emoji configuration File
 
 {% tabs %}
-{% tab title="fluent-bit.conf" %}
-
-```python
-[INPUT]
-    Name mem
-    Tag  mem.local
-
-[OUTPUT]
-    Name  stdout
-    Match *
-
-[FILTER]
-    Name modify
-    Match *
-
-    Remove_Wildcard Mem
-    Remove_Wildcard Swap
-    Set This_plugin_is_on 🔥
-    Set 🔥 is_hot
-    Copy 🔥 💦
-    Rename  💦 ❄️
-    Set ❄️ is_cold
-    Set 💦 is_wet
-```
-
-{% endtab %}
-
 {% tab title="fluent-bit.yaml" %}
 
 ```yaml
@@ -307,23 +278,49 @@ pipeline:
         - name: mem
           tag: mem.local
           interval_sec: 1
+
     filters:
         - name: modify
           match: mem.*
           Remove_wildcard:
             - Mem
             - Swap
-          Set:
+          set:
             - This_plugin_is_on 🔥
             - 🔥 is_hot
-          Copy: 🔥 💦
-          Rename:  💦 ❄️
-          Set:
             - ❄️ is_cold
             - 💦 is_wet
+          copy: 🔥 💦
+          rename:  💦 ❄️
+          
     outputs:
         - name: stdout
           match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+    Name mem
+    Tag  mem.local
+
+[FILTER]
+    Name modify
+    Match *
+    Remove_Wildcard Mem
+    Remove_Wildcard Swap
+    Set This_plugin_is_on 🔥
+    Set 🔥 is_hot
+    Copy 🔥 💦
+    Rename  💦 ❄️
+    Set ❄️ is_cold
+    Set 💦 is_wet
+    
+[OUTPUT]
+    Name  stdout
+    Match *
 ```
 
 {% endtab %}

--- a/pipeline/filters/parser.md
+++ b/pipeline/filters/parser.md
@@ -32,7 +32,6 @@ parsers:
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
@@ -72,7 +71,6 @@ pipeline:
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
@@ -107,10 +105,11 @@ $ ./fluent-bit --config fluent-bit.yaml
 # For classic configuration.
 $ ./fluent-bit --config fluent-bit.conf
 
-Fluent Bit v4.0.0
+Fluent Bit v4.0.3
 * Copyright (C) 2015-2025 The Fluent Bit Authors
 * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
 * https://fluentbit.io
+
 ______ _                  _    ______ _ _             ___  _____
 |  ___| |                | |   | ___ (_) |           /   ||  _  |
 | |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
@@ -118,15 +117,16 @@ ______ _                  _    ______ _ _             ___  _____
 | |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
 \_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/
 
-[2025/06/19 10:58:47] [ info] [fluent bit] version=4.0.0, commit=3a91b155d6, pid=76206
-[2025/06/19 10:58:47] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
-[2025/06/19 10:58:47] [ info] [simd    ] disabled
-[2025/06/19 10:58:47] [ info] [cmetrics] version=0.9.9
-[2025/06/19 10:58:47] [ info] [ctraces ] version=0.6.2
-[2025/06/19 10:58:47] [ info] [input:dummy:dummy.0] initializing
-[2025/06/19 10:58:47] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
-[2025/06/19 10:58:47] [ info] [output:stdout:stdout.0] worker #0 started
-[2025/06/19 10:58:47] [ info] [sp] stream processor started
+
+[2025/07/03 16:15:34] [ info] [fluent bit] version=4.0.3, commit=3a91b155d6, pid=23196
+[2025/07/03 16:15:34] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/07/03 16:15:34] [ info] [simd    ] disabled
+[2025/07/03 16:15:34] [ info] [cmetrics] version=1.0.3
+[2025/07/03 16:15:34] [ info] [ctraces ] version=0.6.6
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] initializing
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
+[2025/07/03 16:15:34] [ info] [output:stdout:stdout.0] worker #0 started
+[2025/07/03 16:15:34] [ info] [sp] stream processor started
 [0] dummy.data: [[1750323528.603308000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
 [0] dummy.data: [[1750323529.603788000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
 [0] dummy.data: [[1750323530.604204000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example"}]
@@ -153,7 +153,6 @@ parsers:
 ```
 
 {% endtab %}
-
 {% tab title="parsers.conf" %}
 
 ```text
@@ -194,7 +193,6 @@ pipeline:
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
@@ -230,10 +228,11 @@ $ ./fluent-bit --config fluent-bit.yaml
 # For classic configuration.
 $ ./fluent-bit --config fluent-bit.conf
 
-Fluent Bit v4.0.0
+Fluent Bit v4.0.3
 * Copyright (C) 2015-2025 The Fluent Bit Authors
 * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
 * https://fluentbit.io
+
 ______ _                  _    ______ _ _             ___  _____
 |  ___| |                | |   | ___ (_) |           /   ||  _  |
 | |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
@@ -241,15 +240,16 @@ ______ _                  _    ______ _ _             ___  _____
 | |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
 \_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/
 
-[2025/06/19 10:58:47] [ info] [fluent bit] version=4.0.0, commit=3a91b155d6, pid=76206
-[2025/06/19 10:58:47] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
-[2025/06/19 10:58:47] [ info] [simd    ] disabled
-[2025/06/19 10:58:47] [ info] [cmetrics] version=0.9.9
-[2025/06/19 10:58:47] [ info] [ctraces ] version=0.6.2
-[2025/06/19 10:58:47] [ info] [input:dummy:dummy.0] initializing
-[2025/06/19 10:58:47] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
-[2025/06/19 10:58:47] [ info] [output:stdout:stdout.0] worker #0 started
-[2025/06/19 10:58:47] [ info] [sp] stream processor started
+
+[2025/07/03 16:15:34] [ info] [fluent bit] version=4.0.3, commit=3a91b155d6, pid=23196
+[2025/07/03 16:15:34] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/07/03 16:15:34] [ info] [simd    ] disabled
+[2025/07/03 16:15:34] [ info] [cmetrics] version=1.0.3
+[2025/07/03 16:15:34] [ info] [ctraces ] version=0.6.6
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] initializing
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
+[2025/07/03 16:15:34] [ info] [output:stdout:stdout.0] worker #0 started
+[2025/07/03 16:15:34] [ info] [sp] stream processor started
 [0] dummy.data: [[1750325238.681398000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example", "key1"=>"value1", "key2"=>"value2"}]
 [0] dummy.data: [[1750325239.682090000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example", "key1"=>"value1", "key2"=>"value2"}]
 [0] dummy.data: [[1750325240.682903000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example", "key1"=>"value1", "key2"=>"value2"}]
@@ -269,7 +269,6 @@ parsers:
 ```
 
 {% endtab %}
-
 {% tab title="parsers.conf" %}
 
 ```text
@@ -311,7 +310,6 @@ pipeline:
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
@@ -348,10 +346,11 @@ $ ./fluent-bit --config fluent-bit.yaml
 # For classic configuration.
 $ ./fluent-bit --config fluent-bit.conf
 
-Fluent Bit v4.0.0
+Fluent Bit v4.0.3
 * Copyright (C) 2015-2025 The Fluent Bit Authors
 * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
 * https://fluentbit.io
+
 ______ _                  _    ______ _ _             ___  _____
 |  ___| |                | |   | ___ (_) |           /   ||  _  |
 | |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
@@ -359,15 +358,16 @@ ______ _                  _    ______ _ _             ___  _____
 | |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
 \_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/
 
-[2025/06/19 10:58:47] [ info] [fluent bit] version=4.0.0, commit=3a91b155d6, pid=76206
-[2025/06/19 10:58:47] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
-[2025/06/19 10:58:47] [ info] [simd    ] disabled
-[2025/06/19 10:58:47] [ info] [cmetrics] version=0.9.9
-[2025/06/19 10:58:47] [ info] [ctraces ] version=0.6.2
-[2025/06/19 10:58:47] [ info] [input:dummy:dummy.0] initializing
-[2025/06/19 10:58:47] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
-[2025/06/19 10:58:47] [ info] [output:stdout:stdout.0] worker #0 started
-[2025/06/19 10:58:47] [ info] [sp] stream processor started
+
+[2025/07/03 16:15:34] [ info] [fluent bit] version=4.0.3, commit=3a91b155d6, pid=23196
+[2025/07/03 16:15:34] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/07/03 16:15:34] [ info] [simd    ] disabled
+[2025/07/03 16:15:34] [ info] [cmetrics] version=1.0.3
+[2025/07/03 16:15:34] [ info] [ctraces ] version=0.6.6
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] initializing
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
+[2025/07/03 16:15:34] [ info] [output:stdout:stdout.0] worker #0 started
+[2025/07/03 16:15:34] [ info] [sp] stream processor started
 [0] dummy.data: [[1750325678.572817000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example", "data"=>"100 0.5 true This is example", "key1"=>"value1", "key2"=>"value2"}]
 [0] dummy.data: [[1750325679.574538000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example", "data"=>"100 0.5 true This is example", "key1"=>"value1", "key2"=>"value2"}]
 [0] dummy.data: [[1750325680.569750000, {}], {"INT"=>"100", "FLOAT"=>"0.5", "BOOL"=>"true", "STRING"=>"This is example", "data"=>"100 0.5 true This is example", "key1"=>"value1", "key2"=>"value2"}]

--- a/pipeline/filters/rewrite-tag.md
+++ b/pipeline/filters/rewrite-tag.md
@@ -42,7 +42,7 @@ $KEY  REGEX  NEW_TAG  KEEP
 
 The key represents the name of the _record key_ that holds the `value` to use to match the regular expression. A key name is specified and prefixed with a `$`. Consider the following structured record (formatted for readability):
 
-```javascript
+```text
 {
   "name": "abc-123",
   "ss": {
@@ -117,9 +117,34 @@ You can use `true` or `false` to decide the expected behavior. This field is man
 The following configuration example will emit a dummy record. The filter will rewrite the tag, discard the old record, and print the new record to the standard output interface:
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+service:
+    flush: 1
+    log_level: info
+
+pipeline:
+    inputs:
+        - name: dummy
+          tag:  test_tag
+          dummy: '{"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}'
+
+    filters:
+        - name: rewrite_tag
+          match: test_tag
+          rule: $tool ^(fluent)$  from.$TAG.new.$tool.$sub['s1']['s2'].out false
+          emitter_name: re_emitted
+
+    outputs:
+        - name: stdout
+          match: from.*
+```
+
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
 
-```python
+```text
 [SERVICE]
     Flush     1
     Log_Level info
@@ -141,42 +166,35 @@ The following configuration example will emit a dummy record. The filter will re
 ```
 
 {% endtab %}
-
-{% tab title="fluent-bit.yaml" %}
-
-```yaml
-service:
-    flush: 1
-    log_level: info
-pipeline:
-    inputs:
-        - name: dummy
-          tag:  test_tag
-          dummy: '{"tool": "fluent", "sub": {"s1": {"s2": "bit"}}}'
-    filters:
-        - name: rewrite_tag
-          match: test_tag
-          rule: $tool ^(fluent)$  from.$TAG.new.$tool.$sub['s1']['s2'].out false
-          emitter_name: re_emitted
-    outputs:
-        - name: stdout
-          match: from.*
-```
-
-{% endtab %}
 {% endtabs %}
 
 The original tag `test_tag` will be rewritten as `from.test_tag.new.fluent.bit.out`:
 
-```bash
-$ bin/fluent-bit -c example.conf
-Fluent Bit v1.x.x
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
+```shell
+$ ./fluent-bit -c example.conf
+
+Fluent Bit v4.0.3
+* Copyright (C) 2015-2025 The Fluent Bit Authors
 * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
 * https://fluentbit.io
 
-...
+______ _                  _    ______ _ _             ___  _____
+|  ___| |                | |   | ___ (_) |           /   ||  _  |
+| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
+|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
+| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
+\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/
+
+
+[2025/07/03 16:15:34] [ info] [fluent bit] version=4.0.3, commit=3a91b155d6, pid=23196
+[2025/07/03 16:15:34] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/07/03 16:15:34] [ info] [simd    ] disabled
+[2025/07/03 16:15:34] [ info] [cmetrics] version=1.0.3
+[2025/07/03 16:15:34] [ info] [ctraces ] version=0.6.6
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] initializing
+[2025/07/03 16:15:34] [ info] [input:dummy:dummy.0] storage_strategy='memory' (memory only)
+[2025/07/03 16:15:34] [ info] [output:stdout:stdout.0] worker #0 started
+[2025/07/03 16:15:34] [ info] [sp] stream processor started
 [0] from.test_tag.new.fluent.bit.out: [1580436933.000050569, {"tool"=>"fluent", "sub"=>{"s1"=>{"s2"=>"bit"}}}]
 ```
 
@@ -190,13 +208,13 @@ The `rewrite_tag` filter emits new records that go through the beginning of the 
 
 Using the previously provided configuration, when you query the metrics exposed in the HTTP interface:
 
-```bash
-curl  http://127.0.0.1:2020/api/v1/metrics/ | jq
+```shell
+$ ./curl  http://127.0.0.1:2020/api/v1/metrics/ | jq
 ```
 
 You will see metrics output similar to the following:
 
-```javascript
+```text
 {
   "input": {
     "dummy.0": {

--- a/pipeline/filters/sysinfo.md
+++ b/pipeline/filters/sysinfo.md
@@ -23,9 +23,29 @@ To start filtering records, you can run the filter from the command line or thro
 The following configuration file is to append the Fluent Bit version and operating system name.
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+        - name: dummy
+          tag: test
+
+    filters:
+        - name: sysinfo
+          match: '*'
+          Fluentbit_version_key: flb_ver
+          Os_name_key: os_name
+
+    outputs:
+        - name: stdout
+          match: '*'
+```
+
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
 
-```python
+```text
 [INPUT]
     Name dummy
     Tag test
@@ -42,31 +62,12 @@ The following configuration file is to append the Fluent Bit version and operati
 ```
 
 {% endtab %}
-
-{% tab title="fluent-bit.yaml" %}
-
-```yaml
-pipeline:
-    inputs:
-        - name: dummy
-          tag: test
-    filters:
-        - name: sysinfo
-          match: '*'
-          Fluentbit_version_key: flb_ver
-          Os_name_key: os_name
-    outputs:
-        - name: stdout
-          match: '*'
-```
-
-{% endtab %}
 {% endtabs %}
 
 You can also run the filter from command line.
 
 ```shell
-fluent-bit -i dummy -o stdout -F sysinfo -m '*' -p fluentbit_version_key=flb_ver -p os_name_key=os_name
+$ ./fluent-bit -i dummy -o stdout -F sysinfo -m '*' -p fluentbit_version_key=flb_ver -p os_name_key=os_name
 ```
 
 The output will be something like the following:

--- a/pipeline/filters/type-converter.md
+++ b/pipeline/filters/type-converter.md
@@ -38,9 +38,30 @@ The plugin outputs `uint` values and `filter_type_converter` converts them into 
 ### Convert `uint` to string
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+        - name: mem
+    
+    filters:
+        - name: type_converter
+          match: '*'
+          uint_key:
+            - Mem.total Mem.total_str string
+            - Mem.used  Mem.used_str  string
+            - Mem.free  Mem.free_str  string
+    
+    outputs:
+        - name: stdout
+          match: '*'
+```
+
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
 
-```python
+```text
 [INPUT]
     Name mem
 
@@ -57,36 +78,16 @@ The plugin outputs `uint` values and `filter_type_converter` converts them into 
 ```
 
 {% endtab %}
-
-{% tab title="fluent-bit.yaml" %}
-
-```yaml
-pipeline:
-    inputs:
-        - name: mem
-    filters:
-        - name: type_converter
-          match: '*'
-          uint_key:
-            - Mem.total Mem.total_str string
-            - Mem.used  Mem.used_str  string
-            - Mem.free  Mem.free_str  string
-    outputs:
-        - name: stdout
-          match: '*'
-```
-
-{% endtab %}
 {% endtabs %}
 
 You can also run the filter from command line.
 
 ```shell
-fluent-bit -i mem -o stdout -F type_converter -p 'uint_key=Mem.total Mem.total_str string' -p 'uint_key=Mem.used Mem.used_str string' -p 'uint_key=Mem.free Mem.free_str string' -m '*'
+$ ./fluent-bit -i mem -o stdout -F type_converter -p 'uint_key=Mem.total Mem.total_str string' -p 'uint_key=Mem.used Mem.used_str string' -p 'uint_key=Mem.free Mem.free_str string' -m '*'
 ```
 
 The output will be
 
-```python
+```text
 [0] mem.0: [1639915154.160159749, {"Mem.total"=>8146052, "Mem.used"=>4513564, "Mem.free"=>3632488, "Swap.total"=>1918356, "Swap.used"=>0, "Swap.free"=>1918356, "Mem.total_str"=>"8146052", "Mem.used_str"=>"4513564", "Mem.free_str"=>"3632488"}]
 ```

--- a/pipeline/filters/wasm.md
+++ b/pipeline/filters/wasm.md
@@ -29,7 +29,33 @@ The plugin supports the following configuration parameters:
 
 Here is a configuration example.
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+        - name: dummy
+          tag: dummy.local
+
+    filters:
+        - name: wasm
+          match: 'dummy.*'
+          event_format: json    # or msgpack
+          wasm_path: /path/to/wasm_program.wasm
+          function_name: filter_function_name
+          # Note: run Fluent Bit from the 'wasm_path' location.
+          accessible_paths: /path/to/accessible
+        
+    outputs:
+        - name: stdout
+          match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
     Name   dummy
     Tag    dummy.local
@@ -46,3 +72,6 @@ Here is a configuration example.
     Name   stdout
     Match  *
 ```
+
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
Update the [filter docs](https://docs.fluentbit.io/manual/pipeline/filters) with YAML configuration examples, specifically the second half of the list:

[Checklist](https://docs.fluentbit.io/manual/pipeline/filters/checklist)
[Grep](https://docs.fluentbit.io/manual/pipeline/filters/grep)
[Log to Metrics](https://docs.fluentbit.io/manual/pipeline/filters/log_to_metrics)
[Parser](https://docs.fluentbit.io/manual/pipeline/filters/parser)
[Modify](https://docs.fluentbit.io/manual/pipeline/filters/modify)
[Nest](https://docs.fluentbit.io/manual/pipeline/filters/nest)
[Rewrite Tag](https://docs.fluentbit.io/manual/pipeline/filters/rewrite-tag)
[Sysinfo](https://docs.fluentbit.io/manual/pipeline/filters/sysinfo)
[Type converter](https://docs.fluentbit.io/manual/pipeline/filters/type-converter)
[WASAM](https://docs.fluentbit.io/manual/pipeline/filters/wasm)