### PR TITLE
pipeline: inputs: mqtt: update mqtt input config with buffer_size defaults and payload_key examples

### DIFF
--- a/pipeline/inputs/mqtt.md
+++ b/pipeline/inputs/mqtt.md
@@ -10,7 +10,7 @@ The plugin supports the following configuration parameters:
 |:--------------|:--------------------------------------------------------------------------------------------------------|:-------------|
 | `buffer_size` | Maximum payload size (in bytes) for a single MQTT message.                                              | `2048`       |
 | `listen`      | Listener network interface.                                                                             | `0.0.0.0`    |
-| `payload_key` | Specify the key where the payload key/value will be preserved.                                          | _none_       |
+| `payload_key` | Field name where the MQTT message payload will be stored in the output record.                          | _none_       |
 | `port`        | TCP port where listening for connections.                                                               | `1883`       |
 | `threaded`    | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs). | `false`      |
 


### PR DESCRIPTION
update mqtt input config with `buffer_size` defaults and `payload_key` examples

Fixes #2282.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized MQTT input configuration keys to snake_case and updated default values.
  * Clarified buffer_size behavior (messages dropped when over limit) and listener/port defaults.
  * Specified JSON-map requirement for payloads and added guidance on payload_key usage in examples.
  * Added a TLS/SSL configuration subsection and referenced transport security guidance.
  * Updated all example configurations and sample pipelines to reflect the new format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->