### PR TITLE
docs: in_process_exporter_metrics: fix defaults, sort tables, add metric details

### DIFF
--- a/pipeline/inputs/process-exporter-metrics.md
+++ b/pipeline/inputs/process-exporter-metrics.md
@@ -20,25 +20,57 @@ All metrics including those collected with this plugin flow through a separate p
 
 | Key                       | Description                                                                                                                                                                                                                                                                           | Default                                                                  |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `scrape_interval`         | The rate, in seconds, at which metrics are collected.                                                                                                                                                                                                                                 | `5`                                                                      |
-| `path.procfs`             | The mount point used to collect process information and metrics. Read-only permissions are enough.                                                                                                                                                                                    | `/proc/`                                                                 |
-| `process_include_pattern` | Regular expression to determine which names of processes are included in the metrics produced by this plugin. It's applied for all process unless explicitly set.                                                                                                                     | `.+`                                                                     |
+| `metrics`                 | Specify which process level of metrics are collected from the host operating system. Actual values of metrics will be read from `/proc` when needed. `context_switches`, `cpu`, `fd`, `io`, `memory`, `start_time`, `state`, `thread`, and `thread_wchan` metrics depend on `procfs`. | `cpu,io,memory,state,context_switches,fd,start_time,thread_wchan,thread` |
+| `path.procfs`             | The mount point used to collect process information and metrics. Read-only permissions are enough.                                                                                                                                                                                    | `/proc`                                                                  |
 | `process_exclude_pattern` | Regular expression to determine which names of processes are excluded in the metrics produced by this plugin. It's not applied unless explicitly set.                                                                                                                                 | `NULL`                                                                   |
-| `metrics`                 | Specify which process level of metrics are collected from the host operating system. Actual values of metrics will be read from `/proc` when needed. `cpu`, `io`, `memory`, `state`, `context_switches`, `fd,` `start_time`, `thread_wchan`, and `thread` metrics depend on `procfs`. | `cpu,io,memory,state,context_switches,fd,start_time,thread_wchan,thread` |
+| `process_include_pattern` | Regular expression to determine which names of processes are included in the metrics produced by this plugin. It's applied for all process unless explicitly set.                                                                                                                     | `.+`                                                                     |
+| `scrape_interval`         | The rate, in seconds, at which metrics are collected.                                                                                                                                                                                                                                 | `5`                                                                      |
 
-## Available  metrics
+## Available metrics
 
 | Name               | Description                                         |
 |--------------------|-----------------------------------------------------|
+| `context_switches` | Exposes `context_switches` statistics from `/proc`. |
 | `cpu`              | Exposes CPU statistics from `/proc`.                |
+| `fd`               | Exposes file descriptors statistics from `/proc`.   |
 | `io`               | Exposes I/O statistics from `/proc`.                |
 | `memory`           | Exposes memory statistics from `/proc`.             |
-| `state`            | Exposes process state statistics from `/proc`.      |
-| `context_switches` | Exposes `context_switches` statistics from `/proc`. |
-| `fd`               | Exposes file descriptors statistics from `/proc`.   |
 | `start_time`       | Exposes `start_time` statistics from `/proc`.       |
-| `thread_wchan`     | Exposes `thread_wchan` from `/proc`.                |
+| `state`            | Exposes process state statistics from `/proc`.      |
 | `thread`           | Exposes thread statistics from `/proc`.             |
+| `thread_wchan`     | Exposes `thread_wchan` from `/proc`.                |
+
+### Prometheus metric names
+
+The following tables describe the Prometheus metrics exposed by each collector.
+
+#### Process-level metrics
+
+| Prometheus Metric                   | Enabled by        | Type    | Description                                        |
+|-------------------------------------|-------------------|---------|----------------------------------------------------|
+| `process_context_switches_total`    | `context_switches`| counter | Context switches (voluntary and non-voluntary).    |
+| `process_cpu_seconds_total`         | `cpu`             | counter | CPU usage in seconds (user and system).            |
+| `process_fd_ratio`                  | `fd`              | gauge   | Ratio between open file descriptors and max limit. |
+| `process_major_page_faults_total`   | `memory`          | counter | Major page faults.                                 |
+| `process_memory_bytes`              | `memory`          | gauge   | Memory in use (virtual memory and `RSS`).          |
+| `process_minor_page_faults_total`   | `memory`          | counter | Minor page faults.                                 |
+| `process_num_threads`               | `thread`          | gauge   | Number of threads.                                 |
+| `process_open_filedesc`             | `fd`              | gauge   | Number of open file descriptors.                   |
+| `process_read_bytes_total`          | `io`              | counter | Number of bytes read.                              |
+| `process_start_time_seconds`        | `start_time`      | gauge   | Start time in seconds since 1970/01/01.            |
+| `process_states`                    | `state`           | gauge   | Process state (R, S, D, Z, T, or I).               |
+| `process_write_bytes_total`         | `io`              | counter | Number of bytes written.                           |
+
+#### Thread-level metrics
+
+| Prometheus Metric                          | Enabled by     | Type    | Description                                             |
+|--------------------------------------------|----------------|---------|---------------------------------------------------------|
+| `process_thread_context_switches_total`    | `thread`       | counter | Thread context switches (voluntary and non-voluntary).  |
+| `process_thread_cpu_seconds_total`         | `thread`       | counter | Thread CPU usage in seconds (user and system).          |
+| `process_thread_io_bytes_total`            | `thread`       | counter | Thread I/O bytes (read and write).                      |
+| `process_thread_major_page_faults_total`   | `thread`       | counter | Thread major page faults.                               |
+| `process_thread_minor_page_faults_total`   | `thread`       | counter | Thread minor page faults.                               |
+| `process_thread_wchan`                     | `thread_wchan` | gauge   | Number of threads waiting on each `wchan`.              |
 
 ## Threading
 


### PR DESCRIPTION
  - Fix path.procfs default from /proc/ to /proc (matches code)
  - Sort Configuration and Available metrics tables alphabetically
  - Fix fd, typo in metrics description
  - Add new "Prometheus metric names" section documenting all 18 exposed metrics with their types (counter/gauge) and which collector enables them

Fixes #2327.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized and expanded Process Exporter Metrics plugin documentation
  * Added detailed Prometheus metrics naming reference with process and thread-level metrics
  * Enhanced configuration sections with updated defaults and metric groupings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->