### PR TITLE
in_node_exporter_metrics: fix config parameter name and default value

### DIFF
--- a/pipeline/inputs/node-exporter-metrics.md
+++ b/pipeline/inputs/node-exporter-metrics.md
@@ -52,7 +52,7 @@ This helps with down-sampling when collecting metrics.
 | `collector.systemd.scrape_interval` | The rate in seconds at which `systemd` metrics are collected from the host operating system. | `0` |
 | `collector.textfile.path` | Specify path or directory to collect textfile metrics from the host operating system. | Not set by default. |
 | `collector.textfile.scrape_interval` | The rate in seconds at which `textfile` metrics are collected from the host operating system. | `0` |
-| `collector.thermal_zone.scrape_interval` | The rate in seconds at which `thermal_zone` metrics are collected from the host operating system. | `0` |
+| `collector.thermalzone.scrape_interval` | The rate in seconds at which `thermal_zone` metrics are collected from the host operating system. | `0` |
 | `collector.time.scrape_interval` | The rate in seconds at which `time` metrics are collected from the host operating system. | `0` |
 | `collector.uname.scrape_interval` | The rate in seconds at which `uname` metrics are collected from the host operating system. | `0` |
 | `collector.vmstat.scrape_interval` | The rate in seconds at which `vmstat` metrics are collected from the host operating system. | `0` |
@@ -64,7 +64,7 @@ This helps with down-sampling when collecting metrics.
 | `path.rootfs` | The root filesystem mount point. | `/` |
 | `path.sysfs` | The path in the filesystem used to collect system metrics. | `/sys` |
 | `scrape_interval` | The rate in seconds at which metrics are collected from the host operating system. | `5` |
-| `systemd_exclude_pattern` | Regular expression to determine which units are excluded in the metrics produced by the `systemd` collector. | `.+\\.(automount\|device\|mount\|scope\|slice)"` |
+| `systemd_exclude_pattern` | Regular expression to determine which units are excluded in the metrics produced by the `systemd` collector. | `.+\\.(automount\|device\|mount\|scope\|slice)` |
 | `systemd_include_pattern` | Regular expression to determine which units are included in the metrics produced by the `systemd` collector. | Not applied unless explicitly set. |
 | `systemd_include_service_task_metrics` | Determines if the collector will include service task metrics. | `false` |
 | `systemd_service_restart_metrics` | Determines if the collector will include service restart metrics. | `false` |


### PR DESCRIPTION
- Change collector.thermal_zone.scrape_interval to collector.thermalzone.scrape_interval to match source code config_map in ne.c
- Remove errant trailing quote from systemd_exclude_pattern default value

Fixes #2296.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated node exporter metrics configuration documentation.

* **Chores**
  * Renamed configuration key `collector.thermal_zone.scrape_interval` to `collector.thermalzone.scrape_interval`.
  * Updated `systemd_exclude_pattern` configuration pattern formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->