### PR TITLE
add vale rule to use gitbook hint syntax

### DIFF
--- a/vale-styles/FluentBit/Hints.yml
+++ b/vale-styles/FluentBit/Hints.yml
@@ -1,0 +1,15 @@
+extends: existence
+message: "Instead of using `>` to call out information, use GitBook hint syntax. https://gitbook.com/docs/creating-content/blocks/hint#representation-in-markdown"
+level: suggestion
+nonword: true
+scope: raw
+tokens:
+  - '> \**_*(?i)note'
+  - '> \**_*(?i)caution'
+  - '> \**_*(?i)warning'
+  - '> \**_*(?i)danger'
+  - '> \**_*(?i)important'
+  - '> \**_*(?i)info'
+  - '> \**_*(?i)hint'
+  - '> \**_*(?i)tip'
+  - '> \**_*(?i)success'


### PR DESCRIPTION
this PR adds a vale suggestion to use GitBook hints rather than ` > Note: lorem ipsum`.