### PR TITLE
fix: reinstated FB codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fluent/fluent-bit-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,3 +9,4 @@ Fluent Bit is developed and supported by many individuals and companies. The fol
 | [Jose Lecaros](https://github.com/lecaros)             | All                      | [Chronosphere](https://chronosphere.io)           |
 | [Paige Cruz](https://github.com/paigerduty)            | All                      | [Chronosphere](https://chronosphere.io/)          |
 | [Eric D. Schabell](https://github.com/eschabell)       | All                      | [Chronosphere](https://chronosphere.io/)          |
+| [Patrick Stephens](https://github.com/patrick-stephens)| All                      | [Telemetry Forge](https://telemetryforge.io)      |


### PR DESCRIPTION
#2335 removed all codeowners from the file, instead of just the chronosphere-tech-writers team. Reinstating that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project code ownership configuration.
  * Expanded project maintainer team.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->