### PR TITLE
docs: kafka: add Windows SSPI support for MSK IAM authentication

### DIFF
--- a/pipeline/outputs/kafka.md
+++ b/pipeline/outputs/kafka.md
@@ -245,7 +245,11 @@ If you are compiling Fluent Bit from source, ensure the following requirements a
 
 - Build Requirements
 
-  The packages `libsasl2` and `libsasl2-dev` must be installed on your build environment.
+| Platform | Requirements |
+|----------|-------------|
+| **Linux/macOS** | The packages `libsasl2` and `libsasl2-dev` must be installed on your build environment. |
+| **Windows** | No additional SASL libraries required. Windows uses the built-in Security Support Provider Interface (SSPI) for SASL authentication, which only requires OpenSSL/TLS to be enabled. |
+
 
 - Runtime Requirements:
 


### PR DESCRIPTION
docs: kafka: add Windows SSPI support for MSK IAM authentication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Build Requirements and AWS MSK IAM prerequisites documentation with platform-specific tables for Linux/macOS and Windows.
  * Added Windows-specific notes regarding SASL libraries, SSPI, and OpenSSL requirements for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
Fix: https://github.com/fluent/fluent-bit/pull/11294
<!-- end of auto-generated comment: release notes by coderabbit.ai -->