### PR TITLE
chore: include Eric in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @fluent/fluent-bit-maintainers
+* @fluent/fluent-bit-maintainers @eschabell


### PR DESCRIPTION
Ensure @eschabell is included in code-owners now tech writers are removed in #2335 