### PR TITLE
in_tail: fix parameter case to match source and fix style

### DIFF
--- a/pipeline/inputs/tail.md
+++ b/pipeline/inputs/tail.md
@@ -90,9 +90,9 @@ If no database file is present, positioning behavior depends on the value of `re
 The database file essentially stores `inode=offset` so it should be unique per instance of the plugin, for example if you have two tail inputs then use two separate `db` files for each. That way each tail input can independently track its own state.
 
 {% hint style="info" %}
-The `Unicode.Encoding` parameter is dependent on the `simdutf` library, which is itself dependent on C++ version 11 or later. In environments that use earlier versions of C++, the `Unicode.Encoding` parameter will fail.
+The `unicode.encoding` parameter is dependent on the `simdutf` library, which is itself dependent on C++ version 11 or later. In environments that use earlier versions of C++, the `unicode.encoding` parameter will fail.
 
-Additionally, the `auto` setting for `Unicode.Encoding` isn't supported in all cases, and can make mistakes when it tries to guess the correct encoding. For best results, use either the `UTF-16LE` or `UTF-16BE` setting if you know the encoding type of the target file.
+Additionally, the `auto` setting for `unicode.encoding` isn't supported in all cases, and can make mistakes when it tries to guess the correct encoding. For best results, use either the `UTF-16LE` or `UTF-16BE` setting if you know the encoding type of the target file.
 {% endhint %}
 
 ## Monitor a large number of files
@@ -495,7 +495,7 @@ This is common in environments that use:
 
 To enable encoding conversion, you will use one of the following two parameters within an input plugin configuration.
 
-1. `Unicode.Encoding`
+1. `unicode.encoding`
 
    Use this parameter for high-performance conversion of UTF-16 encoded logs to UTF-8. This method utilizes modern processor features (SIMD instructions) to accelerate the conversion process, making it highly efficient.
 
@@ -504,7 +504,7 @@ To enable encoding conversion, you will use one of the following two parameters 
      - `UTF-16LE` (Little-Endian)
      - `UTF-16BE` (Big-Endian)
 
-1. `Generic.Encoding`
+1. `generic.encoding`
 
    Use this parameter to convert from a wide variety of other character encodings, particularly legacy Windows code pages.
 
@@ -536,7 +536,7 @@ To enable encoding conversion, you will use one of the following two parameters 
 
 ### Configuration example
 
-Here is an example of how to use `Generic.Encoding` with the Tail input plugin to read a log file encoded in ShiftJIS.
+Here is an example of how to use `generic.encoding` with the Tail input plugin to read a log file encoded in ShiftJIS.
 
 {% tabs %}
 {% tab title="fluent-bit.yaml" %}


### PR DESCRIPTION
- Change Generic.Encoding to generic.encoding to match source
- Change Unicode.Encoding to unicode.encoding to match source
- Fix East asian to East Asian capitalization

Fixes #2202.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed encoding parameters for consistency (updated examples and config samples)
  * Normalized headings and casing (e.g., East Asian encodings)
  * Updated guidance and examples for encoding options and aliases across regions
  * Minor wording and formatting improvements; documentation-only changes, no behavioral impact

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->