### PR TITLE
Added outputs path to stackdriver special fields trying to get file deployed to site. Part of #2159

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -76,7 +76,7 @@ redirects:
     output/slack:          ./pipeline/outputs/slack.md
     output/splunk:         ./pipeline/outputs/splunk.md
     output/stackdriver:    ./pipeline/outputs/stackdriver.md
-    output/stackdriver_special_fields:    ./pipeline/outputs/stackdriver_special_fields.md
+    outputs/stackdriver_special_fields:    ./pipeline/outputs/stackdriver_special_fields.md
     output/stdout:         ./pipeline/outputs/standard-output.md
     output/tcp:            ./pipeline/outputs/tcp-and-tls.md
     output/td:             ./pipeline/outputs/treasure-data.md


### PR DESCRIPTION
Added outputs path to stackdriver special fields trying to get file deployed to site. Part of #2159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation redirect path for Stackdriver special fields reference to ensure proper navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->