### PR TITLE
Fixed elasticsearch input plugin doc with missing config parameters and some cleanup. Fixed #2245

### DIFF
--- a/pipeline/inputs/elasticsearch.md
+++ b/pipeline/inputs/elasticsearch.md
@@ -17,7 +17,7 @@ The plugin supports the following configuration parameters:
 | `port`              | The port for Fluent Bit to listen on.                                                                                                    | `9200`        |
 | `tag_key`           | Specify a key name for extracting as a tag.                                                                                              | `NULL`        |
 | `threaded`          | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).                                  | `false`       |
-| `version`           | Specify Elasticsearch server version. This parameter is effective for checking a version of Elasticsearch/OpenSearch server version.     | `8.0.0`       |
+| `version`           | Specify the Elasticsearch version that Fluent Bit reports to clients during sniffing and API requests.                                   | `8.0.0`       |
 
 ### TLS / SSL
 


### PR DESCRIPTION
Fixed elasticsearch input plugin doc with missing config parameters and some cleanup. Fixed #2245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new connection options: http2, listen, port, and version
  * Introduced TLS/SSL guidance and transport security examples
  * Replaced and clarified sniffing guidance; updated hostname guidance for production reachability
  * Removed buffer_max_size from parameter table and adjusted ordering/placement of tag_key/meta_key
  * Updated usage examples and clarified bulk ingestion and buffer-sizing recommendations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->