### PR TITLE
Update Linkcheck test frequency

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -2,8 +2,10 @@ name: Links
 
 on:
   schedule:
-    - cron: "00 18 * * 0"
-
+    - cron: "00 18 1 * *"
+# Uncomment the following line while testing links in a single PR. Recomment when
+# done.
+# pull_request
 
 jobs:
   linkChecker:
@@ -19,6 +21,8 @@ jobs:
         with:
           fail: false
           jobSummary: true
+
+# If testing links on pull_request, comment these lines out!
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "00 18 1 * *"
 # Uncomment the following line while testing links in a single PR. Recomment when
-# done.
+# done. Be sure to comment out the 'Create Issue from File' section while testing.
 # pull_request
 
 jobs:


### PR DESCRIPTION
This PR changes the link check test to run on the first of the month at 1800 hours. This ensures we have at least a once a month check on links.

Also adds notes on how to use the checker for PRs when you're moving pages around so you don't get a bunch of link report issues. 