### PR TITLE
Adding YAML examples and layout fixes for output plugin docs with names starting with E through F. Fixes #1909.

### DIFF
--- a/pipeline/outputs/bigquery.md
+++ b/pipeline/outputs/bigquery.md
@@ -67,14 +67,36 @@ See Google's [official documentation](https://cloud.google.com/bigquery/docs/ref
 
 If you are using a _Google Cloud Credentials File_, the following configuration is enough to get you started:
 
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: dummy
+      tag: dummy
+          
+  outputs:
+    - name: bigquery
+      match: '*'
+      dataset_id: my_dataset
+      table_id: dummy_table
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
 ```text
 [INPUT]
-    Name  dummy
-    Tag   dummy
+  Name dummy
+  Tag  dummy
 
 [OUTPUT]
-    Name       bigquery
-    Match      *
-    dataset_id my_dataset
-    table_id   dummy_table
+  Name         bigquery
+  Match        *
+  dataset_id   my_dataset
+  table_id     dummy_table
 ```
+
+{% endtab %}
+{% endtabs %}

--- a/pipeline/outputs/chronicle.md
+++ b/pipeline/outputs/chronicle.md
@@ -42,14 +42,36 @@ See Google's [official documentation](https://cloud.google.com/chronicle/docs/re
 
 If you are using a _Google Cloud Credentials File_, the following configuration is enough to get you started:
 
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: dummy
+      tag: dummy
+          
+  outputs:
+    - name: chronicle
+      match: '*'
+      customer_id: my_customer_id
+      log_type: my_super_awesome_type
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
 ```text
 [INPUT]
-    Name  dummy
-    Tag   dummy
+  Name dummy
+  Tag  dummy
 
 [OUTPUT]
-    Name       chronicle
-    Match      *
-    customer_id my_customer_id
-    log_type my_super_awesome_type
+  Name         chronicle
+  Match        *
+  customer_id  my_customer_id
+  log_type     my_super_awesome_type
 ```
+
+{% endtab %}
+{% endtabs %}

--- a/pipeline/outputs/elasticsearch.md
+++ b/pipeline/outputs/elasticsearch.md
@@ -96,14 +96,14 @@ es://host:port/index/type
 
 Using the format specified, you could start Fluent Bit through:
 
-```shell copy
+```shell
 fluent-bit -i cpu -t cpu -o es://192.168.2.3:9200/my_index/my_type \
     -o stdout -m '*'
 ```
 
 Which is similar to the following command:
 
-```shell copy
+```shell
 fluent-bit -i cpu -t cpu -o es -p Host=192.168.2.3 -p Port=9200 \
     -p Index=my_index -p Type=my_type -o stdout -m '*'
 ```
@@ -117,17 +117,17 @@ In your main configuration file append the following `Input` and `Output` sectio
 
 ```yaml
 pipeline:
-    inputs:
-        - name: cpu
-          tag: cpu
-          
-    outputs:
-        - name: es
-          match: '*'
-          host: 192.168.2.3
-          port: 9200
-          index: my_index
-          type: my_type
+  inputs:
+    - name: cpu
+      tag: cpu
+      
+  outputs:
+    - name: es
+      match: '*'
+      host: 192.168.2.3
+      port: 9200
+      index: my_index
+      type: my_type
 ```
 
 {% endtab %}
@@ -136,16 +136,16 @@ pipeline:
 
 ```text
 [INPUT]
-    Name  cpu
-    Tag   cpu
+  Name  cpu
+  Tag   cpu
 
 [OUTPUT]
-    Name  es
-    Match *
-    Host  192.168.2.3
-    Port  9200
-    Index my_index
-    Type  my_type
+  Name  es
+  Match *
+  Host  192.168.2.3
+  Port  9200
+  Index my_index
+  Type  my_type
 ```
 
 {% endtab %}
@@ -186,36 +186,33 @@ Example configuration:
 
 ```yaml
 pipeline:
-    inputs:
-        ...
-          
-    outputs:
-        - name: es
-          match: '*'
-          host: vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
-          port: 443
-          index: my_index
-          type: my_type
-          aws_auth: on
-          aws_region: us-west-2
-          tls: on
+      
+  outputs:
+    - name: es
+      match: '*'
+      host: vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
+      port: 443
+      index: my_index
+      type: my_type
+      aws_auth: on
+      aws_region: us-west-2
+      tls: on
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
-    Name  es
-    Match *
-    Host  vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
-    Port  443
-    Index my_index
-    Type  my_type
-    AWS_Auth On
-    AWS_Region us-west-2
-    tls     On
+  Name  es
+  Match *
+  Host  vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
+  Port  443
+  Index my_index
+  Type  my_type
+  AWS_Auth On
+  AWS_Region us-west-2
+  tls     On
 ```
 
 {% endtab %}
