### PR TITLE
fix: Parsers do not have to be in seperate files

### DIFF
--- a/pipeline/parsers/configuring-parser.md
+++ b/pipeline/parsers/configuring-parser.md
@@ -45,7 +45,7 @@ Multiple parsers can be defined and each section has it own properties. The foll
 
 ## Parsers configuration file
 
-All parsers may be defined in a parsers file. The parsers file exposes all parsers available that can be used by the input plugins that are aware of this feature. A parsers file can have multiple entries, like so:
+All parsers can be defined in a parsers file. The parsers file exposes all parsers available that can be used by the input plugins that are aware of this feature. A parsers file can have multiple entries, like so:
 
 {% tabs %}
 {% tab title="parsers.yaml" %}

--- a/pipeline/parsers/configuring-parser.md
+++ b/pipeline/parsers/configuring-parser.md
@@ -45,7 +45,7 @@ Multiple parsers can be defined and each section has it own properties. The foll
 
 ## Parsers configuration file
 
-All parsers must be defined in a parsers file, not in the Fluent Bit global configuration file. The parsers file exposes all parsers available that can be used by the input plugins that are aware of this feature. A parsers file can have multiple entries, like so:
+All parsers may be defined in a parsers file. The parsers file exposes all parsers available that can be used by the input plugins that are aware of this feature. A parsers file can have multiple entries, like so:
 
 {% tabs %}
 {% tab title="parsers.yaml" %}


### PR DESCRIPTION
On the "Configuring parsers" section, subsection "Parser Configuration File"[2], it says:

> All parsers must be defined in a parsers file, not in the Fluent Bit
> global configuration file.


But on the "Parsers" page[1] for the v4.0 documentation, it states:

> You can define parsers either directly in the main configuration file
> or in separate external files for better organization.


Those seem like contradictory statements. I think the truth is that parsers may be defined in the main global configuration file if the main configuration file is YAML, or in a separate "parsers" file in either classic or YAML config files. I think the behavior of supporting parsers defined in the main YAML configuration file has been supported since v3.2

I'm proposing the smallest possible change to make the docs no longer be incorrect, but please close this PR if y'all feel there's broader changes to be made to these docs.

[1] - https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/yaml/parsers-section
[2] - https://docs.fluentbit.io/manual/data-pipeline/parsers/configuring-parser#parsers-configuration-file