### PR TITLE
aws-credentials: add AWS Greengrass endpoint details

### DIFF
--- a/administration/aws-credentials.md
+++ b/administration/aws-credentials.md
@@ -7,6 +7,7 @@ Plugins that interact with AWS services fetch credentials from the following pro
 - [EKS Web Identity Token (OIDC)](#eks-web-identity-token-oidc)
 - [ECS HTTP credentials endpoint](#ecs-http-credentials-endpoint)
 - [EC2 Instance Profile Credentials (IMDS)](#ec2-instance-profile-credentials-imds)
+- [`AWS Greengrass` credentials](#aws-greengrass-credentials)
 
 All AWS plugins additionally support a `role_arn` (or `AWS_ROLE_ARN`, for [Elasticsearch](../pipeline/outputs/elasticsearch.md)) configuration parameter. If specified, the fetched credentials are used to assume the given role.
 
@@ -42,3 +43,7 @@ Credentials are fetched using  a pod identity endpoint. See [Learn how EKS Pod I
 ## EC2 instance profile credentials (IMDS)
 
 Fetches credentials for the EC2 instance profile's role. See [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html). As of Fluent Bit version 1.8.8, IMDSv2 is used by default and IMDSv1 might be disabled. Prior versions of Fluent Bit require enabling IMDSv1 on EC2.
+
+## `AWS Greengrass` credentials
+
+Fluent Bit fetches credentials from a localhost endpoint provided by the AWS IoT `Greengrass` token exchange service. The token exchange service runs as a local server on `Greengrass` core devices and provides AWS credentials through the `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN` environment variables. For more information, see the AWS documentation about [Token exchange service](https://docs.aws.amazon.com/greengrass/v2/developerguide/token-exchange-service-component.html).


### PR DESCRIPTION
Add documentation for support of AWS Greengrass endpoint

Related: https://github.com/fluent/fluent-bit/pull/11369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation and navigation entry for AWS Greengrass credentials.
  * Describes how to obtain credentials from a local Greengrass token-exchange endpoint, how those credentials are delivered to the application, and links to the token exchange service documentation for setup and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->