@@ -239,17 +236,15 @@ Example configuration:
 
 ```yaml
 pipeline:
-    inputs:
-        ...
-          
-    outputs:
-        - name: es
-          include_tag_key: true
-          tag_key: tags
-          tls: on
-          tls.verify: off
-          cloud_id: 'elastic-obs-deployment:ZXVybxxxxxxxxxxxg=='
-          cloud_auth: 'elastic:2vxxxxxxxxYV'
+      
+  outputs:
+    - name: es
+      include_tag_key: true
+      tag_key: tags
+      tls: on
+      tls.verify: off
+      cloud_id: 'elastic-obs-deployment:ZXVybxxxxxxxxxxxg=='
+      cloud_auth: 'elastic:2vxxxxxxxxYV'
 ```
 
 {% endtab %}
@@ -258,14 +253,14 @@ pipeline:
 
 ```text
 [OUTPUT]
-    Name es
-    Include_Tag_Key true
-    Tag_Key tags
-    tls On
-    tls.verify Off
-    Suppress_Type_Name On
-    cloud_id elastic-obs-deployment:ZXVybxxxxxxxxxxxg==
-    cloud_auth elastic:2vxxxxxxxxYV
+  Name es
+  Include_Tag_Key true
+  Tag_Key tags
+  tls On
+  tls.verify Off
+  Suppress_Type_Name On
+  cloud_id elastic-obs-deployment:ZXVybxxxxxxxxxxxg==
+  cloud_auth elastic:2vxxxxxxxxYV
 ```
 
 {% endtab %}
@@ -301,37 +296,34 @@ This means that you can't set up your configuration like the following:.
 
 ```yaml
 pipeline:
-    inputs:
-        ...
           
-    outputs:
-        - name: es
-          match: 'foo.*'
-          index: search
-          type: type1
+  outputs:
+    - name: es
+      match: 'foo.*'
+      index: search
+      type: type1
 
-        - name: es
-          match: 'bar.*'
-          index: search
-          type: type2
+    - name: es
+      match: 'bar.*'
+      index: search
+      type: type2
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
-    Name  es
-    Match foo.*
-    Index search
-    Type  type1
+  Name  es
+  Match foo.*
+  Index search
+  Type  type1
 
 [OUTPUT]
-    Name  es
-    Match bar.*
-    Index search
-    Type  type2
+  Name  es
+  Match bar.*
+  Index search
+  Type  type2
 ```
 
 {% endtab %}
@@ -357,36 +349,33 @@ as seen on the last line:
 
 ```yaml
 pipeline:
-    inputs:
-        ...
           
-    outputs:
-        - name: es
-          match: '*'
-          host: vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
-          port: 443
-          index: my_index
-          aws_auth: on
-          aws_region: us-west-2
-          tls: on
-          type: doc
+  outputs:
+    - name: es
+      match: '*'
+      host: vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
+      port: 443
+      index: my_index
+      aws_auth: on
+      aws_region: us-west-2
+      tls: on
+      type: doc
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
-    Name  es
-    Match *
-    Host  vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
-    Port  443
-    Index my_index
-    AWS_Auth On
-    AWS_Region us-west-2
-    tls   On
-    Type  doc
+  Name  es
+  Match *
+  Host  vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
+  Port  443
+  Index my_index
+  AWS_Auth On
+  AWS_Region us-west-2
+  tls   On
+  Type  doc
 ```
 
 {% endtab %}
@@ -411,26 +400,23 @@ as follows:
 
 ```yaml
 pipeline:
-    inputs:
-        ...
-          
-    outputs:
-        - name: es
-          match: '*'
-          host: 192.168.12.1
-          generate_id: on
+  
+  outputs:
+    - name: es
+      match: '*'
+      host: 192.168.12.1
+      generate_id: on
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
-    Name es
-    Match *
-    Host  192.168.12.1
-    Generate_ID on
+  Name es
+  Match *
+  Host  192.168.12.1
+  Generate_ID on
 ```
 
 {% endtab %}
@@ -446,30 +432,27 @@ The following snippet demonstrates using the namespace name as extracted by the
 
 ```yaml
 pipeline:
-    inputs:
-        ...
           
-    outputs:
-        - name: es
-          match: '*'
-          # ...
-          logstash_prefix: logstash
-          logstash_prefix_key: $kubernetes['namespace_name'] 
-          # ...
+  outputs:
+    - name: es
+      match: '*'
+      # ...
+      logstash_prefix: logstash
+      logstash_prefix_key: $kubernetes['namespace_name'] 
+      # ...
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [OUTPUT]
-    Name es
-    Match *
-    # ...
-    Logstash_Prefix logstash
-    Logstash_Prefix_Key $kubernetes['namespace_name']
-    # ...
+  Name es
+  Match *
+  # ...
+  Logstash_Prefix logstash
+  Logstash_Prefix_Key $kubernetes['namespace_name']
+  # ...
 ```
 
 {% endtab %}

--- a/pipeline/outputs/file.md
+++ b/pipeline/outputs/file.md
@@ -121,7 +121,7 @@ fluent-bit -i cpu -o file -p path=output.txt
 
 ### Configuration File
 
