### PR TITLE
Added YAML examples for the output plugins listed in description. Fixes #1899.

### DIFF
--- a/pipeline/outputs/counter.md
+++ b/pipeline/outputs/counter.md
@@ -27,13 +27,13 @@ In your main configuration file append the following:
 
 ```yaml
 pipeline:
-    inputs:
-        - name: cpu
-          tag: cpu
-          
-    outputs:
-        - name: counter
-          match: '*'
+  inputs:
+    - name: cpu
+      tag: cpu
+      
+  outputs:
+    - name: counter
+      match: '*'
 ```
 
 {% endtab %}
@@ -41,12 +41,12 @@ pipeline:
 
 ```text
 [INPUT]
-    Name cpu
-    Tag  cpu
+  Name cpu
+  Tag  cpu
 
 [OUTPUT]
-    Name  counter
-    Match *
+  Name  counter
+  Match *
 ```
 
 {% endtab %}
@@ -57,28 +57,7 @@ pipeline:
 Once Fluent Bit is running, you will see the reports in the output interface similar to this:
 
 ```shell
-$ bin/fluent-bit -i cpu -o counter -f 1
-
-Fluent Bit v4.0.3
-* Copyright (C) 2015-2025 The Fluent Bit Authors
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
-
-______ _                  _    ______ _ _             ___  _____ 
-|  ___| |                | |   | ___ (_) |           /   ||  _  |
-| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
-|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
-| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
-\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 
-
-
-[2025/07/11 16:49:57] [ info] [fluent bit] version=4.0.3, commit=37b6e9eda2, pid=52469
-[2025/07/11 16:49:57] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
-[2025/07/11 16:49:57] [ info] [simd    ] disabled
-[2025/07/11 16:49:57] [ info] [cmetrics] version=1.0.3
-[2025/07/11 16:49:57] [ info] [ctraces ] version=0.6.6
-[2025/07/11 16:49:57] [ info] [sp] stream processor started
-[2025/07/11 16:49:57] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
+...
 1500484743,1 (total = 1)
 1500484744,1 (total = 2)
 1500484745,1 (total = 3)

--- a/pipeline/outputs/counter.md
+++ b/pipeline/outputs/counter.md
@@ -14,15 +14,32 @@ You can run the plugin from the command line or through the configuration file:
 
 From the command line you can let Fluent Bit count up a data with the following options:
 
-```bash
+```shell
 fluent-bit -i cpu -o counter
 ```
 
 ### Configuration File
 
-In your main configuration file append the following Input & Output sections:
+In your main configuration file append the following:
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    inputs:
+        - name: cpu
+          tag: cpu
+          
+    outputs:
+        - name: counter
+          match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
     Name cpu
     Tag  cpu
@@ -32,23 +49,39 @@ In your main configuration file append the following Input & Output sections:
     Match *
 ```
 
+{% endtab %}
+{% endtabs %}
+
 ## Testing
 
 Once Fluent Bit is running, you will see the reports in the output interface similar to this:
 
-```bash
+```shell
 $ bin/fluent-bit -i cpu -o counter -f 1
-Fluent Bit v1.x.x
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
+
+Fluent Bit v4.0.3
+* Copyright (C) 2015-2025 The Fluent Bit Authors
 * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
 * https://fluentbit.io
 
-[2017/07/19 11:19:02] [ info] [engine] started
+______ _                  _    ______ _ _             ___  _____ 
+|  ___| |                | |   | ___ (_) |           /   ||  _  |
+| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
+|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
+| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
+\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/ 
+
+
+[2025/07/11 16:49:57] [ info] [fluent bit] version=4.0.3, commit=37b6e9eda2, pid=52469
+[2025/07/11 16:49:57] [ info] [storage] ver=1.5.3, type=memory, sync=normal, checksum=off, max_chunks_up=128
+[2025/07/11 16:49:57] [ info] [simd    ] disabled
+[2025/07/11 16:49:57] [ info] [cmetrics] version=1.0.3
+[2025/07/11 16:49:57] [ info] [ctraces ] version=0.6.6
+[2025/07/11 16:49:57] [ info] [sp] stream processor started
+[2025/07/11 16:49:57] [ info] [engine] Shutdown Grace Period=5, Shutdown Input Grace Period=2
 1500484743,1 (total = 1)
 1500484744,1 (total = 2)
 1500484745,1 (total = 3)
 1500484746,1 (total = 4)
 1500484747,1 (total = 5)
 ```
-

