### PR TITLE
General code example cleanup where wrong code type specified in code blocks throughout entire docs project. Fixes #2020.

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -1,7 +1,5 @@
 # Configuration file
 
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5e67142e-3887-4b56-b940-18494bcc23a7" />
-
 One of the ways to configure Fluent Bit is using a main configuration file. Fluent Bit allows the use one configuration file that works at a global scope and uses the defined [Format and Schema](format-schema.md).
 
 The main configuration file supports four sections:
@@ -39,11 +37,11 @@ The `Service` section defines global properties of the service. The following ke
 
 The following is an example of a `SERVICE` section:
 
-```python
+```text
 [SERVICE]
-    Flush           5
-    Daemon          off
-    Log_Level       debug
+  Flush           5
+  Daemon          off
+  Log_Level       debug
 ```
 
 For scheduler and retry details, see [scheduling and retries](../../scheduling-and-retries.md#Scheduling-and-Retries).
@@ -64,10 +62,10 @@ The `INPUT` section defines a source (related to an input plugin). Each [input p
 
 The following is an example of an `INPUT` section:
 
-```python
+```text
 [INPUT]
-    Name cpu
-    Tag  my_cpu
+  Name cpu
+  Tag  my_cpu
 ```
 
 ## Config filter
@@ -87,11 +85,11 @@ The `FILTER` section defines a filter (related to an filter plugin). Each filter
 
 The following is an example of a `FILTER` section:
 
-```python
+```text
 [FILTER]
-    Name  grep
-    Match *
-    Regex log aa
+  Name  grep
+  Match *
+  Regex log aa
 ```
 
 ## Config output
@@ -109,29 +107,29 @@ The `OUTPUT` section specifies a destination that certain records should go to a
 
 The following is an example of an `OUTPUT` section:
 
-```python
+```text
 [OUTPUT]
-    Name  stdout
-    Match my*cpu
+  Name  stdout
+  Match my*cpu
 ```
 
 ### Collecting `cpu` metrics example
 
 The following configuration file example demonstrates how to collect CPU metrics and flush the results every five seconds to the standard output:
 
-```python
+```text
 [SERVICE]
-    Flush     5
-    Daemon    off
-    Log_Level debug
+  Flush     5
+  Daemon    off
+  Log_Level debug
 
 [INPUT]
-    Name  cpu
-    Tag   my_cpu
+  Name  cpu
+  Tag   my_cpu
 
 [OUTPUT]
-    Name  stdout
-    Match my*cpu
+  Name  stdout
+  Match my*cpu
 ```
 
 ## Config include file

--- a/administration/configuring-fluent-bit/classic-mode/format-schema.md
+++ b/administration/configuring-fluent-bit/classic-mode/format-schema.md
@@ -10,11 +10,11 @@ The schema is defined by three concepts:
 
 An example of a configuration file is as follows:
 
-```python
+```text
 [SERVICE]
-    # This is a commented line
-    Daemon    off
-    log_level debug
+  # This is a commented line
+  Daemon    off
+  log_level debug
 ```
 
 ## Sections
@@ -42,15 +42,15 @@ Commented lines are set prefixing the `#` character. Commented lines aren't proc
 
 Fluent Bit configuration files are based in a strict indented mode. Each configuration file must follow the same pattern of alignment from left to right when writing text. By default, an indentation level of four spaces from left to right is suggested. Example:
 
-```python
+```text
 [FIRST_SECTION]
-    # This is a commented line
-    Key1  some value
-    Key2  another value
-    # more comments
+  # This is a commented line
+  Key1  some value
+  Key2  another value
+  # more comments
 
 [SECOND_SECTION]
-    KeyN  3.14
+  KeyN  3.14
 ```
 
 This example shows two sections with multiple entries and comments. Empty lines are allowed.

--- a/administration/configuring-fluent-bit/classic-mode/upstream-servers.md
+++ b/administration/configuring-fluent-bit/classic-mode/upstream-servers.md
@@ -37,27 +37,27 @@ The following example defines an `Upstream` called forward-balancing which aims 
 - node-2: connects to 127.0.0.1:44000
 - node-3: connects to 127.0.0.1:45000 using TLS without verification. It also defines a specific configuration option required by Forward output called `shared_key`.
 
-```python
+```text
 [UPSTREAM]
-    name       forward-balancing
+  name       forward-balancing
 
 [NODE]
-    name       node-1
-    host       127.0.0.1
-    port       43000
+  name       node-1
+  host       127.0.0.1
+  port       43000
 
 [NODE]
-    name       node-2
-    host       127.0.0.1
-    port       44000
+  name       node-2
+  host       127.0.0.1
+  port       44000
 
 [NODE]
-    name       node-3
-    host       127.0.0.1
-    port       45000
-    tls        on
-    tls.verify off
-    shared_key secret
+  name       node-3
+  host       127.0.0.1
+  port       45000
+  tls        on
+  tls.verify off
+  shared_key secret
 ```
 
 Every `Upstream` definition must exists in its own configuration file in the file system. Adding multiple `Upstream` configurations in the same file or different files isn't allowed.

--- a/administration/configuring-fluent-bit/classic-mode/variables.md
+++ b/administration/configuring-fluent-bit/classic-mode/variables.md
@@ -1,7 +1,5 @@
 # Variables
 
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=1731c7b5-34c6-424f-bfc6-88c2aa71e81f" />
-
 Fluent Bit supports the usage of environment variables in any value associated to a key when using a configuration file.
 
 The variables are case sensitive and can be used in the following format:
@@ -25,22 +23,22 @@ Create the following configuration file \(`fluent-bit.conf`\):
 
 ```yaml
 [SERVICE]
-    Flush        1
-    Daemon       Off
-    Log_Level    info
+  Flush        1
+  Daemon       Off
+  Log_Level    info
 
 [INPUT]
-    Name cpu
-    Tag  cpu.local
+  Name cpu
+  Tag  cpu.local
 
 [OUTPUT]
-    Name  ${MY_OUTPUT}
-    Match *
+  Name  ${MY_OUTPUT}
+  Match *
 ```
 
 Open a terminal and set the environment variable:
 
-```bash
+```shell
 export MY_OUTPUT=stdout
 ```
 
@@ -48,14 +46,9 @@ The previous command sets the `stdout` value to the variable `MY_OUTPUT`.
 
 Run Fluent Bit with the recently created configuration file:
 
-```text
+```shell
 $ bin/fluent-bit -c fluent-bit.conf
-Fluent Bit v1.4.0
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
 
-[2020/03/03 12:25:25] [ info] [engine] started
+...
 [0] cpu.local: [1491243925, {"cpu_p"=>1.750000, "user_p"=>1.750000, "system_p"=>0.000000, "cpu0.p_cpu"=>3.000000, "cpu0.p_user"=>2.000000, "cpu0.p_system"=>1.000000, "cpu1.p_cpu"=>0.000000, "cpu1.p_user"=>0.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>4.000000, "cpu2.p_user"=>4.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>1.000000, "cpu3.p_user"=>1.000000, "cpu3.p_system"=>0.000000}]
 ```

