### PR TITLE
Updated http output plugin doc. Fixes #2216.

### DIFF
--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -1,6 +1,6 @@
 # HTTP
 
-The _HTTP_ output plugin lets you flush your records into an HTTP endpoint. It issues a POST request with the data records in [MessagePack](http://msgpack.org) (or JSON) format.
+The _HTTP_ output plugin lets you flush your records into an HTTP endpoint. It issues `POST` or `PUT` requests with the data records in [MessagePack](http://msgpack.org) (or JSON) format.
 
 ## Configuration parameters
 
@@ -8,34 +8,37 @@ The plugin supports the following configuration parameters:
 
 | Key | Description | Default |
 | --- | ----------- | -------- |
-| `host` | IP address or hostname of the target HTTP Server. | `127.0.0.1` |
-| `http_User` | Basic Auth username. | _none_ |
-| `http_Passwd` | Basic Auth password. Requires `HTTP_User` to be set. | _none_ |
-| `AWS_Auth` | Enable AWS SigV4 authentication. | `false` |
-| `AWS_Service` | Specify the AWS service code of your service, used by SigV4 authentication (for example, `es`, `xray`.) Usually found in the service endpoint's subdomains, `protocol://service-code.region-code.amazonaws.com`. | _none_ |
-| `AWS_Region` | Specify the AWS region of your service, used by SigV4 authentication. | _none_ |
-| `AWS_STS_Endpoint` | Specify the custom STS endpoint to be used by STS API. Used with the `AWS_Role_ARN option` and by SigV4 authentication. | _none_ |
-| `AWS_Role_ARN` | AWS IAM Role to assume, used by SigV4 authentication. | _none_ |
-| `AWS_External_ID` | External ID for the AWS IAM Role specified with `aws_role_arn`, used by SigV4 authentication. | _none_ |
-| `port` | TCP port of the target HTTP Server. | `80` |
-| `Proxy` | Specify an HTTP Proxy. The expected format of this value is `http://HOST:PORT`. HTTPS isn't supported. It's recommended to configure the [HTTP proxy environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS. | _none_ |
-| `uri` | Specify an optional HTTP URI for the target web server. For example, `/somepath`. | `/` |
-| `compress` | Set payload compression mechanism. Allowed value: `gzip`. | _none_ |
-| `format` | Specify the data format to be used in the HTTP request body. Supported formats: `gelf`, `json`, `json_stream`, `json_lines`, `msgpack`. | `msgpack` |
 | `allow_duplicated_headers` | Specify if duplicated headers are allowed. If a duplicated header is found, the latest key/value set is preserved. | `true` |
-| `log_response_payload` | Specify if the response payload should be logged or not. | `true` |
-| `header_tag` | Specify an optional HTTP header field for the original message tag. | _none_ |
-| `http_method` | Specify `POST` versus `PUT` HTTP Method. | `POST` |
-| `header` | Add a HTTP header key/value pair. Multiple headers can be set. | _none_ |
-| `json_date_key` | Specify the name of the time key in the output record. To disable the time key, set the value to `false`. | `date` |
-| `json_date_format` | Specify the format of the date. Supported formats: `double`, `epoch`, `epoch_ms`, `iso8601`, `java_sql_timestamp`. | `double` |
-| `gelf_timestamp_key` | Specify the key to use for `timestamp` in `gelf` format. | _none_ |
-| `gelf_host_key` | Specify the key to use for the `host` in `gelf` format. | _none_ |
-| `gelf_short_message_key` | Specify the key to use as the `short` message in `gelf` format. | _none_ |
-| `gelf_full_message_key` | Specify the key to use for the `full` message in `gelf` format. | _none_ |
-| `gelf_level_key` | Specify the key to use for the `level` in `gelf` format. | _none_ |
+| `aws_auth` | Enable AWS SigV4 authentication. | `false` |
+| `aws_external_id` | External ID for the AWS IAM Role specified with `aws_role_arn`, used by SigV4 authentication. | _none_ |
+| `aws_profile` | AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in `$HOME/.aws/` directory. | _none_ |
+| `aws_region` | Specify the AWS region of your service, used by SigV4 authentication. | _none_ |
+| `aws_role_arn` | AWS IAM Role to assume, used by SigV4 authentication. | _none_ |
+| `aws_service` | Specify the AWS service code of your service, used by SigV4 authentication (for example, `es`, `xray`.) Usually found in the service endpoint's subdomains, `protocol://service-code.region-code.amazonaws.com`. | _none_ |
+| `aws_sts_endpoint` | Specify the custom STS endpoint to be used by STS API. Used with the `aws_role_arn` option and by SigV4 authentication. | _none_ |
 | `body_key` | Specify the key to use as the body of the request (must prefix with `$`). The key must contain either a binary or raw string, and the content type can be specified using `headers_key`, which must be passed whenever `body_key` is present. When this option is present, each `msgpack` record will create a separate request. | _none_ |
+| `compress` | Set payload compression mechanism. Allowed values: `gzip`, `snappy`, `zstd`. | _none_ |
+| `format` | Specify the data format to be used in the HTTP request body. Supported formats: `gelf`, `json`, `json_stream`, `json_lines`, `msgpack`. | `json` |
+| `gelf_full_message_key` | Specify the key to use for the `full` message in `gelf` format. | _none_ |
+| `gelf_host_key` | Specify the key to use for the `host` in `gelf` format. | _none_ |
+| `gelf_level_key` | Specify the key to use for the `level` in `gelf` format. | _none_ |
+| `gelf_short_message_key` | Specify the key to use as the `short` message in `gelf` format. | _none_ |
+| `gelf_timestamp_key` | Specify the key to use for `timestamp` in `gelf` format. | _none_ |
+| `header` | Add a HTTP header key/value pair. Multiple headers can be set. | _none_ |
+| `header_tag` | Specify an optional HTTP header field for the original message tag. | _none_ |
 | `headers_key` | Specify the key to use as the headers of the request (must prefix with `$`). The key must contain a map, which will have the contents merged on the request headers. This can be used for many purposes, such as specifying the content type of the data contained in `body_key`.| _none_ |
+| `host` | IP address or hostname of the target HTTP Server. | `127.0.0.1` |
+| `http.read_idle_timeout` | Set maximum allowed time between two consecutive reads. If set to `0s`, uses the `io_timeout` value from the network setup. | `0s` |
+| `http.response_timeout` | Set maximum time to wait for a server response. | `60s` |
+| `http_method` | Specify `POST` versus `PUT` HTTP Method. | `POST` |
+| `http_passwd` | Basic Auth password. Requires `http_user` to be set. | _none_ |
+| `http_user` | Basic Auth username. | _none_ |
+| `json_date_format` | Specify the format of the date. Supported formats: `double`, `epoch`, `epoch_ms`, `iso8601`, `java_sql_timestamp`. | `double` |
+| `json_date_key` | Specify the name of the time key in the output record. To disable the time key, set the value to `false`. | `date` |
+| `log_response_payload` | Specify if the response payload should be logged or not. | `true` |
+| `port` | TCP port of the target HTTP Server. | `80` |
+| `proxy` | Specify an HTTP Proxy. The expected format of this value is `http://HOST:PORT`. HTTPS isn't supported. It's recommended to configure the [HTTP proxy environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS. | _none_ |
+| `uri` | Specify an optional HTTP URI for the target web server. For example, `/somepath`. | `/` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `2` |
 
 ### TLS / SSL
@@ -244,3 +247,40 @@ _sourcecategory="my_fluent_bit"
 | timeslice 1m
 | max(cpu) as cpu group by _timeslice
 ```
+
+#### Using `PUT` method
+
+The following example shows how to configure the HTTP output plugin to use the `PUT` method instead of the default `POST` method.
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+
+  outputs:
+    - name: http
+      match: '*'
+      host: 192.168.2.3
+      port: 80
+      uri: /api/endpoint
+      http_method: PUT
+      format: json
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[OUTPUT]
+  Name       http
+  Match      *
+  Host       192.168.2.3
+  Port       80
+  URI        /api/endpoint
+  Http_Method PUT
+  Format     json
+```
+
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
Fixes to the http output plugin:

- added 3 missing options: http.response_timeout, http.read_idle_timeout, aws_profile
- fixed 1 incorrect default: format default should be json, not msgpack
- added 2 missing compression options: snappy and zstd for the compress parameter
- fixed parameter name casing inconsistencies in documentation
- added PUT method docs and example
- sorted alphabetically the options table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * HTTP output now supports PUT method in addition to POST.
  * Configuration parameters updated with new naming conventions and expanded AWS authentication, timeout, and header handling options.
  * Added example configurations demonstrating PUT method usage in Fluent Bit deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->