### PR TITLE
Document simple_aggregation for kinesis/firehose

### DIFF
--- a/pipeline/outputs/firehose.md
+++ b/pipeline/outputs/firehose.md
@@ -27,6 +27,7 @@ This plugin uses the following configuration parameters:
 | `sts_endpoint` | Custom endpoint for the STS API. | _none_ |
 | `auto_retry_requests` | Immediately retry failed requests to AWS services once. This option doesn't affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which can help improve throughput when there are transient/random networking issues. | `true` |
 | `external_id` | Specify an external ID for the STS API. Can be used with the `role_arn` parameter if your role requires an external ID. | _none_ |
+| `simple_aggregation` | Enable simple aggregation to combine multiple records into single API calls. This reduces the number of requests and can improve throughput. When enabled, multiple log records are concatenated with newlines and sent as a single record to Firehose, up to the maximum record size limit (1,024,000 bytes). | `false` |
 | `profile` | AWS profile name to use. | `default` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. |  `1` |
 

--- a/pipeline/outputs/kinesis.md
+++ b/pipeline/outputs/kinesis.md
@@ -27,6 +27,7 @@ For information about how AWS credentials are fetched, see [AWS credentials](../
 | `sts_endpoint` | Custom endpoint for the STS API. | _none_ |
 | `auto_retry_requests` | Immediately retry failed requests to AWS services once. This option doesn't affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which might help improve throughput when there are transient/random networking issues. | `true` |
 | `external_id` | Specify an external ID for the STS API, can be used with the `role_arn` parameter if your role requires an external ID. | _none_ |
+| `simple_aggregation` | Enable simple aggregation to combine multiple records into single API calls. This reduces the number of requests and can improve throughput. When enabled, multiple log records are concatenated with newlines and sent as a single record to Kinesis, up to the maximum record size limit (1,048,556 bytes). | `false` |
 | `profile` | AWS profile name to use. | `default` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `1` |
 


### PR DESCRIPTION
Documentation for simple_aggregation added to out_kinesis_firehose and out_kinesis_streams - https://github.com/fluent/fluent-bit/pull/11284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `simple_aggregation` configuration option for Firehose and Kinesis outputs. When enabled, multiple records are concatenated with newlines and sent as a single API call (up to 1,024,000 bytes per record). Defaults to false.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->