### PR TITLE
Fix Typo of GeoLite

### DIFF
--- a/pipeline/filters/geoip2-filter.md
+++ b/pipeline/filters/geoip2-filter.md
@@ -34,7 +34,7 @@ pipeline:
   filters:
     - name: geoip2
       match: '*'
-      database: GoeLite2-City.mmdb
+      database: GeoLite2-City.mmdb
       lookup_key: remote_addr
       record:
         - country remote_addr %{country.names.en}


### PR DESCRIPTION
GioLite2 -> GoeLite2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in the GeoIP2 filter documentation, correcting the database filename reference so users see the proper name/path for GeoIP2 city lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->