### PR TITLE
Add vale test to catch consistent grammar issue

### DIFF
--- a/vale-styles/FluentBit/WordList.yml
+++ b/vale-styles/FluentBit/WordList.yml
@@ -24,6 +24,7 @@ swap:
   action bar: app bar
   admin: administrator
   Ajax: AJAX
+  allows to: lets you
   allows you to: lets you
   Android device: Android-powered device
   android: Android


### PR DESCRIPTION
'allows to' isn't US english grammar and we keep missing it in cleanup. This adds a vale test for it.
