### PR TITLE
expand hint-related tests

### DIFF
--- a/vale-styles/FluentBit/Hints.yml
+++ b/vale-styles/FluentBit/Hints.yml
@@ -1,15 +1,15 @@
 extends: existence
-message: "Instead of using `>` to call out information, use GitBook hint syntax. https://gitbook.com/docs/creating-content/blocks/hint#representation-in-markdown"
+message: "To call out information, use GitBook hint syntax. https://gitbook.com/docs/creating-content/blocks/hint#representation-in-markdown"
 level: error
 nonword: true
 scope: raw
 tokens:
-  - '> \**_*(?i)note'
-  - '> \**_*(?i)caution'
-  - '> \**_*(?i)warning'
-  - '> \**_*(?i)danger'
-  - '> \**_*(?i)important'
-  - '> \**_*(?i)info'
-  - '> \**_*(?i)hint'
-  - '> \**_*(?i)tip'
-  - '> \**_*(?i)success'
+  - '(> |^| )\**_*(?i)note:*\**_*:*'
+  - '(> |^| )\**_*(?i)caution:*\**_*:*'
+  - '(> |^| )\**_*(?i)warning:*\**_*:*'
+  - '(> |^| )\**_*(?i)danger:*\**_*:*'
+  - '(> |^| )\**_*(?i)important:*\**_*:*'
+  - '(> |^| )\**_*(?i)info:*\**_*:*'
+  - '(> |^| )\**_*(?i)hint:*\**_*:*'
+  - '(> |^| )\**_*(?i)tip:*\**_*:*'
+  - '(> |^| )\**_*(?i)success:*\**_*:*'


### PR DESCRIPTION
these updated rules catch things like:

`> note:`
`note:`
`*note*:`
`**note**:`
`**note:**`
`...blah blah. note:`

and more :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced documentation validation to recognize more flexible formatting patterns for documentation hints (notes, cautions, warnings, etc.). The improved pattern recognition now supports optional emphasis, colon variations, and leading characters, providing more robust documentation validation while maintaining consistency standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->