### PR TITLE
pipeline: inputs: create gpu-metrics docs. Fixes #2080

### DIFF
--- a/pipeline/inputs/gpu-metrics.md
+++ b/pipeline/inputs/gpu-metrics.md
@@ -1,27 +1,27 @@
-# GPU Metrics
+# GPU metrics
 
-The **gpu_metrics** input plugin collects GPU performance metrics from graphics cards on Linux systems. It provides real-time monitoring of GPU utilization, memory usage (VRAM), clock frequencies, power consumption, temperature, and fan speeds.
+The **gpu_metrics** input plugin collects graphics processing unit (GPU) performance metrics from graphics cards on Linux systems. It provides real-time monitoring of GPU utilization, memory usage (VRAM), clock frequencies, power consumption, temperature, and fan speeds.
 
-The plugin reads metrics directly from the Linux sysfs filesystem (`/sys/class/drm/`) without requiring external tools or libraries. Currently, **only AMD GPUs are supported** through the amdgpu kernel driver. NVIDIA and Intel GPUs are not supported at this time.
+The plugin reads metrics directly from the Linux sysfs filesystem (`/sys/class/drm/`) without requiring external tools or libraries. Currently, **only AMD GPUs are supported** through the amdgpu kernel driver. NVIDIA and Intel GPUs aren't supported at this time.
 
-## Metrics Collected
+## Metrics collected
 
 The plugin collects the following metrics for each detected GPU:
 
