### PR TITLE
Link checker scheduling

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -3,7 +3,7 @@ name: Links
 on:
   pull_request:
   schedule:
-    - cron: "00 18 * * 7"
+    - cron: "00 18 * * 0"
 
 
 jobs:

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,7 +1,6 @@
 name: Links
 
 on:
-  pull_request:
   schedule:
     - cron: "00 18 * * 0"
 

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -2,6 +2,9 @@ name: Links
 
 on:
   pull_request:
+  schedule:
+    - cron: "00 18 * * 7"
+
 
 jobs:
   linkChecker:
@@ -18,10 +21,10 @@ jobs:
           fail: false
           jobSummary: true
 
-#      - name: Create Issue From File
-#        if: steps.lychee.outputs.exit_code != 0
-#        uses: peter-evans/create-issue-from-file@v5
-#        with:
-#          title: Link Checker Report
-#          content-filepath: ./lychee/out.md
-#          labels: report, automated issue
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
This updates the link checker test to run on Sundays at 6 PM and open an issue if there's a bad link.

If this does open an issue on sunday (because I know there's one link that does complain due to a 403), then we'll know it works. 

Once it's working, I'll follow up with a secondary issue to run the link checker once a month so we can be sure the links are being checked regularly, without overwhelming the issue queue. 