### PR TITLE
installation: linux: debian: update package name to fluent-bit

### DIFF
--- a/installation/linux/debian.md
+++ b/installation/linux/debian.md
@@ -1,6 +1,6 @@
 # Debian
 
-Fluent Bit is distributed as the `fluent-bit` package and is available for the latest stable CentOS system.
+Fluent Bit is distributed as the `fluent-bit` package and is available for the latest stable Debian system.
 
 The following architectures are supported
 


### PR DESCRIPTION
This pull request corrects a typo in the documentation for installing Fluent Bit on `Debian` systems. The package name has been updated to the correct `fluent-bit`