### PR TITLE
in_kubernetes_events: add missing parameters and fix defaults. 

### DIFF
--- a/pipeline/inputs/kubernetes-events.md
+++ b/pipeline/inputs/kubernetes-events.md
@@ -14,8 +14,6 @@ Kubernetes exports events through the API server. This input plugin lets you ret
 | `db.journal_mode` | Set the journal mode for databases. Values: `DELETE`, `TRUNCATE`, `PERSIST`, `MEMORY`, `WAL`, `OFF`. | `WAL` |
 | `db.locking` | Specify that the database will be accessed only by Fluent Bit. Enabling this feature helps increase performance when accessing the database but restricts external tools from querying the content. | `false` |
 | `db.sync` | Set a database sync method. Values: `extra`, `full`, `normal`, `off`. | `normal` |
-| `dns_retries` | Set the number of DNS lookup retries until the network starts working. | `6` |
-| `dns_wait_time` | Set the time interval between network status checks (in seconds). | `30` |
 | `interval_nsec` | Set the reconnect interval (sub seconds: nanoseconds). | `500000000` |
 | `interval_sec` | Set the reconnect interval (seconds). | `0` |
 | `kube_ca_file` | Kubernetes TLS CA file. | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` |


### PR DESCRIPTION
- Add missing config parameters: db.journal_mode, db.locking, dns_retries, dns_wait_time
- Fix tls.verify default from 'On' to 'true' to match source
- Fix kube_namespace default from 'all' to none
- Sort parameters alphabetically
- Align table format with other input plugin docs
- Expand tls.debug description with all debug levels

Fixes #2272.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes Events plugin configuration with new configuration parameters (DB journal/locking, DNS/tls options) and clearer default values.
  * Reordered and clarified interval semantics and namespace defaults (namespace now _none_ by default).
  * Clarified that the plugin collects events without a fixed 5s interval and noted behavior changes for newer Fluent Bit watch streams.
  * Reworded examples and prose for improved readability and setup guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->