### PR TITLE
fix broken redirect

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -101,5 +101,5 @@ redirects:
     about/sandbox-and-lab-resources: ./about/resources.md
     installation/downloads/amazon-ec2: ./installation/downloads/linux/amazon-linux.md
     administration/configuring-fluent-bit/yaml/configuration-file: ./administration/configuring-fluent-bit/yaml.md
-    administration/configuring-fluent-bit/unit-sizes: ./administration/configuring-fluent-bit.md#unit-sizes
+    administration/configuring-fluent-bit/unit-sizes: ./administration/configuring-fluent-bit.md
     administration/configuring-fluent-bit/multiline-parsing: ./pipeline/parsers/multiline-parsing.md


### PR DESCRIPTION
I guess gitbook doesn't let you create a redirect with a specific subheading as its destination. (the other recent redirects I made are all working though, thankfully.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated redirect mapping to point users to the main documentation page instead of a specific section reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->