### PR TITLE
Added output plugin entry for otuput formats file. Fixes #2105.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -203,6 +203,7 @@
   * [OpenSearch](pipeline/outputs/opensearch.md)
   * [OpenTelemetry](pipeline/outputs/opentelemetry.md)
   * [Oracle Cloud Infrastructure Logging Analytics](pipeline/outputs/oci-logging-analytics.md)
+  * [Output Formats](pipeline/outputs/output_formats.md)
   * [Parseable](pipeline/outputs/parseable.md)
   * [PostgreSQL](pipeline/outputs/postgresql.md)
   * [Prometheus exporter](pipeline/outputs/prometheus-exporter.md)


### PR DESCRIPTION
Trivial entry to list missing output plugin file found in pipeline/outputs/output_formats.md. Fixes #2105.