--- a/pipeline/outputs/dash0.md
+++ b/pipeline/outputs/dash0.md
@@ -27,10 +27,27 @@ For more details about the properties available and general configuration, see [
 To get started with sending logs to Dash0:
 
 1. Get an [Auth Token](https://www.dash0.com/documentation/dash0/key-concepts/auth-tokens) from **Settings** > **Auth Tokens**.
-1. In your main Fluent Bit configuration file, append the following `Output` section:
+1. In your main Fluent Bit configuration file append the following:
 
 {% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+    
+    outputs:
+        - name: opentelemetry      
+          match: '*'
+          host: ingress.eu-west-1.aws.dash0.com
+          port: 443
+          header: Authorization Bearer {your-Auth-token-here}
+          metrics_uri: /v1/metrics
+          logs_uri: /v1/logs
+          traces_uri: /v1/traces
+```
+{% endtab %}
 {% tab title="fluent-bit.conf" %}
+
 ```text
 [OUTPUT]
    Name         opentelemetry
@@ -42,20 +59,7 @@ To get started with sending logs to Dash0:
    Logs_uri     /v1/logs
    Traces_uri   /v1/traces
 ```
-{% endtab %}
 
-{% tab title="fluent-bit.yaml" %}
-```yaml
-[OUTPUT]
-   Name:         opentelemetry
-   Match:        *
-   Host:         ingress.eu-west-1.aws.dash0.com
-   Port:         443
-   Header:       Authorization Bearer {your-Auth-token-here}
-   Metrics_uri:  /v1/metrics
-   Logs_uri:     /v1/logs
-   Traces_uri:   /v1/traces
-```
 {% endtab %}
 {% endtabs %}
 

--- a/pipeline/outputs/dash0.md
+++ b/pipeline/outputs/dash0.md
@@ -35,29 +35,29 @@ To get started with sending logs to Dash0:
 ```yaml
 pipeline:
     
-    outputs:
-        - name: opentelemetry      
-          match: '*'
-          host: ingress.eu-west-1.aws.dash0.com
-          port: 443
-          header: Authorization Bearer {your-Auth-token-here}
-          metrics_uri: /v1/metrics
-          logs_uri: /v1/logs
-          traces_uri: /v1/traces
+  outputs:
+    - name: opentelemetry      
+      match: '*'
+      host: ingress.eu-west-1.aws.dash0.com
+      port: 443
+      header: Authorization Bearer {your-Auth-token-here}
+      metrics_uri: /v1/metrics
+      logs_uri: /v1/logs
+      traces_uri: /v1/traces
 ```
 {% endtab %}
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
-   Name         opentelemetry
-   Match        *
-   Host         ingress.eu-west-1.aws.dash0.com
-   Port         443
-   Header       Authorization Bearer {your-Auth-token-here}
-   Metrics_uri  /v1/metrics
-   Logs_uri     /v1/logs
-   Traces_uri   /v1/traces
+  Name         opentelemetry
+  Match        *
+  Host         ingress.eu-west-1.aws.dash0.com
+  Port         443
+  Header       Authorization Bearer {your-Auth-token-here}
+  Metrics_uri  /v1/metrics
+  Logs_uri     /v1/logs
+  Traces_uri   /v1/traces
 ```
 
 {% endtab %}

--- a/pipeline/outputs/datadog.md
+++ b/pipeline/outputs/datadog.md
@@ -39,18 +39,17 @@ Get started quickly with this configuration file:
 ```yaml
 pipeline:
           
-    outputs:
-        - name: datadog
-          match: '*'
-          host: http-intake.logs.datadoghq.com
-          tls: on
-          compress: gzip
-          apikey: <my-datadog-api-key>
-          dd_service: <my-app-service>
-          dd_source: <my-app-source>
-          dd_tags: team:logs,foo:bar
-          dd_hostname: myhost
-      
+  outputs:
+    - name: datadog
+      match: '*'
+      host: http-intake.logs.datadoghq.com
+      tls: on
+      compress: gzip
+      apikey: <my-datadog-api-key>
+      dd_service: <my-app-service>
+      dd_source: <my-app-source>
+      dd_tags: team:logs,foo:bar
+      dd_hostname: myhost  
 ```
 
 {% endtab %}
@@ -58,16 +57,16 @@ pipeline:
 
 ```text
 [OUTPUT]
-    Name        datadog
-    Match       *
-    Host        http-intake.logs.datadoghq.com
-    TLS         on
-    compress    gzip
-    apikey      <my-datadog-api-key>
-    dd_service  <my-app-service>
-    dd_source   <my-app-source>
-    dd_tags     team:logs,foo:bar
-    dd_hostname myhost
+  Name        datadog
+  Match       *
+  Host        http-intake.logs.datadoghq.com
+  TLS         on
+  compress    gzip
+  apikey      <my-datadog-api-key>
+  dd_service  <my-app-service>
+  dd_source   <my-app-source>
+  dd_tags     team:logs,foo:bar
+  dd_hostname myhost
 ```
 
 {% endtab %}

--- a/pipeline/outputs/datadog.md
+++ b/pipeline/outputs/datadog.md
@@ -33,7 +33,30 @@ Before you begin, you need a [Datadog account](https://app.datadoghq.com/signup)
 
 Get started quickly with this configuration file:
 
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+          
+    outputs:
+        - name: datadog
+          match: '*'
+          host: http-intake.logs.datadoghq.com
+          tls: on
+          compress: gzip
+          apikey: <my-datadog-api-key>
+          dd_service: <my-app-service>
+          dd_source: <my-app-source>
+          dd_tags: team:logs,foo:bar
+          dd_hostname: myhost
+      
 ```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [OUTPUT]
     Name        datadog
     Match       *
@@ -46,6 +69,9 @@ Get started quickly with this configuration file:
     dd_tags     team:logs,foo:bar
     dd_hostname myhost
 ```
+
+{% endtab %}
+{% endtabs %}
 
 ## Troubleshooting
 

--- a/pipeline/outputs/dynatrace.md
+++ b/pipeline/outputs/dynatrace.md
@@ -40,21 +40,21 @@ To get started with sending logs to Dynatrace:
       ```yaml
       pipeline:
              
-          outputs:
-              - name: http
-                match: '*'
-                header:
-                    - 'Content-Type application/json; charset=utf-8'
-                    - 'Authorization Api-Token {your-API-token-here}'
-                allow_duplicated_headers: false
-                host: {your-environment-id}.live.dynatrace.com
-                port: 443
-                uri: /api/v2/logs/ingest
-                format: json
-                json_date_format: iso8601
-                json_date_key: timestamp
-                tls: on
-                tls.verify: on      
+        outputs:
+          - name: http
+            match: '*'
+            header:
+              - 'Content-Type application/json; charset=utf-8'
+              - 'Authorization Api-Token {your-API-token-here}'
+            allow_duplicated_headers: false
+            host: {your-environment-id}.live.dynatrace.com
+            port: 443
+            uri: /api/v2/logs/ingest
+            format: json
+            json_date_format: iso8601
+            json_date_key: timestamp
+            tls: on
+            tls.verify: on      
       ```
    
       {% endtab %}
@@ -62,19 +62,19 @@ To get started with sending logs to Dynatrace:
    
       ```text
       [OUTPUT]
-          name         http
-          match        *
-          header       Content-Type application/json; charset=utf-8
-          header       Authorization Api-Token {your-API-token-here}
-          allow_duplicated_headers false
-          host         {your-environment-id}.live.dynatrace.com
-          Port         443
-          URI          /api/v2/logs/ingest
-          Format       json
-          json_date_format iso8601
-          json_date_key timestamp
-          tls          On
-          tls.verify   On
+        name         http
+        match        *
+        header       Content-Type application/json; charset=utf-8
+        header       Authorization Api-Token {your-API-token-here}
+        allow_duplicated_headers false
+        host         {your-environment-id}.live.dynatrace.com
+        Port         443
+        URI          /api/v2/logs/ingest
+        Format       json
+        json_date_format iso8601
+        json_date_key timestamp
+        tls          On
+        tls.verify   On
       ```
    
       {% endtab %}

--- a/pipeline/outputs/dynatrace.md
+++ b/pipeline/outputs/dynatrace.md
@@ -32,23 +32,53 @@ To get started with sending logs to Dynatrace:
    token with the `logs.ingest` (Ingest Logs) scope.
 1. Determine your Dynatrace
    [environment ID](https://docs.dynatrace.com/docs/shortlink/monitoring-environment#environment-id).
-1. In your main Fluent Bit configuration file, append the following `Output` section:
+   1. In your main Fluent Bit configuration file, append the following `Output` section:
 
-   ```text
-   [OUTPUT]
-       name         http
-       match        *
-       header       Content-Type application/json; charset=utf-8
-       header       Authorization Api-Token {your-API-token-here}
-       allow_duplicated_headers false
-       host         {your-environment-id}.live.dynatrace.com
-       Port         443
-       URI          /api/v2/logs/ingest
-       Format       json
-       json_date_format iso8601
-       json_date_key timestamp
-       tls          On
-       tls.verify   On
+      {% tabs %}
+      {% tab title="fluent-bit.yaml" %}
+
+      ```yaml
+      pipeline:
+             
+          outputs:
+              - name: http
+                match: '*'
+                header:
+                    - 'Content-Type application/json; charset=utf-8'
+                    - 'Authorization Api-Token {your-API-token-here}'
+                allow_duplicated_headers: false
+                host: {your-environment-id}.live.dynatrace.com
+                port: 443
+                uri: /api/v2/logs/ingest
+                format: json
+                json_date_format: iso8601
+                json_date_key: timestamp
+                tls: on
+                tls.verify: on      
+      ```
+   
+      {% endtab %}
+      {% tab title="fluent-bit.conf" %}
+   
+      ```text
+      [OUTPUT]
+          name         http
+          match        *
+          header       Content-Type application/json; charset=utf-8
+          header       Authorization Api-Token {your-API-token-here}
+          allow_duplicated_headers false
+          host         {your-environment-id}.live.dynatrace.com
+          Port         443
+          URI          /api/v2/logs/ingest
+          Format       json
+          json_date_format iso8601
+          json_date_key timestamp
+          tls          On
+          tls.verify   On
+      ```
+   
+      {% endtab %}
+      {% endtabs %}
 
 ## References
 


### PR DESCRIPTION
Update the [output plugin docs](https://docs.fluentbit.io/manual/pipeline/outputs) with YAML configuration examples for Counter, DashO, Datadog, and Dynatrace.