### PR TITLE
in_tail: Add data reliability note

### DIFF
--- a/pipeline/inputs/tail.md
+++ b/pipeline/inputs/tail.md
@@ -90,6 +90,18 @@ If no database file is present, positioning behavior depends on the value of `re
 The database file essentially stores `inode=offset` so it should be unique per instance of the plugin, for example if you have two tail inputs then use two separate `db` files for each. That way each tail input can independently track its own state.
 
 {% hint style="info" %}
+
+**Data Reliability and Recovery**
+
+During normal operations and graceful shutdowns (SIGTERM), Fluent Bit synchronizes file offsets with the database to ensure no data is lost.
+
+In unexpected shutdowns (for example, system crash, power loss, SIGKILL), Fluent Bit guarantees _at-least-once_ delivery. The database offset might slightly trail the actual processed position if an unexpected shutdown occurs after data is processed but before the new offset is committed to the database.
+
+Upon restart, Fluent Bit resumes from the last committed checkpoint. This ensures no data is lost, though it might result in the re-ingestion of a minimal amount of previously processed records (duplication).
+
+{% endhint %}
+
+{% hint style="info" %}
 The `unicode.encoding` parameter is dependent on the `simdutf` library, which is itself dependent on C++ version 11 or later. In environments that use earlier versions of C++, the `unicode.encoding` parameter will fail.
 
 Additionally, the `auto` setting for `unicode.encoding` isn't supported in all cases, and can make mistakes when it tries to guess the correct encoding. For best results, use either the `UTF-16LE` or `UTF-16BE` setting if you know the encoding type of the target file.


### PR DESCRIPTION
This commit adds a 'Data Reliability and Recovery' hint to the Tail input plugin documentation.

It clarifies the behavior of the database offset mechanism during unexpected shutdowns (e.g., system crash, power loss). Specifically, it explains that while Fluent Bit guarantees at-least-once delivery, there is a possibility of slight offset lag and minimal data duplication upon recovery. This ensures users understand that no data is lost even in these scenarios.

https://github.com/fluent/fluent-bit/pull/11269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on data reliability and recovery for the Tail input, describing at-least-once delivery, restart-from-last-committed-checkpoint behavior, and potential minimal re-ingestion after unexpected shutdowns (added in two locations).
  * Clarified unicode.encoding guidance: noted that "auto" may fail in some environments, can misguess encoding, and recommended explicitly using UTF-16LE or UTF-16BE when guessing is unreliable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->