### PR TITLE
Fixed link url in stackdriver output plugin doc. Part of #2159.

### DIFF
--- a/pipeline/outputs/stackdriver.md
+++ b/pipeline/outputs/stackdriver.md
@@ -295,4 +295,4 @@ Check the following:
 
 Stackdriver officially supports a [logging agent based on Fluentd](https://cloud.google.com/logging/docs/agent).
 
-Fluent Bit plans to support some [special fields in structured payloads](https://cloud.google.com/logging/docs/agent/configuration#special-fields). For more information, see the documentation about [Stackdriver Special Fields](./stackdriver_special_fields.md#log-entry-fields).
+Fluent Bit plans to support some [special fields in structured payloads](https://cloud.google.com/logging/docs/agent/configuration#special-fields). For more information, see the documentation about [Stackdriver Special Fields](stackdriver_special_fields.md#logentry-fields).


### PR DESCRIPTION
Fixed link url in stackdriver output plugin doc. Part of #2159.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a hyperlink in the Stackdriver documentation to ensure proper navigation to the Special Fields reference section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->