### PR TITLE
Fixed error in Tensorflow fliter option for source build and install doc. 

### DIFF
--- a/installation/downloads/source/build-and-install.md
+++ b/installation/downloads/source/build-and-install.md
@@ -254,7 +254,7 @@ The following table describes the filters available on this version:
 | [`FLB_FILTER_REWRITE_TAG`](../../../pipeline/filters/rewrite-tag.md)         | Enable Rewrite Tag filter          | `On`    |
 | [`FLB_FILTER_STDOUT`](../../../pipeline/filters/standard-output.md)          | Enable Stdout filter               | `On`    |
 | [`FLB_FILTER_SYSINFO`](../../../pipeline/filters/sysinfo.md)                 | Enable Sysinfo filter              | `On`    |
-| [`FLB_FILTER_TYPE_TENSORFLOW`](../../../pipeline/filters/tensorflow.md)      | Enable Tensorflow filter           | `Off`   |
+| [`FLB_FILTER_TENSORFLOW`](../../../pipeline/filters/tensorflow.md)           | Enable Tensorflow filter           | `Off`   |
 | [`FLB_FILTER_THROTTLE`](../../../pipeline/filters/throttle.md)               | Enable Throttle filter             | `On`    |
 | [`FLB_FILTER_TYPE_CONVERTER`](../../../pipeline/filters/type-converter.md)   | Enable Type Converter filter       | `On`    |
 | [`FLB_FILTER_WASM`](../../../pipeline/filters/wasm.md)                       | Enable Wasm filter                 | `On`    |


### PR DESCRIPTION
Very small change to a source build config option as the variable was named wrong (FLB_FILTER_TENSORFLOW).