### PR TITLE
Vale: Fluent Bit casing test

### DIFF
--- a/vale-styles/FluentBit/FluentBitCasing.yml
+++ b/vale-styles/FluentBit/FluentBitCasing.yml
@@ -1,0 +1,16 @@
+extends: existence
+message: "Use the proper noun 'Fluent Bit' with correct casing and spacing."
+level: warning
+ignorecase: false
+scope: text
+tokens:
+  # Matches incorrect variants in plain prose but excludes filenames, links, quotes, and code
+  - '\bfluent bit\b(?![".\w:/\]])'
+  - '\bfluentbit\b(?![".\w:/\]])'
+  - '\bFluent bit\b(?![".\w:/\]])'
+  - '\bfluent Bit\b(?![".\w:/\]])'
+  - '\bfluent-bit\b(?![".\w:/\]])'
+  - '\bFluent-Bit\b(?![".\w:/\]])'
+  - '\bfluent\-Bit\b(?![".\w:/\]])'
+  - '\bFLUENT BIT\b(?![".\w:/\]])'
+  - '\bFLUENT-BIT\b(?![".\w:/\]])'


### PR DESCRIPTION
This adds a test to check for Fluent Bit - properly spaced and capitalized.

It *mostly* works. I can't get it to not flag on markdown links  like `[fluent-bit-4.0.4-win32.msi]`

But this should catch most of them. 