### PR TITLE
Fixes to standardize health input plugin doc. Fixes #2264.

### DIFF
--- a/pipeline/inputs/health.md
+++ b/pipeline/inputs/health.md
@@ -12,7 +12,7 @@ The plugin supports the following configuration parameters:
 | `add_port`      | If enabled, port number is appended to each record.                                                                | `false` |
 | `alert`         | If enabled, it generates messages only when the target TCP service is down.                                        | `false` |
 | `host`          | Name of the target host or IP address.                                                                             | _none_  |
-| `interval_nsec` | Specify a nanoseconds interval for service checks. Works in conjunction with the `interval_sec` configuration key. | `0`     |
+| `interval_nsec` | Specify a nanoseconds interval for service checks. Works with the `interval_sec` configuration key.                | `0`     |
 | `interval_sec`  | Interval in seconds between the service checks.                                                                    | `1`     |
 | `port`          | TCP port where to perform the connection request.                                                                  | _none_  |
 | `threaded`      | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).            | `false` |


### PR DESCRIPTION
Following fixes:

- Critical typo fixed: Internal_Nsec → Interval_Nsec (line 14 in the original)
- Grammar corrections: "each records" → "each record" (in Add_Host and Add_Port descriptions)
- Sorted configuration parameters alphabetically as per project conventions
- Clarified Alert description: Changed from "if the target TCP service is down" to "only when the target TCP service is down" to better reflect the behavior (it suppresses messages when the service is UP)
- Fixed Testing section wording: Changed "random values" to "health check results" (they're not random!)
- Removed trailing whitespace on line 47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed health check parameters to snake_case across reference docs for consistency (e.g., host, port, interval_sec, interval_nsec, alert, add_host, add_port, threaded).
  * Tightened alert wording to indicate messages are generated only when the target TCP service is down.
  * Updated examples, testing guidance, and minor formatting for clearer health result terminology and improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->