### PR TITLE
CI: Uncommenting the linkcheck test part that creates the issue

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -25,10 +25,10 @@ jobs:
 
 # If testing links on pull_request, comment these lines out!
 
-#      - name: Create Issue From File
-#        if: steps.lychee.outputs.exit_code != 0
-#        uses: peter-evans/create-issue-from-file@v5
-#        with:
-#          title: Link Checker Report
-#          content-filepath: ./lychee/out.md
-#          labels: report, automated issue
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
It ran, but it didn't create an issue because the issue part got commented out while I was testing something else.
