### PR TITLE
Added hint detail in the introduction to TLS doc detailing switch to ALNP as default implementation. Fixes #2087.

### DIFF
--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -5,7 +5,7 @@ Fluent Bit provides integrated support for Transport Layer Security (TLS) and it
 
 {% hint style="info" %}
 
-The release of Fluent Bit v4.1.0 introduced the replacement of Next Protocol Negotiation (NPN) with Application Layer Protocol Negotiation (ALPN) as its implementation for TLS. 
+Fluent Bit 4.1.0 introduced the replacement of Next Protocol Negotiation (NPN) with Application Layer Protocol Negotiation (ALPN) as its implementation for TLS. 
 Both NPN and ALPN are used when client and server are establishing SSL/TLS connections. ALPN avoids an additional round trip because the client list the application layer protocols supported by the client in the client hello message.   
 
 {% endhint %}


### PR DESCRIPTION
Added hint detail in the introduction to TLS doc detailing switch to ALNP as default implementation. Fixes #2087.