### PR TITLE
packaging: remove buster

### DIFF
--- a/installation/downloads/linux/raspbian-raspberry-pi.md
+++ b/installation/downloads/linux/raspbian-raspberry-pi.md
@@ -4,7 +4,6 @@ Fluent Bit is distributed as the `fluent-bit` package and is available for [Rasp
 
 - Raspbian Bookworm (12)
 - Raspbian Bullseye (11)
-- Raspbian Buster (10)
 
 ## Server GPG key
 
@@ -30,12 +29,6 @@ echo "deb https://packages.fluentbit.io/raspbian/bookworm bookworm main" | sudo 
 
 ```shell
 echo "deb https://packages.fluentbit.io/raspbian/bullseye bullseye main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
-```
-
-### Raspbian 10 (Buster)
-
-```shell
-echo "deb https://packages.fluentbit.io/raspbian/buster buster main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 ```
 
 ### Update your repositories database


### PR DESCRIPTION
Should be merged after https://github.com/fluent/fluent-bit/pull/10908 and https://github.com/fluent/fluent-bit-docs/pull/2067 has been merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Raspbian Buster (10) from the list of supported versions and updated the installation instructions accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->