### PR TITLE
Update the Amazon output plugin docs with YAML configuration examples. Fixes #1890.

### DIFF
--- a/pipeline/outputs/firehose.md
+++ b/pipeline/outputs/firehose.md
@@ -4,8 +4,6 @@ description: Send logs to Amazon Kinesis Firehose
 
 # Amazon Kinesis Data Firehose
 
-![](../../.gitbook/assets/image%20%288%29.png)
-
 The Amazon Kinesis Data Firehose output plugin allows to ingest your records into the [Firehose](https://aws.amazon.com/kinesis/data-firehose/) service.
 
 This is the documentation for the core Fluent Bit Firehose plugin written in C. It can replace the [aws/amazon-kinesis-firehose-for-fluent-bit](https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit) Golang Fluent Bit plugin released last year. The Golang plugin was named `firehose`; this new high performance and highly efficient firehose plugin is called `kinesis_firehose` to prevent conflicts/confusion.
@@ -38,13 +36,29 @@ In order to send records into Amazon Kinesis Data Firehose, you can run the plug
 
 The **firehose** plugin, can read the parameters from the command line through the **-p** argument \(property\), e.g:
 
-```text
+```shell
 fluent-bit -i cpu -o kinesis_firehose -p delivery_stream=my-stream -p region=us-west-2 -m '*' -f 1
 ```
 
 ### Configuration File
 
-In your main configuration file append the following _Output_ section:
+In your main configuration file append the following:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: kinesis_firehose
+          match: '*'
+          region: us-east-1
+          delivery_stream: my-stream
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
@@ -54,11 +68,14 @@ In your main configuration file append the following _Output_ section:
     delivery_stream my-stream
 ```
 
+{% endtab %}
+{% endtabs %}
+
 ### Permissions
 
 The following AWS IAM permissions are required to use this plugin:
 
-```
+```json
 {
 	"Version": "2012-10-17",
 	"Statement": [{
@@ -77,6 +94,23 @@ Fluent Bit 1.7 adds a new feature called `workers` which enables outputs to have
 
 Example:
 
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: kinesis_firehose
+          match: '*'
+          region: us-east-1
+          delivery_stream: my-stream
+          workers: 2
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
 ```text
 [OUTPUT]
     Name  kinesis_firehose
@@ -86,7 +120,14 @@ Example:
     workers 2
 ```
 
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+
 If you enable a single worker, you are enabling a dedicated thread for your Firehose output. We recommend starting with without workers, evaluating the performance, and then adding workers one at a time until you reach your desired/needed throughput. For most users, no workers or a single worker will be sufficient.
+
+{% endhint %}
 
 ### AWS for Fluent Bit
 
@@ -102,19 +143,19 @@ Amazon distributes a container image with Fluent Bit and these plugins.
 
 Our images are available in Amazon ECR Public Gallery. You can download images with different tags by following command:
 
-```text
+```shell
 docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:<tag>
 ```
 
 For example, you can pull the image with latest version by:
 
-```text
+```shell
 docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
 ```
 
 If you see errors for image pull limits, try log into public ECR with your AWS credentials:
 
-```text
+```shell
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 ```
 
@@ -128,8 +169,8 @@ You can check the [Amazon ECR Public official doc](https://docs.aws.amazon.com/A
 
 You can use our SSM Public Parameters to find the Amazon ECR image URI in your region:
 
-```text
+```shell
 aws ssm get-parameters-by-path --path /aws/service/aws-for-fluent-bit/
 ```
 
-For more see [the AWS for Fluent Bit github repo](https://github.com/aws/aws-for-fluent-bit#public-images).
+For more see [the AWS for Fluent Bit GitHub repo](https://github.com/aws/aws-for-fluent-bit#public-images).

--- a/pipeline/outputs/kinesis.md
+++ b/pipeline/outputs/kinesis.md
@@ -4,8 +4,6 @@ description: Send logs to Amazon Kinesis Streams
 
 # Amazon Kinesis Data Streams
 
-![](../../.gitbook/assets/image%20%288%29.png)
-
 The Amazon Kinesis Data Streams output plugin allows to ingest your records into the [Kinesis](https://aws.amazon.com/kinesis/data-streams/) service.
 
 This is the documentation for the core Fluent Bit Kinesis plugin written in C. It has all the core features of the [aws/amazon-kinesis-streams-for-fluent-bit](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) Golang Fluent Bit plugin released in 2019. The Golang plugin was named `kinesis`; this new high performance and highly efficient kinesis plugin is called `kinesis_streams` to prevent conflicts/confusion.
@@ -40,13 +38,29 @@ In order to send records into Amazon Kinesis Data Streams, you can run the plugi
 
 The **kinesis\_streams** plugin, can read the parameters from the command line through the **-p** argument \(property\), e.g:
 
-```text
+```shell
 fluent-bit -i cpu -o kinesis_streams -p stream=my-stream -p region=us-west-2 -m '*' -f 1
 ```
 
 ### Configuration File
 
-In your main configuration file append the following _Output_ section:
+In your main configuration file append the following:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: kinesis_steams
+          match: '*'
+          region: us-east-1
+          stream: my-stream
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
@@ -56,11 +70,14 @@ In your main configuration file append the following _Output_ section:
     stream my-stream
 ```
 
+{% endtab %}
+{% endtabs %}
+
 ### Permissions
 
 The following AWS IAM permissions are required to use this plugin:
 
-```
+```json
 {
 	"Version": "2012-10-17",
 	"Statement": [{
@@ -87,19 +104,19 @@ Amazon distributes a container image with Fluent Bit and these plugins.
 
 Our images are available in Amazon ECR Public Gallery. You can download images with different tags by following command:
 
-```text
+```shell
 docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:<tag>
 ```
 
 For example, you can pull the image with latest version by:
 
-```text
+```shell
 docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
 ```
 
 If you see errors for image pull limits, try log into public ECR with your AWS credentials:
 
-```text
+```shell
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 ```
 
@@ -113,7 +130,7 @@ You can check the [Amazon ECR Public official doc](https://docs.aws.amazon.com/A
 
 You can use our SSM Public Parameters to find the Amazon ECR image URI in your region:
 
-```text
+```shell
 aws ssm get-parameters-by-path --path /aws/service/aws-for-fluent-bit/
 ```
 

--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -29,11 +29,13 @@ See [AWS
 Credentials](https://github.com/fluent/fluent-bit-docs/tree/43c4fe134611da471e706b0edb2f9acd7cdfdbc3/administration/aws-credentials.md)
 for details about fetching AWS credentials.
 
-{% hint style="info" %}
+{% hint style="warning" %}
+
 The [Prometheus success/retry/error metrics values](administration/monitoring.md)
 output by the built-in HTTP server in Fluent Bit are meaningless for S3 output. S3 has
 its own buffering and retry mechanisms. The Fluent Bit AWS S3 maintainers apologize
 for this feature gap; you can [track issue progress on GitHub](https://github.com/fluent/fluent-bit/issues/6141).
+
 {% endhint %}
 
 ## Configuration Parameters
@@ -79,7 +81,7 @@ properties available and general configuration, refer to
 
 The plugin requires the following AWS IAM permissions:
 
-```text
+```json
 {
     "Version": "2012-10-17",
     "Statement": [{
@@ -148,7 +150,26 @@ inject the tag into the S3 key using the following syntax:
 In the following example, assume the date is `January 1st, 2020 00:00:00` and the tag
 associated with the logs in question is `my_app_name-logs.prod`.
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: my-bucket
+          region: us-west-2
+          total_file_size: 250M
+          s3_key_format: '/$TAG[2]/$TAG[0]/%Y/%m/%d/%H/%M/%S/$UUID.gz'
+          s3_key_format_tag_delimiters: '.-'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [OUTPUT]
     Name  s3
     Match *
@@ -158,6 +179,9 @@ associated with the logs in question is `my_app_name-logs.prod`.
     s3_key_format                /$TAG[2]/$TAG[0]/%Y/%m/%d/%H/%M/%S/$UUID.gz
     s3_key_format_tag_delimiters .-
 ```
+
+{% endtab %}
+{% endtabs %}
 
 With the delimiters as `.` and `-`, the tag splits into parts as follows:
 
@@ -198,7 +222,27 @@ random UUID appended to it. Disabled this with `static_file_path On`.
 
 This example attempts to set a `.gz` extension without specifying `$UUID`:
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: my-bucket
+          region: us-west-2
+          total_file_size: 50M
+          use_put_object: off
+          compression: gzip
+          s3_key_format: '/$TAG/%Y/%m/%d/%H_%M_%S.gz'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [OUTPUT]
     Name  s3
     Match *
@@ -209,6 +253,9 @@ This example attempts to set a `.gz` extension without specifying `$UUID`:
     compression                  gzip
     s3_key_format                /$TAG/%Y/%m/%d/%H_%M_%S.gz
 ```
+
+{% endtab %}
+{% endtabs %}
 
 In the case where pending data is uploaded on shutdown, if the tag was `app`, the S3
 key in the S3 bucket might be:
@@ -224,7 +271,28 @@ There are two ways of disabling this behavior:
 
 - Use `static_file_path`:
 
-    ```python
+    {% tabs %}
+    {% tab title="fluent-bit.yaml" %}
+    
+    ```yaml
+    pipeline:
+              
+        outputs:
+            - name: s3
+              match: '*'
+              bucket: my-bucket
+              region: us-west-2
+              total_file_size: 50M
+              use_put_object: off
+              compression: gzip
+              s3_key_format: '/$TAG/%Y/%m/%d/%H_%M_%S.gz'
+              static_file_path: on
+    ```
+    
+    {% endtab %}
+    {% tab title="fluent-bit.conf" %}
+    
+    ```text
     [OUTPUT]
         Name  s3
         Match *
@@ -236,20 +304,46 @@ There are two ways of disabling this behavior:
         s3_key_format                /$TAG/%Y/%m/%d/%H_%M_%S.gz
         static_file_path             On
     ```
+    
+    {% endtab %}
+    {% endtabs %}
 
-- Explicitly define where the random UUID will go in the S3 key format:
+  - Explicitly define where the random UUID will go in the S3 key format:
 
-    ```python
-    [OUTPUT]
-        Name  s3
-        Match *
-        bucket                       my-bucket
-        region                       us-west-2
-        total_file_size              50M
-        use_put_object               Off
-        compression                  gzip
-        s3_key_format                /$TAG/%Y/%m/%d/%H_%M_%S/$UUID.gz
-    ```
+    {% tabs %}
+    {% tab title="fluent-bit.yaml" %}
+
+      ```yaml
+      pipeline:
+              
+          outputs:
+              - name: s3
+                match: '*'
+                bucket: my-bucket
+                region: us-west-2
+                total_file_size: 50M
+                use_put_object: off
+                compression: gzip
+                s3_key_format: '/$TAG/%Y/%m/%d/%H_%M_%S/$UUID.gz'
+      ```
+
+    {% endtab %}
+    {% tab title="fluent-bit.conf" %}
+
+      ```text
+      [OUTPUT]
+          Name  s3
+          Match *
+          bucket                       my-bucket
+          region                       us-west-2
+          total_file_size              50M
+          use_put_object               Off
+          compression                  gzip
+          s3_key_format                /$TAG/%Y/%m/%d/%H_%M_%S/$UUID.gz
+      ```
+
+    {% endtab %}
+    {% endtabs %}
 
 ## Reliability
 
@@ -285,16 +379,38 @@ in the event Fluent Bit is killed unexpectedly.
 
 The following settings are recommended for this use case:
 
-```python
-[OUTPUT]
-    Name s3
-    Match *
-    bucket your-bucket
-    region us-east-1
-    total_file_size 1M
-    upload_timeout 1m
-    use_put_object On
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: your-bucket
+          region: us-east-1
+          total_file_size: 1M
+          upload_timeout: 1m
+          use_put_object: on
 ```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[OUTPUT]
+    Name  s3
+    Match *
+    bucket             your-bucket
+    region             us-east-1
+    total_file_size    1M
+    upload_timeout     1m
+    use_put_object     On
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## S3 Multipart Uploads
 
@@ -393,13 +509,32 @@ at `localhost:9000`, and create a bucket of `your-bucket`.
 
 Example:
 
-```python
-[OUTPUT]
-   Name s3
-   Match *
-   bucket your-bucket
-   endpoint http://localhost:9000
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: your-bucket
+          endpoint: http://localhost:9000
 ```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[OUTPUT]
+    Name     s3
+    Match    *
+    bucket   your-bucket
+    endpoint http://localhost:9000
+```
+
+{% endtab %}
+{% endtabs %}
 
 The records store in the MinIO server.
 
@@ -410,13 +545,32 @@ those keys for `access-key` and `access-secret`.
 
 Example:
 
-```python
-[OUTPUT]
-   Name s3
-   Match *
-   bucket your-bucket
-   endpoint  https://storage.googleapis.com
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: your-bucket
+          endpoint: https://storage.googleapis.com
 ```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[OUTPUT]
+    Name     s3
+    Match    *
+    bucket   your-bucket
+    endpoint https://storage.googleapis.com
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## Get Started
 
@@ -427,7 +581,7 @@ through the configuration file.
 
 The S3 plugin reads parameters from the command line through the `-p` argument:
 
-```text
+```shell
 fluent-bit -i cpu -o s3 -p bucket=my-bucket -p region=us-west-2 -p -m '*' -f 1
 ```
 
@@ -435,30 +589,75 @@ fluent-bit -i cpu -o s3 -p bucket=my-bucket -p region=us-west-2 -p -m '*' -f 1
 
 In your main configuration file append the following `Output` section:
 
-```python
-[OUTPUT]
-    Name s3
-    Match *
-    bucket your-bucket
-    region us-east-1
-    store_dir /home/ec2-user/buffer
-    total_file_size 50M
-    upload_timeout 10m
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: your-bucket
+          region: us-east-1
+          store_dir: /home/ec2-user/buffer
+          total_file_size: 50M
+          upload_timeout: 10m
 ```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[OUTPUT]
+    Name            s3
+    Match           *
+    bucket          your-bucket
+    region          us-east-1
+    store_dir       /home/ec2-user/buffer
+    total_file_size 50M
+    upload_timeout  10m
+```
+
+{% endtab %}
+{% endtabs %}
 
 An example using `PutObject` instead of multipart:
 
-```python
-[OUTPUT]
-    Name s3
-    Match *
-    bucket your-bucket
-    region us-east-1
-    store_dir /home/ec2-user/buffer
-    use_put_object On
-    total_file_size 10M
-    upload_timeout 10m
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: s3
+          match: '*'
+          bucket: your-bucket
+          region: us-east-1
+          store_dir: /home/ec2-user/buffer
+          use_put_object: on
+          total_file_size: 10M
+          upload_timeout: 10m
 ```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[OUTPUT]
+    Name            s3
+    Match           *
+    bucket          your-bucket
+    region          us-east-1
+    store_dir       /home/ec2-user/buffer
+    use_put_object  On
+    total_file_size 10M
+    upload_timeout  10m
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## AWS for Fluent Bit
 
@@ -475,20 +674,20 @@ Images are available in the Amazon ECR Public Gallery as
 
 You can download images with different tags using the following command:
 
-```text
+```shell
 docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:<tag>
 ```
 
 For example, you can pull the image with latest version with:
 
-```text
+```shell
 docker pull public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
 ```
 
 If you see errors for image pull limits, try signing in to public ECR with your
 AWS credentials:
 
-```text
+```shell
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 ```
 
@@ -505,7 +704,7 @@ is also available from the Docker Hub.
 
 Use Fluent Bit SSM Public Parameters to find the Amazon ECR image URI in your region:
 
-```text
+```shell
 aws ssm get-parameters-by-path --path /aws/service/aws-for-fluent-bit/
 ```
 
@@ -523,7 +722,7 @@ default, and has a dependency on a shared version of `libarrow`.
 To use this feature, `FLB_ARROW` must be turned on at compile time. Use the following
 commands:
 
-```text
+```shell
 cd build/
 cmake -DFLB_ARROW=On ..
 cmake --build .
@@ -533,7 +732,27 @@ After being compiled, Fluent Bit can upload incoming data to S3 in Apache Arrow 
 
 For example:
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+      - name: cpu 
+        
+    outputs:
+        - name: s3
+          bucket: your-bucket-name
+          total_file_size: 1M
+          use_put_object: on
+          upload_timeout: 60s
+          compression: arrow
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
     Name cpu
 
@@ -546,8 +765,10 @@ For example:
     Compression arrow
 ```
 
-Setting `Compression` to `arrow` makes Fluent Bit convert payload into Apache Arrow
-format.
+{% endtab %}
+{% endtabs %}
+
+Setting `Compression` to `arrow` makes Fluent Bit convert payload into Apache Arrow format.
 
 Load, analyze, and process stored data using popular data
 processing tools such as Python pandas, Apache Spark and Tensorflow.


### PR DESCRIPTION
Update the [output plugin docs](https://docs.fluentbit.io/manual/pipeline/outputs) with YAML configuration examples for Amazon CloudWatch, Kinesis Data Firehouse, Kinesis Data Streams, and S3.