### PR TITLE
Note that envvar cannot be used in include section

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -159,3 +159,5 @@ Wildcard character (`*`) supports including multiple files. For example:
 ```
 
 Files matching the wildcard character are included unsorted. If plugin ordering between files needs to be preserved, the files should be included explicitly.
+
+Environment variables aren't supported in includes section. The file path must be specified as a literal string.

--- a/administration/configuring-fluent-bit/yaml/includes-section.md
+++ b/administration/configuring-fluent-bit/yaml/includes-section.md
@@ -27,4 +27,4 @@ Ensure that the included files are formatted correctly and contain valid YAML co
 
 If a path isn't specified as absolute, it will be treated as relative to the file that includes it.
 
-Environment variables are not supported in includes section. The file path must be specified as a literal string.
+Environment variables aren't supported in includes section. The file path must be specified as a literal string.


### PR DESCRIPTION
This PR is a short addition noting that **environment variables cannot be used in the include section**.
Some users may attempt to use environment variables in the include section and eventually run into issues - often ending up at workaround discussions such as this one: https://github.com/fluent/fluent-bit/issues/2020

It would be great to add a note clarifying that the include section does not parse environment variables, and, if possible, include a link to the above issue as a reference for the workaround.

Thank you! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that environment variables are not supported in include directives.
  * Noted that included file paths must be specified as literal strings.
  * Updated guidance to prevent confusion when referencing external configuration files, ensuring users supply explicit file paths rather than relying on variable expansion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->