### PR TITLE
Testing CI/CD by adding vale to actions

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -30,3 +30,4 @@ jobs:
       - uses: errata-ai/vale-action@v2.1.1
         with:
           files: all
+          fail_on_error: true

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -21,3 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ludeeus/action-shellcheck@master
+
+  vale:
+    name: runner / vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@v2.1.1

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -28,3 +28,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: errata-ai/vale-action@v2.1.1
+        with:
+          files: all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ requests. Vale suggestions, errors, and warnings will display in GitHub on the
 
 Most Vale tests are at the `suggestion` level and won't block merging.
 
-The following tests are at a `error` level and will cause a test failure:
+The following tests are at `error` level and will cause a test failure:
 
 - [AmSpelling](https://developers.google.com/style/word-list)
 - [Ampersand](https://developers.google.com/style/word-list#ampersand)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,11 +132,15 @@ the prose of your pull requests and adds suggestions to improve style and clarit
 There is a [VSCode plugin for Vale](https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode)
 which outputs suggestions to the problems pane in the IDE.
 
+The Fluent Bit repository runs Vale as a GitHub Action on updated text in new pull
+requests. Vale suggestions, errors, and warnings will display in GitHub on the
+**Files changed** page.
+
 [See the Vale tests for Fluent Bit](https://github.com/fluent/fluent-bit-docs/tree/master/vale-styles).
 
 Most Vale tests are at the `suggestion` level and won't block merging.
 
-The following tests are at a `error` level and will prevent merging:
+The following tests are at a `error` level and will cause a test failure:
 
 - [AmSpelling](https://developers.google.com/style/word-list)
 - [Ampersand](https://developers.google.com/style/word-list#ampersand)

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -5,8 +5,6 @@ description: A guide on how to install, deploy, and upgrade Fluent Bit
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e9732f9c-44a4-46d3-ab87-86138455c698" />
 
-Fluent bit &
-
 ## Container deployment
 
 | Deployment Type   | instructions                                       |

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -5,7 +5,7 @@ description: A guide on how to install, deploy, and upgrade Fluent Bit
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e9732f9c-44a4-46d3-ab87-86138455c698" />
 
-Fluent bit
+Fluent bit &
 
 ## Container deployment
 

--- a/installation/getting-started-with-fluent-bit.md
+++ b/installation/getting-started-with-fluent-bit.md
@@ -5,6 +5,8 @@ description: A guide on how to install, deploy, and upgrade Fluent Bit
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e9732f9c-44a4-46d3-ab87-86138455c698" />
 
+Fluent bit
+
 ## Container deployment
 
 | Deployment Type   | instructions                                       |


### PR DESCRIPTION
This adds vale testing as a GitHub action. Vale will run on any updated text in PRs and display notices in the Files Changed tab. Vale tests are set to fail on [tests that error](https://github.com/fluent/fluent-bit-docs/blob/master/CONTRIBUTING.md#additional-testing). Failing tests do not block merging at this time.