-In your main configuration file append the following Input & Output sections:
+In your main configuration file append the following:
 
 {% tabs %}
 {% tab title="fluent-bit.yaml" %}

--- a/pipeline/outputs/file.md
+++ b/pipeline/outputs/file.md
@@ -20,7 +20,7 @@ The plugin supports the following configuration parameters:
 
 Output time, tag and json records. There is no configuration parameters for out\_file.
 
-```javascript
+```text
 tag: [time, {"key1":"value1", "key2":"value2", "key3":"value3"}]
 ```
 
@@ -28,7 +28,7 @@ tag: [time, {"key1":"value1", "key2":"value2", "key3":"value3"}]
 
 Output the records as JSON \(without additional `tag` and `timestamp` attributes\). There is no configuration parameters for plain format.
 
-```javascript
+```json
 {"key1":"value1", "key2":"value2", "key3":"value3"}
 ```
 
@@ -40,7 +40,7 @@ Output the records as csv. Csv supports an additional configuration parameter.
 | :--- | :--- |
 | Delimiter | The character to separate each data. Accepted values are "\t" (or "tab"), "space" or "comma". Other values are ignored and will use default silently. Default: ',' |
 
-```python
+```text
 time[delimiter]"value1"[delimiter]"value2"[delimiter]"value3"
 ```
 
@@ -53,7 +53,7 @@ Output the records as LTSV. LTSV supports an additional configuration parameter.
 | Delimiter | The character to separate each pair. Default: '\t'\(TAB\) |
 | Label\_Delimiter | The character to separate label and the value. Default: ':' |
 
-```python
+```text
 field1[label_delimiter]value1[delimiter]field2[label_delimiter]value2\n
 ```
 
@@ -69,6 +69,24 @@ This accepts a formatting template and fills placeholders using corresponding va
 
 For example, if you set up the configuration as below:
 
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: mem
+          
+  outputs:
+    - name: file
+      match: '*'
+      format: template
+      template: '{time} used={Mem.used} free={Mem.free} total={Mem.total}'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
 ```text
 [INPUT]
   Name mem
@@ -79,6 +97,9 @@ For example, if you set up the configuration as below:
   Format template
   Template {time} used={Mem.used} free={Mem.free} total={Mem.total}
 ```
+
+{% endtab %}
+{% endtabs %}
 
 You will get the following output:
 
@@ -94,7 +115,7 @@ You can run the plugin from the command line or through the configuration file:
 
 From the command line you can let Fluent Bit count up a data with the following options:
 
-```bash
+```shell
 fluent-bit -i cpu -o file -p path=output.txt
 ```
 
@@ -102,13 +123,34 @@ fluent-bit -i cpu -o file -p path=output.txt
 
 In your main configuration file append the following Input & Output sections:
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: cpu
+      tag: cpu
+          
+  outputs:
+    - name: file
+      match: '*'
+      path: output_dir
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
-    Name cpu
-    Tag  cpu
+  Name cpu
+  Tag  cpu
 
 [OUTPUT]
-    Name file
-    Match *
-    Path output_dir
+  Name  file
+  Match *
+  Path  output_dir
 ```
+
+{% endtab %}
+{% endtabs %}

--- a/pipeline/outputs/flowcounter.md
+++ b/pipeline/outputs/flowcounter.md
@@ -19,37 +19,52 @@ You can run the plugin from the command line or through the configuration file:
 
 From the command line you can let Fluent Bit count up a data with the following options:
 
-```bash
+```shell
 fluent-bit -i cpu -o flowcounter
 ```
 
 ### Configuration File
 
-In your main configuration file append the following Input & Output sections:
+In your main configuration file append the following:
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: cpu
+      tag: cpu
+          
+  outputs:
+    - name: flowcounter
+      match: '*'
+      unit: second
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
-    Name cpu
-    Tag  cpu
+  Name cpu
+  Tag  cpu
 
 [OUTPUT]
-    Name flowcounter
-    Match *
-    Unit second
+  Name  flowcounter
+  Match *
+  Unit second
 ```
+
+{% endtab %}
+{% endtabs %}
 
 ## Testing
 
 Once Fluent Bit is running, you will see the reports in the output interface similar to this:
 
-```bash
-$ fluent-bit -i cpu -o flowcounter
-Fluent Bit v1.x.x
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
-
-[2016/12/23 11:01:20] [ info] [engine] started
+```text
+...
 [out_flowcounter] cpu.0:[1482458540, {"counts":60, "bytes":7560, "counts/minute":1, "bytes/minute":126 }]
+...
 ```


### PR DESCRIPTION
Adding YAML examples and layout fixes for output plugin docs with names starting with E through F. Fixes #1909.

Update the [output plugin docs](https://docs.fluentbit.io/manual/pipeline/outputs) with YAML configuration examples for the following:

- Elasticsearch
- File
- FlowCounter
- Forward
- GELF
- Google Chronicle
- Google Cloud BigQuery