--- a/administration/configuring-fluent-bit/multiline-parsing.md
+++ b/administration/configuring-fluent-bit/multiline-parsing.md
@@ -102,7 +102,6 @@ To simplify the configuration of regular expressions, you can use the [Rubular](
 The following example provides a full Fluent Bit configuration file for multiline parsing by using the definition explained previously. It's provided in following YAML and classic configuration examples:
 
 {% tabs %}
-
 {% tab title="fluent-bit.yaml" %}
 
 This is the primary Fluent Bit YAML configuration file. It includes the `parsers_multiline.yaml` and tails the file `test.log`  by applying the multiline parser `multiline-regex-test`. Then it sends the processing to the standard output.
@@ -224,7 +223,7 @@ another line...
 
 By running Fluent Bit with the corresponding configuration file you will obtain the following output:
 
-```text
+```shell
 # For YAML configuration.
 $ ./fluent-bit --config fluent-bit.yaml
 
@@ -399,7 +398,6 @@ Dec 14 06:41:08 Exception in thread "main" java.lang.RuntimeException: Something
     at com.myproject.module.MyProject.someMethod(MyProject.java:10)
     at com.myproject.module.MyProject.main(MyProject.java:6)
 another line...
-
 ```
 
 {% endtab %}
@@ -407,7 +405,7 @@ another line...
 
 By running Fluent Bit with the corresponding configuration file you will obtain:
 
-```text
+```shell
 # For YAML configuration.
 $ ./fluent-bit --config fluent-bit.yaml
 

--- a/administration/configuring-fluent-bit/yaml/environment-variables-section.md
+++ b/administration/configuring-fluent-bit/yaml/environment-variables-section.md
@@ -41,7 +41,7 @@ Variables set in the `env` section can't be overridden by system environment var
 
 For example, to set the `FLUSH_INTERVAL` system environment variable to `2` and use it in your configuration:
 
-```bash
+```shell
 export FLUSH_INTERVAL=2
 ```
 

--- a/administration/networking.md
+++ b/administration/networking.md
@@ -134,14 +134,15 @@ pipeline:
 
 In another terminal, start `nc` and make it listen for messages on TCP port 9090:
 
-```text
+```shell
 nc -l 9090
 ```
 
 Start Fluent Bit with the configuration file you defined previously to see data flowing to netcat:
 
-```text
+```shell
 $ nc -l 9090
+
 {"date":1587769732.572266,"rand_value":9704012962543047466}
 {"date":1587769733.572354,"rand_value":7609018546050096989}
 {"date":1587769734.572388,"rand_value":17035865539257638950}

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -143,7 +143,7 @@ pipeline:
 
 By default, the HTTP output plugin uses plain TCP. Run the following command to enable TLS:
 
-```bash
+```shell
 fluent-bit -i cpu -t cpu -o http://192.168.2.3:80/something \
            -p tls=on         \
            -p tls.verify=off \

--- a/development/golang-output-plugins.md
+++ b/development/golang-output-plugins.md
@@ -7,9 +7,11 @@ Fluent Bit supports integration of Golang plugins built as shared objects for ou
 Compile Fluent Bit with Golang support:
 
 ```shell
-cd build/
-cmake -DFLB_DEBUG=On -DFLB_PROXY_GO=On ../
-make
+$ cd build/
+
+$ cmake -DFLB_DEBUG=On -DFLB_PROXY_GO=On ../
+
+$ make
 ```
 
 Once compiled, you can see the new `-e` option in the binary which stands for _external plugin_.
@@ -74,7 +76,7 @@ The previous code is a template to write an output plugin. It's important to kee
 
 To build the code, use the following line:
 
-```bash
+```shell
 go build -buildmode=c-shared -o out_gstdout.so out_gstdout.go
 ```
 
@@ -82,16 +84,17 @@ Once built, a shared library called `out_gstdout.so` will be available. Confirm 
 
 ```shell
 $ ldd out_gstdout.so
-    linux-vdso.so.1 =>  (0x00007fff561dd000)
-    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc4aeef0000)
-    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc4aeb27000)
-    /lib64/ld-linux-x86-64.so.2 (0x000055751a4fd000)
+  
+  linux-vdso.so.1 =>  (0x00007fff561dd000)
+  libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc4aeef0000)
+  libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc4aeb27000)
+  /lib64/ld-linux-x86-64.so.2 (0x000055751a4fd000)
 ```
 
 ## Run Fluent Bit with the new plugin
 
-```bash
-bin/fluent-bit -e /path/to/out_gstdout.so -i cpu -o gstdout
+```shell
+fluent-bit -e /path/to/out_gstdout.so -i cpu -o gstdout
 ```
 
 ## Configuration file
@@ -109,10 +112,23 @@ Fluent Bit can load and run Golang plugins using two configuration files.
 
 #### Plugin file example
 
-```python
-[PLUGINS]
-    Path /path/to/out_gstdout.so
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+plugins:
+  - /path/to/out_gstdout.so
 ```
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[PLUGINS]
+  Path /path/to/out_gstdout.so
+```
+
+{% endtab %}
+{% endtabs %}
 
 ### Main configuration file
 
@@ -126,16 +142,36 @@ The keys for Golang plugin available as of this version are described in the fol
 
 The following is an example of a main configuration file.
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+service:
+  - /path/to/plugins.yaml
+  
+pipeline:
+  inputs:
+    - name dummy
+
+  outputs:
+    - name: gstdout
+```
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [SERVICE]
-    plugins_file /path/to/plugins.conf
+  plugins_file /path/to/plugins.conf
 
 [INPUT]
-    Name dummy
+  Name dummy
 
 [OUTPUT]
-    Name gstdout
+  Name gstdout
 ```
+
+{% endtab %}
+{% endtabs %}
 
 #### Config key constraint
 
@@ -173,6 +209,6 @@ The following configuration keys are reserved by Fluent Bit and must not be used
 
 You can load a main configuration file using `-c` option. You don't need to specify a plugins configuration file from command line.
 
-```text
+```shell
 fluent-bit -c fluent-bit.conf
 ```

--- a/development/msgpack-format.md
+++ b/development/msgpack-format.md
@@ -15,7 +15,7 @@ This section provides an overview of the specific types used by Fluent Bit withi
 
 Set up Fluent Bit to send in `msgpack` format to a specific port.
 
-```bash
+```shell
 docker run --rm -it --network=host fluent/fluent-bit /fluent-bit/bin/fluent-bit -i cpu -o tcp://127.0.0.1:5170 -p format=msgpack -v
 ```
 
@@ -45,9 +45,10 @@ while True:
 
 Now make sure to install `msgpack` for Python (3) and then run up your test code:
 
-```bash
+```shell
 $ pip install msgpack
-$ python3 test.py
-(ExtType(code=0, data=b'b\n5\xc65\x05\x14\xac'), {'cpu_p': 0.1875, 'user_p': 0.125, 'system_p': 0.0625, 'cpu0.p_cpu': 0.0, 'cpu0.p_user': 0.0, 'cpu0.p_system': 0.0, 'cpu1.p_cpu': 0.0, 'cpu1.p_user': 0.0, 'cpu1.p_system': 0.0, 'cpu2.p_cpu': 1.0, 'cpu2.p_user': 0.0, 'cpu2.p_system': 1.0, 'cpu3.p_cpu': 0.0, 'cpu3.p_user': 0.0, 'cpu3.p_system': 0.0, 'cpu4.p_cpu': 0.0, 'cpu4.p_user': 0.0, 'cpu4.p_system': 0.0, 'cpu5.p_cpu': 0.0, 'cpu5.p_user': 0.0, 'cpu5.p_system': 0.0, 'cpu6.p_cpu': 0.0, 'cpu6.p_user': 0.0, 'cpu6.p_system': 0.0, 'cpu7.p_cpu': 0.0, 'cpu7.p_user': 0.0, 'cpu7.p_system': 0.0, 'cpu8.p_cpu': 0.0, 'cpu8.p_user': 0.0, 'cpu8.p_system': 0.0, 'cpu9.p_cpu': 1.0, 'cpu9.p_user': 1.0, 'cpu9.p_system': 0.0, 'cpu10.p_cpu': 0.0, 'cpu10.p_user': 0.0, 'cpu10.p_system': 0.0, 'cpu11.p_cpu': 0.0, 'cpu11.p_user': 0.0, 'cpu11.p_system': 0.0, 'cpu12.p_cpu': 0.0, 'cpu12.p_user': 0.0, 'cpu12.p_system': 0.0, 'cpu13.p_cpu': 0.0, 'cpu13.p_user': 0.0, 'cpu13.p_system': 0.0, 'cpu14.p_cpu': 0.0, 'cpu14.p_user': 0.0, 'cpu14.p_system': 0.0, 'cpu15.p_cpu': 0.0, 'cpu15.p_user': 0.0, 'cpu15.p_system': 0.0})
 
+$ python3 test.py
+
+(ExtType(code=0, data=b'b\n5\xc65\x05\x14\xac'), {'cpu_p': 0.1875, 'user_p': 0.125, 'system_p': 0.0625, 'cpu0.p_cpu': 0.0, 'cpu0.p_user': 0.0, 'cpu0.p_system': 0.0, 'cpu1.p_cpu': 0.0, 'cpu1.p_user': 0.0, 'cpu1.p_system': 0.0, 'cpu2.p_cpu': 1.0, 'cpu2.p_user': 0.0, 'cpu2.p_system': 1.0, 'cpu3.p_cpu': 0.0, 'cpu3.p_user': 0.0, 'cpu3.p_system': 0.0, 'cpu4.p_cpu': 0.0, 'cpu4.p_user': 0.0, 'cpu4.p_system': 0.0, 'cpu5.p_cpu': 0.0, 'cpu5.p_user': 0.0, 'cpu5.p_system': 0.0, 'cpu6.p_cpu': 0.0, 'cpu6.p_user': 0.0, 'cpu6.p_system': 0.0, 'cpu7.p_cpu': 0.0, 'cpu7.p_user': 0.0, 'cpu7.p_system': 0.0, 'cpu8.p_cpu': 0.0, 'cpu8.p_user': 0.0, 'cpu8.p_system': 0.0, 'cpu9.p_cpu': 1.0, 'cpu9.p_user': 1.0, 'cpu9.p_system': 0.0, 'cpu10.p_cpu': 0.0, 'cpu10.p_user': 0.0, 'cpu10.p_system': 0.0, 'cpu11.p_cpu': 0.0, 'cpu11.p_user': 0.0, 'cpu11.p_system': 0.0, 'cpu12.p_cpu': 0.0, 'cpu12.p_user': 0.0, 'cpu12.p_system': 0.0, 'cpu13.p_cpu': 0.0, 'cpu13.p_user': 0.0, 'cpu13.p_system': 0.0, 'cpu14.p_cpu': 0.0, 'cpu14.p_user': 0.0, 'cpu14.p_system': 0.0, 'cpu15.p_cpu': 0.0, 'cpu15.p_user': 0.0, 'cpu15.p_system': 0.0})
 ```

--- a/installation/aws-container.md
+++ b/installation/aws-container.md
@@ -34,13 +34,13 @@ AWS vends SSM public parameters with the regional repository link for each image
 
 To see a list of available version tags in a given region, run the following command:
 
-```bash
+```shell
 aws ssm get-parameters-by-path --region eu-central-1 --path /aws/service/aws-for-fluent-bit/ --query 'Parameters[*].Name'
 ```
 
 To see the ECR repository URI for a given image tag in a given region, run the following:
 
-```bash
+```shell
 aws ssm get-parameter --region ap-northeast-1 --name /aws/service/aws-for-fluent-bit/2.0.0
 ```
 

--- a/installation/linux/alma-rocky.md
+++ b/installation/linux/alma-rocky.md
@@ -12,7 +12,7 @@ Fluent Bit supports the following architectures:
 
 Fluent Bit provides an installation script to use for most Linux targets.This will always install the most recently released version.
 
-```bash
+```shell
 curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 ```
 
@@ -31,12 +31,12 @@ The `fluent-bit` is provided through a Yum repository. To add the repository ref
 
    ```text
    [fluent-bit]
-   name = Fluent Bit
-   baseurl = https://packages.fluentbit.io/almalinux/$releasever/
-   gpgcheck=1
-   gpgkey=https://packages.fluentbit.io/fluentbit.key
-   repo_gpgcheck=1
-   enabled=1
+     name = Fluent Bit
+     baseurl = https://packages.fluentbit.io/almalinux/$releasever/
+     gpgcheck=1
+     gpgkey=https://packages.fluentbit.io/fluentbit.key
+     repo_gpgcheck=1
+     enabled=1
    ```
 
 1. As a best practice, enable `gpgcheck` and `repo_gpgcheck` for security reasons. Fluent Bit signs its repository metadata and all Fluent Bit packages.
@@ -45,20 +45,21 @@ The `fluent-bit` is provided through a Yum repository. To add the repository ref
 
 1. After your repository is configured, run the following command to install it:
 
-   ```bash
+   ```shell
    sudo yum install fluent-bit
    ```
 
 1. Instruct `Systemd` to enable the service:
 
-   ```bash
+   ```shell
    sudo systemctl start fluent-bit
    ```
 
 If you do a status check, you should see a similar output like this:
 
-```bash
+```shell
 $ systemctl status fluent-bit
+
 ● fluent-bit.service - Fluent Bit
    Loaded: loaded (/usr/lib/systemd/system/fluent-bit.service; disabled; vendor preset: disabled)
    Active: active (running) since Thu 2016-07-07 02:08:01 BST; 9s ago

--- a/installation/linux/amazon-linux.md
+++ b/installation/linux/amazon-linux.md
@@ -13,7 +13,7 @@ Amazon Linux 2022 is no longer supported.
 
 Fluent Bit provides an installation script to use for most Linux targets. This will always install the most recently released version.
 
-```bash copy
+```shell
 curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 ```
 
@@ -25,24 +25,24 @@ The `fluent-bit` is provided through a Yum repository. To add the repository ref
 
 ### Amazon Linux 2
 
-```text copy
+```text
 [fluent-bit]
-name = Fluent Bit
-baseurl = https://packages.fluentbit.io/amazonlinux/2/
-gpgcheck=1
-gpgkey=https://packages.fluentbit.io/fluentbit.key
-enabled=1
+  name = Fluent Bit
+  baseurl = https://packages.fluentbit.io/amazonlinux/2/
+  gpgcheck=1
+  gpgkey=https://packages.fluentbit.io/fluentbit.key
+  enabled=1
 ```
 
 ### Amazon Linux 2023
 
-```text copy
+```text
 [fluent-bit]
-name = Fluent Bit
-baseurl = https://packages.fluentbit.io/amazonlinux/2023/
-gpgcheck=1
-gpgkey=https://packages.fluentbit.io/fluentbit.key
-enabled=1
+  name = Fluent Bit
+  baseurl = https://packages.fluentbit.io/amazonlinux/2023/
+  gpgcheck=1
+  gpgkey=https://packages.fluentbit.io/fluentbit.key
+  enabled=1
 ```
 
 You should always enable `gpgcheck` for security reasons. All Fluent Bit packages are signed.
@@ -72,20 +72,21 @@ Refer to the [supported platform documentation](../supported-platforms.md) to se
 
 1. After your repository is configured, run the following command to install it:
 
-   ```bash copy
+   ```shell
    sudo yum install fluent-bit
    ```
 
 1. Instruct `systemd` to enable the service:
 
-```bash copy
+```shell
 sudo systemctl start fluent-bit
 ```
 
 If you do a status check, you should see a similar output like this:
 
-```bash
+```shell
 $ systemctl status fluent-bit
+
 ● fluent-bit.service - Fluent Bit
    Loaded: loaded (/usr/lib/systemd/system/fluent-bit.service; disabled; vendor preset: disabled)
    Active: active (running) since Thu 2016-07-07 02:08:01 BST; 9s ago

--- a/installation/linux/debian.md
+++ b/installation/linux/debian.md
@@ -12,7 +12,7 @@ The following architectures are supported
 
 Fluent Bit provides an installation script to use for most Linux targets. This will always install the most recently released version.
 
-```bash copy
+```shell
 curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 ```
 
@@ -24,7 +24,7 @@ The first step is to add the Fluent Bit server GPG key to your keyring to ensure
 
 Follow the official [Debian wiki guidance](https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution).
 
-```bash copy
+```shell
 sudo sh -c 'curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg'
 ```
 
@@ -54,11 +54,13 @@ Refer to the [supported platform documentation](../supported-platforms.md) to se
 For Debian, you must add the Fluent Bit APT server entry to your sources lists.
 Ensure codename is set to your specific [Debian release name](https://wiki.debian.org/DebianReleases#Production\_Releases). (for example: `bookworm` for Debian 12)
 
-```bash
+```shell
 codename=$(grep -oP '(?<=VERSION_CODENAME=).*' /etc/os-release 2>/dev/null || lsb_release -cs 2>/dev/null)
 ```
-Now Update your sources listes
-```bash copy
+
+Now Update your sources lists
+
+```shell
 echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/$codename $codename main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 ```
 
@@ -66,32 +68,35 @@ echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages
 
 Update your system's `apt` database:
 
-```bash copy
+```shell
 sudo apt-get update
 ```
 
 {% hint style="info" %}
+
 Fluent Bit recommends upgrading your system (`sudo apt-get upgrade`). This could avoid potential issues with expired certificates.
+
 {% endhint %}
 
 ## Install Fluent Bit
 
 1. Use the following `apt-get` command to install the latest Fluent Bit:
 
-   ```bash copy
+   ```shell
    sudo apt-get install fluent-bit
    ```
 
 1. Instruct `systemd` to enable the service:
 
-   ```bash copy
+   ```shell
    sudo systemctl start fluent-bit
    ```
 
 If you do a status check, you should see a similar output similar to:
 
-```bash
-sudo service fluent-bit status
+```shell
+$ sudo service fluent-bit status
+
 ● fluent-bit.service - Fluent Bit
    Loaded: loaded (/lib/systemd/system/fluent-bit.service; disabled; vendor preset: enabled)
    Active: active (running) since mié 2016-07-06 16:58:25 CST; 2h 45min ago

--- a/installation/linux/raspbian-raspberry-pi.md
+++ b/installation/linux/raspbian-raspberry-pi.md
@@ -43,19 +43,19 @@ Add the following content at bottom of your `/etc/apt/sources.list` file.
 
 ### Raspbian 12 (Bookworm)
 
-```text
+```shell
 echo "deb https://packages.fluentbit.io/raspbian/bookworm bookworm main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 ```
 
 ### Raspbian 11 (Bullseye)
 
-```text
+```shell
 echo "deb https://packages.fluentbit.io/raspbian/bullseye bullseye main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 ```
 
 ### Raspbian 10 (Buster)
 
-```text
+```shell
 echo "deb https://packages.fluentbit.io/raspbian/buster buster main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 ```
 
@@ -63,12 +63,14 @@ echo "deb https://packages.fluentbit.io/raspbian/buster buster main" | sudo tee 
 
 Now let your system update the `apt` database:
 
-```bash
+```shell
 sudo apt-get update
 ```
 
 {% hint style="info" %}
+
 Fluent Bit recommends upgrading your system (`sudo apt-get upgrade`) to avoid potential issues with expired certificates.
+
 {% endhint %}
 
 ## Install Fluent Bit
@@ -81,14 +83,15 @@ Fluent Bit recommends upgrading your system (`sudo apt-get upgrade`) to avoid po
 
 1. Instruct `systemd` to enable the service:
 
-   ```bash
+   ```shell
    sudo service fluent-bit start
    ```
 
 If you do a status check, you should see a similar output like this:
 
-```bash
-sudo service fluent-bit status
+```shell
+$ sudo service fluent-bit status
+
 ● fluent-bit.service - Fluent Bit
    Loaded: loaded (/lib/systemd/system/fluent-bit.service; disabled; vendor preset: enabled)
    Active: active (running) since mié 2016-07-06 16:58:25 CST; 2h 45min ago

--- a/installation/linux/redhat-centos.md
+++ b/installation/linux/redhat-centos.md
@@ -14,7 +14,7 @@ For CentOS 9 and later, Fluent Bit uses [CentOS Stream](https://www.centos.org/c
 
 Fluent Bit provides an installation script to use for most Linux targets. This will always install the most recently released version.
 
-```bash
+```shell
 curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 ```
 
@@ -27,8 +27,9 @@ CentOS 8 is now end-of-life, so the default Yum repositories are unavailable.
 Ensure you've configured an appropriate mirror. For example:
 
 ```shell
-sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+$ sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+
+$ sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 ```
 
 An alternative is to use Rocky or Alma Linux, which should be equivalent.
@@ -48,12 +49,12 @@ The `fluent-bit` is provided through a Yum repository. To add the repository ref
 
    ```text
    [fluent-bit]
-   name = Fluent Bit
-   baseurl = https://packages.fluentbit.io/centos/$releasever/
-   gpgcheck=1
-   gpgkey=https://packages.fluentbit.io/fluentbit.key
-   repo_gpgcheck=1
-   enabled=1
+     name = Fluent Bit
+     baseurl = https://packages.fluentbit.io/centos/$releasever/
+     gpgcheck=1
+     gpgkey=https://packages.fluentbit.io/fluentbit.key
+     repo_gpgcheck=1
+     enabled=1
    ```
 
 1. As a best practice, enable `gpgcheck` and `repo_gpgcheck` for security reasons. Fluent Bit signs its repository metadata and all Fluent Bit packages.
@@ -83,20 +84,21 @@ Refer to the [supported platform documentation](../supported-platforms.md) to se
 
 1. After your repository is configured, run the following command to install it:
 
-   ```bash
+   ```shell
    sudo yum install fluent-bit
    ```
 
 1. Instruct `Systemd` to enable the service:
 
-   ```bash
+   ```shell
    sudo systemctl start fluent-bit
    ```
 
 If you do a status check, you should see a similar output like this:
 
-```bash
+```shell
 $ systemctl status fluent-bit
+
 ● fluent-bit.service - Fluent Bit
    Loaded: loaded (/usr/lib/systemd/system/fluent-bit.service; disabled; vendor preset: disabled)
    Active: active (running) since Thu 2016-07-07 02:08:01 BST; 9s ago
@@ -116,9 +118,8 @@ The `fluent-bit.repo` file for the latest installations of Fluent Bit uses a `$r
 
 ```text
 [fluent-bit]
-name = Fluent Bit
-baseurl = https://packages.fluentbit.io/centos/$releasever/$basearch/
-...
+  name = Fluent Bit
+  baseurl = https://packages.fluentbit.io/centos/$releasever/$basearch/
 ```
 
 Depending on your Red Hat distribution version, this variable can return a value other than the OS major release version (for example, RHEL7 Server distributions return `7Server` instead of `7`). The Fluent Bit package URL uses the major OS release version, so any other value here will cause a 404.
@@ -127,12 +128,12 @@ To resolve this issue, replace the `$releasever` variable with your system's OS 
 
 ```text
 [fluent-bit]
-name = Fluent Bit
-baseurl = https://packages.fluentbit.io/centos/7/$basearch/
-gpgcheck=1
-gpgkey=https://packages.fluentbit.io/fluentbit.key
-repo_gpgcheck=1
-enabled=1
+  name = Fluent Bit
+  baseurl = https://packages.fluentbit.io/centos/7/$basearch/
+  gpgcheck=1
+  gpgkey=https://packages.fluentbit.io/fluentbit.key
+  repo_gpgcheck=1
+  enabled=1
 ```
 
 ### Yum install fails with incompatible dependencies using CentOS 9+

--- a/installation/linux/ubuntu.md
+++ b/installation/linux/ubuntu.md
@@ -6,7 +6,7 @@ Fluent Bit is distributed as the `fluent-bit` package and is available for long-
 
 An installation script is provided for most Linux targets. This will always install the most recent version released.
 
-```bash
+```shell
 curl https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
 ```
 
@@ -18,7 +18,7 @@ The first step is to add the Fluent Bit server GPG key to your keyring to ensure
 
 Follow the official [Debian wiki guidance](https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution).
 
-```bash
+```shell
 sudo sh -c 'curl https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg'
 ```
 
@@ -48,12 +48,12 @@ Refer to the [supported platform documentation](../supported-platforms.md) to se
 On Ubuntu, you need to add the Fluent Bit APT server entry to your sources lists.
 Ensure `codename` is set to your specific [Ubuntu release name](https://wiki.ubuntu.com/Releases). For example, `focal` for Ubuntu 20.04.
 
-```bash
+```shell
 codename=$(grep -oP '(?<=VERSION_CODENAME=).*' /etc/os-release 2>/dev/null || lsb_release -cs 2>/dev/null)
 ```
-Now Update your sources listes 
+Now Update your sources lists 
 
-```bash
+```shell
 echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/$codename $codename main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 ```
 
@@ -61,39 +61,41 @@ echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages
 
 Update the `apt` database on your system:
 
-```bash
+```shell
 sudo apt-get update
 ```
 
 {% hint style="info" %}
+
 Fluent Bit recommends upgrading your system to avoid potential issues with expired certificates:
 
 `sudo apt-get upgrade`
 
-
 If you receive the error `Certificate verification failed`, check if the package `ca-certificates` is properly installed:
 
 `sudo apt-get install ca-certificates`
+
 {% endhint %}
 
 ## Install Fluent Bit
 
 1. Use the following `apt-get` command to install the latest Fluent Bit:
 
-   ```bash copy
+   ```shell
    sudo apt-get install fluent-bit
    ```
 
 1. Instruct `systemd` to enable the service:
 
-   ```bash copy
+   ```shell
    sudo systemctl start fluent-bit
    ```
 
 If you do a status check, you should see a similar output like this:
 
-```bash
-systemctl status fluent-bit
+```shell
+$ systemctl status fluent-bit
+
 ● fluent-bit.service - Fluent Bit
    Loaded: loaded (/lib/systemd/system/fluent-bit.service; disabled; vendor preset: enabled)
    Active: active (running) since mié 2016-07-06 16:58:25 CST; 2h 45min ago

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -10,7 +10,7 @@ Installation packages can be found [here](https://packages.fluentbit.io/macos/).
 
 You must have [Homebrew](https://brew.sh/) installed in your system. If it isn't present, install it with the following command:
 
-```bash copy
+```shell
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
@@ -18,7 +18,7 @@ You must have [Homebrew](https://brew.sh/) installed in your system. If it isn't
 
 The Fluent Bit package on Homebrew isn't officially supported, but should work for basic use cases and testing. It can be installed using:
 
-```bash copy
+```shell
 brew install fluent-bit
 ```
 
@@ -28,7 +28,7 @@ brew install fluent-bit
 
 Run the following brew command in your terminal to retrieve the dependencies:
 
-```bash
+```shell
 brew install git cmake openssl bison libyaml
 ```
 
@@ -36,40 +36,43 @@ brew install git cmake openssl bison libyaml
 
 1. Download a copy of the Fluent Bit source code (upstream):
 
-   ```bash
-   git clone https://github.com/fluent/fluent-bit
-   cd fluent-bit
+   ```shell
+   $ git clone https://github.com/fluent/fluent-bit
+   
+   $ cd fluent-bit
    ```
 
-   If you want to use a specific version, checkout to the proper tag. For example, to use `v1.8.13`, use the command:
+   If you want to use a specific version, checkout to the proper tag. For example, to use `v4.0.4`, use the command:
 
-   ```bash copy
-   git checkout v1.8.13
+   ```shell
+   git checkout v4.0.4
    ```
 
 1. To prepare the build system, you must expose certain environment variables so Fluent Bit CMake build rules can pick the right libraries:
 
-   ```bash copy
-   export OPENSSL_ROOT_DIR=`brew --prefix openssl`
-   export PATH=`brew --prefix bison`/bin:$PATH
+   ```shell
+   $ export OPENSSL_ROOT_DIR=`brew --prefix openssl`
+   
+   $ export PATH=`brew --prefix bison`/bin:$PATH
    ```
 
 1. Change to the `build/` directory inside the Fluent Bit sources:
 
-   ```bash
+   ```shell
    cd build/
    ```
 
 1. Build Fluent Bit. This example indicates to the build system the location the final binaries and `config` files should be installed:
 
-   ```bash
-   cmake -DFLB_DEV=on -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit ../
-   make -j 16
+   ```shell
+   $ cmake -DFLB_DEV=on -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit ../
+   
+   $ make -j 16
    ```
 
 1. Install Fluent Bit to the previously specified directory. Writing to this directory requires root privileges.
 
-   ```bash
+   ```shell
    sudo make install
    ```
 
@@ -79,43 +82,47 @@ The binaries and configuration examples can be located at `/opt/fluent-bit/`.
 
 1. Clone the Fluent Bit source code (upstream):
 
-   ```bash
-   git clone https://github.com/fluent/fluent-bit
-   cd fluent-bit
+   ```shell
+   $ git clone https://github.com/fluent/fluent-bit
+   
+   $ cd fluent-bit
    ```
 
    If you want to use a specific version, checkout to the proper tag. For example,
-   to use `v1.9.2` do:
+   to use `v4.0.4` do:
 
-   ```bash
-   git checkout v1.9.2
+   ```shell
+   git checkout v4.0.4
    ```
 
 1. To prepare the build system, you must expose certain environment variables so Fluent Bit CMake build rules can pick the right libraries:
 
-   ```bash copy
-   export OPENSSL_ROOT_DIR=`brew --prefix openssl`
-   export PATH=`brew --prefix bison`/bin:$PATH
+   ```shell
+   $ export OPENSSL_ROOT_DIR=`brew --prefix openssl`
+   
+   $ export PATH=`brew --prefix bison`/bin:$PATH
    ```
 
 1. Create the specific macOS SDK target. For example, to specify macOS Big Sur (11.3) SDK environment:
 
-   ```bash copy
+   ```shell
    export MACOSX_DEPLOYMENT_TARGET=11.3
    ```
 
 1. Change to the `build/` directory inside the Fluent Bit sources:
 
-   ```bash copy
+   ```shell
    cd build/
    ```
 
 1. Build the Fluent Bit macOS installer:
 
-   ```bash copy
-   cmake -DCPACK_GENERATOR=productbuild -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit ../
-   make -j 16
-   cpack -G productbuild
+   ```shell
+   $ cmake -DCPACK_GENERATOR=productbuild -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit ../
+   
+   $ make -j 16
+   
+   $ cpack -G productbuild
    ```
 
 The macOS installer will be generated as:
@@ -145,30 +152,20 @@ The created installer will put binaries at `/opt/fluent-bit/`.
 
 To make the access path easier to Fluent Bit binary, extend the `PATH` variable:
 
-```bash copy
+```shell
 export PATH=/opt/fluent-bit/bin:$PATH
 ```
 
 To test, try Fluent Bit by generating a test message using the [Dummy input plugin](https://docs.fluentbit.io/manual/pipeline/inputs/dummy) which prints to the standard output interface every one second:
 
-```bash copy
+```shell
 fluent-bit -i dummy -o stdout -f 1
 ```
 
 You will see an output similar to this:
 
 ```text
-Fluent Bit v1.9.0
-* Copyright (C) 2015-2021 The Fluent Bit Authors
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
-
-[2022/02/08 17:13:52] [ info] [engine] started (pid=14160)
-[2022/02/08 17:13:52] [ info] [storage] version=1.1.6, initializing...
-[2022/02/08 17:13:52] [ info] [storage] in-memory
-[2022/02/08 17:13:52] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
-[2022/02/08 17:13:52] [ info] [cmetrics] version=0.2.2
-[2022/02/08 17:13:52] [ info] [sp] stream processor started
+...
 [0] dummy.0: [1644362033.676766000, {"message"=>"dummy"}]
 [0] dummy.0: [1644362034.676914000, {"message"=>"dummy"}]
 ```

--- a/installation/sources/build-and-install.md
+++ b/installation/sources/build-and-install.md
@@ -18,13 +18,13 @@ The following steps explain how to build and install the project with the defaul
 
 1. Change to the `build/` directory inside the Fluent Bit sources:
 
-   ```bash
+   ```shell
    cd build/
    ```
 
 1. Let [CMake](http://cmake.org) configure the project specifying where the root path is located:
 
-   ```bash
+   ```shell
    cmake ../
    ```
 
@@ -50,7 +50,7 @@ The following steps explain how to build and install the project with the defaul
 
 1. Start the compilation process using the `make` command:
 
-   ```bash
+   ```shell
    make
    ```
 
@@ -77,7 +77,7 @@ The following steps explain how to build and install the project with the defaul
 
 1. To continue installing the binary on the system, use `make install`:
 
-   ```bash
+   ```shell
    make install
    ```
 

--- a/installation/sources/build-with-static-configuration.md
+++ b/installation/sources/build-with-static-configuration.md
@@ -21,35 +21,34 @@ As an example, create a new `fluent-bit.yaml` file or `fluent-bit.conf` file:
 
 ```yaml
 service:
-    flush: 1
-    daemon: off
-    log_level: info
+  flush: 1
+  daemon: off
+  log_level: info
 
 pipeline:
-    inputs:
-        - name: cpu
+  inputs:
+    - name: cpu
 
-    outputs:
-        - name: stdout
-          match: '*'
+  outputs:
+    - name: stdout
+      match: '*'
 ```
 
 {% endtab %}
-
 {% tab title="fluent-bit.conf" %}
 
 ```text
 [SERVICE]
-    Flush     1
-    Daemon    off
-    Log_Level info
+  Flush     1
+  Daemon    off
+  Log_Level info
 
 [INPUT]
-    Name      cpu
+  Name      cpu
 
 [OUTPUT]
-    Name      stdout
-    Match     *
+  Name      stdout
+  Match     *
 ```
 
 {% endtab %}
@@ -61,30 +60,28 @@ This configuration calculates CPU metrics from the running system and prints the
 
 1. Go to the Fluent Bit source code build directory:
 
-   ```bash copy
+   ```shell
    cd fluent-bit/build/
    ```
 
 1. Run CMake, appending the `FLB_STATIC_CONF` option pointing to
    the configuration directory recently created:
 
-   ```bash copy
+   ```shell
    cmake -DFLB_STATIC_CONF=/path/to/my/confdir/
    ```
 
 1. Build Fluent Bit:
 
-   ```bash copy
+   ```shell
    make
    ```
 
 The generated `fluent-bit` binary is ready to run without additional configuration:
 
-```bash
+```shell
 $ bin/fluent-bit
-Fluent-Bit v0.15.0
-Copyright (C) Treasure Data
 
-[2018/10/19 15:32:31] [ info] [engine] started (pid=15186)
+...
 [0] cpu.local: [1539984752.000347547, {"cpu_p"=>0.750000, "user_p"=>0.500000, "system_p"=>0.250000, "cpu0.p_cpu"=>1.000000, "cpu0.p_user"=>1.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>0.000000, "cpu1.p_user"=>0.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>0.000000, "cpu2.p_user"=>0.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>1.000000, "cpu3.p_user"=>1.000000, "cpu3.p_system"=>0.000000}]
 ```

--- a/installation/sources/download-source-code.md
+++ b/installation/sources/download-source-code.md
@@ -17,7 +17,7 @@ For example, for version 1.8.12 the link is: [https://github.com/fluent/fluent-b
 
 If you want to contribute to Fluent Bit, you should use the most recent code. You can get the development version from the Git repository:
 
-```bash
+```shell
 git clone https://github.com/fluent/fluent-bit
 ```
 

--- a/installation/upgrade-notes.md
+++ b/installation/upgrade-notes.md
@@ -50,7 +50,14 @@ Fluent Bit v1.2 fixed many issues associated with JSON encoding and decoding.
 
 For example, when parsing Docker logs, it's no longer necessary to use decoders. The new Docker parser looks like this:
 
-```python [PARSER] Name docker Format json Time_Key time Time_Format %Y-%m-%dT%H:%M:%S.%L Time_Keep On ```
+```text
+[PARSER] 
+  Name        docker 
+  Format      json 
+  Time_Key    time 
+  Time_Format %Y-%m-%dT%H:%M:%S.%L 
+  Time_Keep   On 
+```
 
 ### Kubernetes Filter
 
@@ -58,15 +65,26 @@ Fluent Bit made improvements to Kubernetes Filter handling of stringified `log` 
 
 In addition, fixes and improvements were made to the `Merge_Log_Key` option. If a merge log succeed, all new keys will be packaged under the key specified by this option. A suggested configuration is as follows:
 
-```python [FILTER] Name Kubernetes Match kube.* Kube_Tag_Prefix kube.var.log.containers. Merge_Log On Merge_Log_Key log_processed ```
+```text 
+[FILTER] 
+  Name Kubernetes 
+  Match kube.* 
+  Kube_Tag_Prefix kube.var.log.containers. 
+  Merge_Log On 
+  Merge_Log_Key log_processed 
+```
 
 As an example, if the original log content is the following map:
 
-```javascript {"key1": "val1", "key2": "val2"} ```
+```json
+{"key1": "val1", "key2": "val2"} 
+```
 
 the final record will be composed as follows:
 
-```javascript { "log": "{\"key1\": \"val1\", \"key2\": \"val2\"}", "log_processed": { "key1": "val1", "key2": "val2" } } ```
+```json 
+{"log": "{\"key1\": \"val1\", \"key2\": \"val2\"}", "log_processed": { "key1": "val1", "key2": "val2" } } 
+```
 
 ## Fluent Bit v1.1
 
@@ -78,7 +96,12 @@ Fluent Bit introduced a new configuration property called `Kube_Tag_Prefix` to h
 
 During the `1.0.x` release cycle, a commit in the Tail input plugin changed the default behavior on how the Tag was composed when using the wildcard for expansion generating breaking compatibility with other services. Consider the following configuration example:
 
-```python [INPUT] Name tail Path /var/log/containers/*.log Tag kube.* ```
+```text 
+[INPUT] 
+  Name tail 
+  Path /var/log/containers/*.log 
+  Tag kube.* 
+```
 
 The expected behavior is that Tag will be expanded to:
 
@@ -94,8 +117,16 @@ Having absolute path in the Tag is relevant for routing and flexible configurati
 
 This behavior switch in Tail input plugin affects how Filter Kubernetes operates. When the filter is used it needs to perform local metadata lookup that comes from the file names when using Tail as a source. With the new `Kube_Tag_Prefix` option you can specify the prefix used in the Tail input plugin. For the previous configuration example the new configuration will look like:
 
-```python [INPUT] Name tail Path /var/log/containers/*.log Tag kube.*
+```text 
+[INPUT] 
+  Name tail 
+  Path /var/log/containers/*.log 
+  Tag kube.*
 
-[FILTER] Name kubernetes Match * Kube_Tag_Prefix kube.var.log.containers. ```
+[FILTER] 
+  Name kubernetes 
+  Match * 
+  Kube_Tag_Prefix kube.var.log.containers. 
+```
 
 The proper value for `Kube_Tag_Prefix` must be composed by Tag prefix set in Tail input plugin plus the converted monitored directory replacing slashes with dots.

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -10,70 +10,102 @@ Provide a valid Windows configuration with the installation.
 
 The following configuration is an example:
 
-```python
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+service:
+  flush: 5
+  daemon: off
+  log_level: info
+  parsers_file: parsers.yaml
+  plugins_file: plugins.yaml
+  http_server: off
+  http_listen: 0.0.0.0
+  http_port: 2020
+  storage.metrics: on
+
+pipeline:
+  inputs:
+    - name: winlog
+      channels: Setup,Windows Powershell
+      interval_sec: 1
+
+  outputs:
+    - name: stdout
+      match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [SERVICE]
-    # Flush
-    # =====
-    # set an interval of seconds before to flush records to a destination
-    flush        5
+  # Flush
+  # =====
+  # set an interval of seconds before to flush records to a destination
+  flush        5
 
-    # Daemon
-    # ======
-    # instruct Fluent Bit to run in foreground or background mode.
-    daemon       Off
+  # Daemon
+  # ======
+  # instruct Fluent Bit to run in foreground or background mode.
+  daemon       Off
 
-    # Log_Level
-    # =========
-    # Set the verbosity level of the service, values can be:
-    #
-    # - error
-    # - warning
-    # - info
-    # - debug
-    # - trace
-    #
-    # by default 'info' is set, that means it includes 'error' and 'warning'.
-    log_level    info
+  # Log_Level
+  # =========
+  # Set the verbosity level of the service, values can be:
+  #
+  # - error
+  # - warning
+  # - info
+  # - debug
+  # - trace
+  #
+  # by default 'info' is set, that means it includes 'error' and 'warning'.
+  log_level    info
 
-    # Parsers File
-    # ============
-    # specify an optional 'Parsers' configuration file
-    parsers_file parsers.conf
+  # Parsers File
+  # ============
+  # specify an optional 'Parsers' configuration file
+  parsers_file parsers.conf
 
-    # Plugins File
-    # ============
-    # specify an optional 'Plugins' configuration file to load external plugins.
-    plugins_file plugins.conf
+  # Plugins File
+  # ============
+  # specify an optional 'Plugins' configuration file to load external plugins.
+  plugins_file plugins.conf
 
-    # HTTP Server
-    # ===========
-    # Enable/Disable the built-in HTTP Server for metrics
-    http_server  Off
-    http_listen  0.0.0.0
-    http_port    2020
+  # HTTP Server
+  # ===========
+  # Enable/Disable the built-in HTTP Server for metrics
+  http_server  Off
+  http_listen  0.0.0.0
+  http_port    2020
 
-    # Storage
-    # =======
-    # Fluent Bit can use memory and filesystem buffering based mechanisms
-    #
-    # - https://docs.fluentbit.io/manual/administration/buffering-and-storage
-    #
-    # storage metrics
-    # ---------------
-    # publish storage pipeline metrics in '/api/v1/storage'. The metrics are
-    # exported only if the 'http_server' option is enabled.
-    #
-    storage.metrics on
+  # Storage
+  # =======
+  # Fluent Bit can use memory and filesystem buffering based mechanisms
+  #
+  # - https://docs.fluentbit.io/manual/administration/buffering-and-storage
+  #
+  # storage metrics
+  # ---------------
+  # publish storage pipeline metrics in '/api/v1/storage'. The metrics are
+  # exported only if the 'http_server' option is enabled.
+  #
+  storage.metrics on
 
 [INPUT]
-    Name         winlog
-    Channels     Setup,Windows PowerShell
-    Interval_Sec 1
+  Name         winlog
+  Channels     Setup,Windows PowerShell
+  Interval_Sec 1
 
 [OUTPUT]
-    name  stdout
-    match *
+  name  stdout
+  match *
 ```
+
+{% endtab %}
+{% endtabs %}
 
 ## Migration to Fluent Bit
 
@@ -102,7 +134,7 @@ MSI installers are also available:
 
 To check the integrity, use the `Get-FileHash` cmdlet for PowerShell.
 
-```shell copy
+```shell
 Get-FileHash fluent-bit-4.0.5-win32.exe
 ```
 
@@ -138,24 +170,15 @@ Get-FileHash fluent-bit-4.0.5-win32.exe
 1. Launch `cmd.exe` or PowerShell on your machine, and execute `fluent-bit.exe`:
 
    ```shell
-   .\bin\fluent-bit.exe -i dummy -o stdout
+   fluent-bit.exe -i dummy -o stdout
    ```
 
 The following output indicates Fluent Bit is running:
 
 ```shell
-.\bin\fluent-bit.exe  -i dummy -o stdout
-Fluent Bit v2.0.x
-* Copyright (C) 2019-2020 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
+fluent-bit.exe  -i dummy -o stdout
 
-[2019/06/28 10:13:04] [ info] [storage] initializing...
-[2019/06/28 10:13:04] [ info] [storage] in-memory
-[2019/06/28 10:13:04] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
-[2019/06/28 10:13:04] [ info] [engine] started (pid=10324)
-[2019/06/28 10:13:04] [ info] [sp] stream processor started
+...
 [0] dummy.0: [1561684385.443823800, {"message"=>"dummy"}]
 [1] dummy.0: [1561684386.428399000, {"message"=>"dummy"}]
 [2] dummy.0: [1561684387.443641900, {"message"=>"dummy"}]
@@ -337,13 +360,13 @@ start vs.exe
 Now you should be able to run Fluent Bit:
 
 ```shell
-.\bin\debug\fluent-bit.exe -i dummy -o stdout
+fluent-bit.exe -i dummy -o stdout
 ```
 
 ### Packaging
 
 To create a ZIP package, call `cpack` as follows:
 
-```text
+```shell
 cpack -G ZIP
 ```

--- a/local-testing/logging-pipeline.md
+++ b/local-testing/logging-pipeline.md
@@ -12,14 +12,14 @@ Start by creating one of the corresponding Fluent Bit configuration files to sta
 
 ```yaml
 pipeline:
-    inputs:
-        - name: dummy
-          dummy: '{"top": {".dotted": "value"}}'
-          
-    outputs:       
-        - name: es
-          host: elasticsearch
-          replace_dots: on
+  inputs:
+    - name: dummy
+      dummy: '{"top": {".dotted": "value"}}'
+      
+  outputs:       
+    - name: es
+      host: elasticsearch
+      replace_dots: on
 ```
 
 {% endtab %}
@@ -44,6 +44,7 @@ pipeline:
 Use [Docker Compose](https://docs.docker.com/compose/) to run Fluent Bit (with the configuration file mounted) and Elasticsearch.
 
 {% code title="docker-compose.yaml" %}
+
 ```yaml
 version: "3.7"
 
@@ -61,13 +62,14 @@ services:
     environment:
       - discovery.type=single-node
 ```
+
 {% endcode %}
 
 ## View indexed logs
 
 To view indexed logs, run the following command:
 
-```bash
+```shell
 curl "localhost:9200/_search?pretty" \
   -H 'Content-Type: application/json' \
   -d'{ "query": { "match_all": {} }}'
@@ -77,6 +79,6 @@ curl "localhost:9200/_search?pretty" \
 
 To reset your index, run the following command:
 
-```bash
+```shell
 curl -X DELETE "localhost:9200/fluent-bit?pretty"
 ```

--- a/pipeline/inputs/exec.md
+++ b/pipeline/inputs/exec.md
@@ -177,7 +177,7 @@ Take great care with shell quoting and escaping when wrapping commands.
 
 A script like the following can ruin your day if someone passes it the argument `$(rm -rf /my/important/files; echo "deleted your stuff!")'`
 
-```bash
+```shell
 #!/bin/bash
 # This is a DANGEROUS example of what NOT to do, NEVER DO THIS
 exec fluent-bit \
@@ -190,7 +190,7 @@ exec fluent-bit \
 
 The previous script would be safer if written with:
 
-```bash
+```shell
   -p command='echo '"$(printf '%q' "$@")" \
 ```
 

--- a/pipeline/inputs/standard-input.md
+++ b/pipeline/inputs/standard-input.md
@@ -68,7 +68,7 @@ To demonstrate how the plugin works, you can use a `bash` script that generates 
 
 3. The command should return output like the following:
 
-    ```shell
+    ```text
     [0] stdin.0: [[1684196745.942883835, {}], {"key"=>"some value"}]
     [0] stdin.0: [[1684196746.938949056, {}], {"key"=>"some value"}]
     [0] stdin.0: [[1684196747.940162493, {}], {"key"=>"some value"}]
@@ -105,7 +105,7 @@ To demonstrate how the plugin works, you can use a `bash` script that generates 
 
 3. Which returns the following:
 
-    ```shell
+    ```text
     [0] stdin.0: [[1684110480.028171300, {}], {"realtimestamp"=>1684196880.030070}]
     [0] stdin.0: [[1684110481.033753395, {}], {"realtimestamp"=>1684196881.034741}]
     [0] stdin.0: [[1684110482.036730051, {}], {"realtimestamp"=>1684196882.037704}]
@@ -144,7 +144,7 @@ To demonstrate how the plugin works, you can use a `bash` script that generates 
 
 3. Which returns results like the following:
 
-    ```shell
+    ```text
     [0] stdin.0: [[1684110513.060139417, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196913.061017}]
     [0] stdin.0: [[1684110514.063085317, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196914.064145}]
     [0] stdin.0: [[1684110515.066210508, {"metakey"=>"metavalue"}], {"realtimestamp"=>1684196915.067155}]
@@ -155,7 +155,7 @@ To demonstrate how the plugin works, you can use a `bash` script that generates 
 
 4. On older Fluent Bit versions records in this format will be discarded. If the log level permits, Fluent Bit will log:
 
-    ```shell
+    ```text
     [ warn] unknown time format 6
     ```
 

--- a/stream-processing/getting-started/hands-on.md
+++ b/stream-processing/getting-started/hands-on.md
@@ -18,39 +18,29 @@ These steps use the official Fluent Bit Docker image.
 
 Run the following command to confirm that Fluent Bit is installed and up-to-date:
 
-```bash
-docker run -ti fluent/fluent-bit:1.4 /fluent-bit/bin/fluent-bit --version
-Fluent Bit v1.8.2
+```shell
+$ docker run -ti fluent/fluent-bit:1.4 /fluent-bit/bin/fluent-bit --version
+
+Fluent Bit v4.0.4
 ```
 
 ### 2. Parse sample files
 
 The sample file contains JSON records. Run the following command to append the `parsers.conf` file and instruct the Tail input plugin to parse content as JSON:
 
-```bash
-docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log        \
-     fluent/fluent-bit:1.8.2                                          \
-     /fluent-bit/bin/fluent-bit -R /fluent-bit/etc/parsers.conf     \
-                                -i tail -p path=/sp-samples-1k.log  \
-                                        -p parser=json              \
-                                        -p read_from_head=true      \
-                                -o stdout -f 1
+```shell
+docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log  \
+  fluent/fluent-bit:1.8.2                                     \
+  /fluent-bit/bin/fluent-bit -R /fluent-bit/etc/parsers.conf  \
+  -i tail -p path=/sp-samples-1k.log  \
+  -p parser=json                      \
+  -p read_from_head=true              \
+  -o stdout -f 1
 ```
 
 This command prints the parsed content to the standard output interface. The parsed content includes a tag associated with each record and an array with two fields: a timestamp and a record map:
 
 ```text
-Fluent Bit v1.8.2
-* Copyright (C) 2019-2021 The Fluent Bit Authors
-* Copyright (C) 2015-2018 Treasure Data
-* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
-* https://fluentbit.io
-
-[2019/05/08 13:34:16] [ info] [storage] initializing...
-[2019/05/08 13:34:16] [ info] [storage] in-memory
-[2019/05/08 13:34:16] [ info] [storage] normal synchronization mode, checksum disabled
-[2019/05/08 13:34:16] [ info] [engine] started (pid=1)
-[2019/05/08 13:34:16] [ info] [sp] stream processor started
 [0] tail.0: [1557322456.315513208, {"date"=>"22/abr/2019:12:43:51 -0600", "ip"=>"73.113.230.135", "word"=>"balsamine", "country"=>"Japan", "flag"=>false, "num"=>96}]
 [1] tail.0: [1557322456.315525280, {"date"=>"22/abr/2019:12:43:52 -0600", "ip"=>"242.212.128.227", "word"=>"inappendiculate", "country"=>"Chile", "flag"=>false, "num"=>15}]
 [2] tail.0: [1557322456.315532364, {"date"=>"22/abr/2019:12:43:52 -0600", "ip"=>"85.61.182.212", "word"=>"elicits", "country"=>"Argentina", "flag"=>true, "num"=>73}]
@@ -63,17 +53,17 @@ Fluent Bit v1.8.2
 
 Run the following command to create a stream processor query using the `-T` flag and change the output to the Null plugin. This obtains the stream processing results in the standard output interface and avoids confusion in the terminal.
 
-```bash
-docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log             \
-     fluent/fluent-bit:1.2                                               \
-     /fluent-bit/bin/fluent-bit                                          \
-         -R /fluent-bit/etc/parsers.conf                                 \
-         -i tail                                                         \
-             -p path=/sp-samples-1k.log                                  \
-             -p parser=json                                              \
-             -p read_from_head=true                                      \
-         -T "SELECT word, num FROM STREAM:tail.0 WHERE country='Chile';" \
-         -o null -f 1
+```shell
+docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log  \
+  fluent/fluent-bit:1.2                                       \
+  /fluent-bit/bin/fluent-bit                                  \
+  -R /fluent-bit/etc/parsers.conf                             \
+  -i tail                                                     \
+  -p path=/sp-samples-1k.log                                  \
+  -p parser=json                                              \
+  -p read_from_head=true                                      \
+  -T "SELECT word, num FROM STREAM:tail.0 WHERE country='Chile';" \
+  -o null -f 1
 ```
 
 The previous query aims to retrieve all records for which the `country` key contains the value `Chile`. For each match, it composes and outputs a record that only contains the keys `word` and `num`:
@@ -90,17 +80,17 @@ The previous query aims to retrieve all records for which the `country` key cont
 
 Run the following command to use the `AVG` aggregation function to get the average value of ingested records:
 
-```bash
-docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log             \
-     fluent/fluent-bit:1.8.2                                             \
-     /fluent-bit/bin/fluent-bit                                          \
-         -R /fluent-bit/etc/parsers.conf                                 \
-         -i tail                                                         \
-             -p path=/sp-samples-1k.log                                  \
-             -p parser=json                                              \
-             -p read_from_head=true                                      \
-         -T "SELECT AVG(num) FROM STREAM:tail.0 WHERE country='Chile';"  \
-         -o null -f 1
+```shell
+docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log  \
+  fluent/fluent-bit:1.8.2                                     \
+  /fluent-bit/bin/fluent-bit                                  \
+  -R /fluent-bit/etc/parsers.conf                             \
+  -i tail                                                     \
+  -p path=/sp-samples-1k.log                                  \
+  -p parser=json                                              \
+  -p read_from_head=true                                      \
+  -T "SELECT AVG(num) FROM STREAM:tail.0 WHERE country='Chile';"  \
+  -o null -f 1
 ```
 
 The previous query yields the following output:
@@ -114,27 +104,29 @@ The previous query yields the following output:
 ```
 
 {% hint style="info" %}
+
 The resulting output contains multiple records because Fluent Bit processes data in chunks, and the stream processor processes each chunk independently. To process multiple chunks at the same time, you can group results using time windows.
+
 {% endhint %}
 
 ### 5. Group results and windows
 
 Grouping results within a time window simplifies data processing. Run the following command to group results by `country` and calculate the average of `num` with a one-second processing window:
 
-```bash
-docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log        \
-     fluent/fluent-bit:1.8.2                                        \
-     /fluent-bit/bin/fluent-bit                                     \
-         -R /fluent-bit/etc/parsers.conf                            \
-         -i tail                                                    \
-             -p path=/sp-samples-1k.log                             \
-             -p parser=json                                         \
-             -p read_from_head=true                                 \
-         -T "SELECT country, AVG(num) FROM STREAM:tail.0            \
-             WINDOW TUMBLING (1 SECOND)                             \
-             WHERE country='Chile'                                  \
-             GROUP BY country;"                                     \
-         -o null -f 1
+```shell
+docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log \
+  fluent/fluent-bit:1.8.2                                    \
+  /fluent-bit/bin/fluent-bit                                 \
+  -R /fluent-bit/etc/parsers.conf                            \
+  -i tail                                                    \
+  -p path=/sp-samples-1k.log                                 \
+  -p parser=json                                             \
+  -p read_from_head=true                                     \
+  -T "SELECT country, AVG(num) FROM STREAM:tail.0            \
+      WINDOW TUMBLING (1 SECOND)                             \
+      WHERE country='Chile'                                  \
+      GROUP BY country;"                                     \
+  -o null -f 1
 ```
 
 The previous query yields the following output:
@@ -149,22 +141,22 @@ Next, instruct the stream processor to ingest results as part of the Fluent Bit 
 
 Run the following command, which uses a `CREATE STREAM` statement to tag results with the `sp-results` tag, then outputs records with that tag to standard output:
 
-```bash
-docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log        \
-     fluent/fluent-bit:1.8.2                                        \
-     /fluent-bit/bin/fluent-bit                                     \
-         -R /fluent-bit/etc/parsers.conf                            \
-         -i tail                                                    \
-             -p path=/sp-samples-1k.log                             \
-             -p parser=json                                         \
-             -p read_from_head=true                                 \
-         -T "CREATE STREAM results WITH (tag='sp-results')          \
-             AS                                                     \
-               SELECT country, AVG(num) FROM STREAM:tail.0          \
-               WINDOW TUMBLING (1 SECOND)                           \
-               WHERE country='Chile'                                \
-               GROUP BY country;"                                   \
-         -o stdout -m 'sp-results' -f 1
+```shell
+docker run -ti -v `pwd`/sp-samples-1k.log:/sp-samples-1k.log   \
+  fluent/fluent-bit:1.8.2                                      \
+  /fluent-bit/bin/fluent-bit                                   \
+  -R /fluent-bit/etc/parsers.conf                              \
+  -i tail                                                      \
+  -p path=/sp-samples-1k.log                                   \
+  -p parser=json                                               \
+  -p read_from_head=true                                       \
+  -T "CREATE STREAM results WITH (tag='sp-results')            \
+      AS                                                       \
+      SELECT country, AVG(num) FROM STREAM:tail.0              \
+      WINDOW TUMBLING (1 SECOND)                               \
+      WHERE country='Chile'                                    \
+      GROUP BY country;"                                       \
+  -o stdout -m 'sp-results' -f 1
 ```
 
 The previous query yields the following results:


### PR DESCRIPTION
General code example cleanup where wrong code type specified in code blocks throughout entire docs project. Fixes #2020.

Looking to standardize and searching out incorrect usage of shell vs bash and text vs python.
