### PR TITLE
docs: development: ingest-records-manually: fix backtick typo

### DIFF
--- a/development/ingest-records-manually.md
+++ b/development/ingest-records-manually.md
@@ -2,7 +2,7 @@
 
 There are some cases where Fluent Bit library is used to send records from the caller application to some destination. This process is called _manual data ingestion_.
 
-For this purpose, a specific input plugin called **lib** exists and can be used in conjunction with the `flb_lib`_push()` API function.
+For this purpose, a specific input plugin called **lib** exists and can be used in conjunction with the `flb_lib_push()` API function.
 
 ## Data format
 


### PR DESCRIPTION
On the [Ingest records manually](https://docs.fluentbit.io/manual/fluent-bit-for-developers/ingest-records-manually) page, the line with `flb_lib_push()` is rendering as `flb_lib`_push()`:

<img width="789" height="122" alt="missing_backtick_render" src="https://github.com/user-attachments/assets/7bb1db8d-a1eb-478a-a861-572734305575" />

This fixes the backtick placement so it should render correctly now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected API function name reference in development documentation to ensure accurate guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->