-| Key                       | Description                                                                                                    |
-|---------------------------|----------------------------------------------------------------------------------------------------------------|
-| `gpu_utilization_percent` | GPU core utilization as a percentage (0-100). Indicates how busy the GPU is processing workloads.              |
-| `gpu_memory_used_bytes`   | Amount of VRAM currently in use, measured in bytes.                                                            |
-| `gpu_memory_total_bytes`  | Total VRAM capacity available on the GPU, measured in bytes.                                                   |
-| `gpu_clock_mhz`           | Current GPU clock frequency in MHz. This metric has multiple instances with different type labels (see below). |
-| `gpu_power_watts`         | Current power consumption in watts. Can be disabled with enable_power false.                                   |
-| `gpu_temperature_celsius` | GPU die temperature in degrees Celsius. Can be disabled with enable_temperature false.                         |
-| `gpu_fan_speed_rpm`       | Fan rotation speed in revolutions per minute (RPM).                                                            |
-| `gpu_fan_pwm_percent`     | Fan PWM duty cycle as a percentage (0-100). Indicates fan intensity.                                           |
+| Key                       | Description                                                                                                                              |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `gpu_utilization_percent` | GPU core utilization as a percentage (0-100). Indicates how busy the GPU is processing workloads.                                        |
+| `gpu_memory_used_bytes`   | Amount of video RAM (VRAM) currently in use, measured in bytes.                                                                          |
+| `gpu_memory_total_bytes`  | Total video RAM (VRAM) capacity available on the GPU, measured in bytes.                                                                 |
+| `gpu_clock_mhz`           | Current GPU clock frequency in MHz. This metric has multiple instances with different type labels (see [Clock metrics](#clock-metrics)). |
+| `gpu_power_watts`         | Current power consumption in watts. Can be disabled with enable_power false.                                                             |
+| `gpu_temperature_celsius` | GPU die temperature in degrees Celsius. Can be disabled with enable_temperature false.                                                   |
+| `gpu_fan_speed_rpm`       | Fan rotation speed in revolutions per minute (RPM).                                                                                      |
+| `gpu_fan_pwm_percent`     | Fan PWM duty cycle as a percentage (0-100). Indicates fan intensity.                                                                     |
 
-### Clock Metrics
+### Clock metrics
 
-The gpu_clock_mhz metric is reported separately for three clock domains:
+The `gpu_clock_mhz` metric is reported separately for three clock domains:
 
 | Type       | Description                          |
 |------------|--------------------------------------|
@@ -29,7 +29,7 @@ The gpu_clock_mhz metric is reported separately for three clock domains:
 | `memory`   | VRAM clock frequency.                |
 | `soc`      | System-on-chip clock frequency.      |
 
-## Configuration Parameters
+## Configuration parameters
 
 The plugin supports the following configuration parameters:
 
@@ -39,10 +39,10 @@ The plugin supports the following configuration parameters:
 | `path_sysfs`         | Path to the sysfs root directory. Typically used for testing or non-standard systems.                                   | `/sys`    |
 | `cards_include`      | Pattern specifying which GPU cards to monitor. Supports wildcards (*), ranges (0-3), and comma-separated lists (0,2,4). | `*`       |
 | `cards_exclude`      | Pattern specifying which GPU cards to exclude from monitoring. Uses the same syntax as cards_include.                   | _none_    |
-| `enable_power`       | Enable collection of power consumption metrics (gpu_power_watts).                                                       | `true`    |
-| `enable_temperature` | Enable collection of temperature metrics (gpu_temperature_celsius).                                                     | `true`    |
+| `enable_power`       | Enable collection of power consumption metrics (`gpu_power_watts`).                                                     | `true`    |
+| `enable_temperature` | Enable collection of temperature metrics (`gpu_temperature_celsius`).                                                   | `true`    |
 
-## GPU Detection
+## GPU detection
 
 The GPU metrics plugin will automatically scan for supported **AMD GPUs** that are using the `amdgpu` kernel driver. GPUs using legacy drivers will be ignored.
 
@@ -59,7 +59,7 @@ Example output:
 73:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Granite Ridge [Radeon Graphics] (rev c5)
 ```
 
-### Multiple GPU Systems
+### Multiple GPU systems
 
 In systems with multiple GPUs, the GPU metrics plugin will detect all AMD cards by default. You can control which GPUs you want to monitor with the `cards_include` and `cards_exclude` parameters.
 
@@ -76,11 +76,11 @@ Example output:
 /sys/class/drm/card1/device/vendor
 ```
 
-## Getting Started
+## Getting started
 
 To get GPU metrics from your system, you can run the plugin from either the command line or through the configuration file:
 
-### Command Line
+### Command line
 
 Run the following command from the command line:
 
@@ -110,7 +110,7 @@ Example output:
 2025-10-25T20:36:55.236905093Z gpu_fan_pwm_percent{card="1",vendor="amd"} = 0
 ```
 
-### Configuration File
+### Configuration file
 
 In your main configuration file append the following:
 


### PR DESCRIPTION
Hello! I saw that there was no documentation for the new GPU metrics plugin. My system fits the current requirements for the plugin to work, so I went ahead and documented the feature.

My system specs are:

- **CPU:** Ryzen 7 9700X with Radeon Graphics
- **GPU:** AMD Radeon RX 7900 GRE
- **Operating System:** EndeavourOS
- **Kernel:** 6.17.4-arch2-1
- **Architecture:** x86_64

I did have to build Fluent Bit for my system but it did compile just fine on EndeavourOS. These are the configuration files that I made for testing:

test-gpu.yaml:

```yaml
pipeline:
   inputs:
      - name: gpu_metrics
        scrape_interval: 2
        path_sysfs: /sys
        cards_include: "1"
        cards_exclude: "0"
        enable_power: true
        enable_temperature: true

   outputs:
      - name: stdout
        match: '*'
```

test-gpu.conf:

```text
[INPUT]
   Name                gpu_metrics
   scrape_interval     2
   path_sysfs          /sys
   cards_include       1
   cards_exclude       0
   enable_power        true
   enable_temperature  true

[OUTPUT]
   Name   stdout
   Match  *
```

After compiling Fluent Bit I ran these commands to test:

```bash
./build/bin/fluent-bit -c test-gpu.yaml
./build/bin/fluent-bit -c test-gpu.conf
```

I followed the CPU metrics and the memory metrics documentation when writing this. I have not tested this on other operating systems. As per the code, I've explicitly mentioned that only AMD GPUs are supported right now.

Please let me know if there are any edits that I need to make!