### PR TITLE
Turn off markdownlint test 47

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,6 +4,7 @@
     "MD007": { "indent": 2 },
     "MD013": false,
     "MD025": { "front_matter_title": "false" },
+    "MD047": false,
     "MD049": { "style": "underscore" },
 	"no-hard-tabs": false,
     "whitespace": false,


### PR DESCRIPTION
This test wants a newline character at the end of every file.

While that's nice, I don't see it as actually making a difference to users or maintainers.
