### PR TITLE
Add fluentbit_input_ingestion_paused metric to the documentation

### DIFF
--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -191,6 +191,7 @@ The following terms are key to understanding how Fluent Bit processes metrics:
 | Metric Name                                | Labels                                                                  | Description | Type    | Unit    |
 |--------------------------------------------|-------------------------------------------------------------------------|-------------|---------|---------|
 | `fluentbit_input_bytes_total`            | name: the name or alias for the input instance  | The number of bytes of log records that this input instance has ingested successfully. | counter | bytes   |
+| `fluentbit_input_ingestion_paused`       | name: the name or alias for the input instance  | Indicates whether the input instance ingestion is currently paused (1) or not (0). | gauge   | boolean |
 | `fluentbit_input_records_total`          | name: the name or alias for the input instance  | The number of log records this input ingested successfully. | counter | records |
 | `fluentbit_filter_bytes_total`           | name: the name or alias for the filter instance | The number of bytes of log records that this filter instance has ingested successfully. | counter | bytes   |
 | `fluentbit_filter_records_total`         | name: the name or alias for the filter instance | The number of log records this filter has ingested successfully. | counter | records |


### PR DESCRIPTION
:wave:

While working on reducing dropped logs in a high-volume Kubernetes setup, we found the ingestion paused input metric (added in https://github.com/fluent/fluent-bit/pull/8044) to be super helpful for validating Fluent Bit health under pressure and for tuning settings like `mem_buf_limit`. We realized it was not called out in the docs, so this PR adds it to the metrics reference for future operators.