### PR TITLE
geoip2-filter: Correct filter name in example

### DIFF
--- a/pipeline/filters/geoip2-filter.md
+++ b/pipeline/filters/geoip2-filter.md
@@ -32,7 +32,7 @@ pipeline:
       dummy: {"remote_addr": "8.8.8.8"}
 
   filters:
-    - name: gioip2
+    - name: geoip2
       match: '*'
       database: GioLite2-City.mmdb
       lookup_key: remote_addr


### PR DESCRIPTION
This is just a correction of geoip2 filter name in example

I just copy pasted it and noticed that name is incorrect after running fluent-bit