### PR TITLE
Added documentation of the Routing Metrics & Observability features in fluent bit 4.2 to router docs. Fixes #2205.

### DIFF
--- a/pipeline/router.md
+++ b/pipeline/router.md
@@ -247,7 +247,7 @@ Each rule in the `condition.rules` array must include:
 | `field` | The field within your logs to evaluate. Uses [record accessor syntax](/administration/configuring-fluent-bit/classic-mode/record-accessor.md). |
 | `op` | The comparison operator. |
 | `value` | This is the value to compare against. It can be a single value or an array for `in` and `not_in` operators. |
-| `context` | Optional. Specifies where to look for the field. See context types below. Defaults to `body`. |
+| `context` | Optional. Specifies where to look for the field. See the Context types section. Defaults to `body`. |
 
 ### Context types
 
@@ -997,7 +997,7 @@ service:
 {% endtab %}
 {% endtabs %}
 
-Once enabled, access routing metrics at `http://localhost:2020/api/v2/metrics` (or `/api/v1/metrics/prometheus` for Prometheus format). The metrics appear alongside other Fluent Bit internal metrics.
+Once enabled, access routing metrics at `http://localhost:2020/api/v2/metrics` (or `/api/v2/metrics/prometheus` for Prometheus format). The metrics appear alongside other Fluent Bit internal metrics.
 
 ### Example metric output
 


### PR DESCRIPTION
Added documentation of the Routing Metrics & Observability features in fluent bit 4.2 to router docs. Fixes #2205.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded routing docs with a new "Context types" section listing available context fields for condition rules (body, metadata, group metadata/attributes, and OpenTelemetry-related attributes) and examples.
  * Added a "Routing metrics" section describing Prometheus-format metrics, label meanings, how to enable/access them via the HTTP endpoint, configuration snippets, and sample outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->