### PR TITLE
Added note to amazon s3 output plugin about dry run fix for version 4.2 and greater to docs. Fixes #2218.

### DIFF
--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -25,7 +25,7 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 
 {% hint style="info" %}
 
-**Dry-run mode fix**: A segmentation fault that occurred when using `--dry-run` mode with the S3 output plugin has been fixed. The fix adds a NULL context check during worker termination. If you experience crashes during configuration validation with `--dry-run`, make sure you are using Fluent Bit 4.2 or greater.
+**Dry-run mode fix**: A segmentation fault that occurred when using `--dry-run` mode with the S3 output plugin has been fixed. The fix adds a `NULL` context check during worker termination. If you experience crashes during configuration validation with `--dry-run`, make sure you are using Fluent Bit 4.2 or greater.
 
 {% endhint %}
 


### PR DESCRIPTION
Added note to amazon s3 output plugin about dry run fix for version 4.2 and greater to docs. Fixes #2218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an informational note to the S3 output plugin docs describing a dry-run mode crash fix and advising users to run Fluent Bit 4.2 or later for the resolved behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->