### PR TITLE
fix: add missing 4.1 images

### DIFF
--- a/installation/downloads/docker.md
+++ b/installation/downloads/docker.md
@@ -44,6 +44,10 @@ The following table describes the Linux container tags that are available on Doc
 | ------------ | ------------------------- | -------------------------------------------------------------- |
 | 4.2.0-debug | x86_64, arm64v8, arm32v7, s390x | Debug images |
 | 4.2.0 | x86_64, arm64v8, arm32v7, s390x | Release [v4.2.0](https://fluentbit.io/announcements/v4.2.0/) |
+| 4.1.1-debug | x86_64, arm64v8, arm32v7, s390x | Debug images |
+| 4.1.1 | x86_64, arm64v8, arm32v7, s390x | Release [v4.1.1](https://fluentbit.io/announcements/v4.1.1/) |
+| 4.1.0-debug | x86_64, arm64v8, arm32v7, s390x | Debug images |
+| 4.1.0 | x86_64, arm64v8, arm32v7, s390x | Release [v4.1.0](https://fluentbit.io/announcements/v4.1.0/) |
 | 4.0.13-debug | x86_64, arm64v8, arm32v7, s390x | Debug images |
 | 4.0.13 | x86_64, arm64v8, arm32v7, s390x | Release [v4.0.13](https://fluentbit.io/announcements/v4.0.13/) |
 | 4.0.12-debug | x86_64, arm64v8, arm32v7, s390x | Debug images |


### PR DESCRIPTION
Resolves #2175 by adding the missing 4.1 series of container images from docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker version documentation for releases 4.1.1 and 4.1.0, including debug variants with support for x86_64, arm64v8, arm32v7, and s390x architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->