### PR TITLE
docs: in_splunk: fix config params, add missing options, sort table

### DIFF
--- a/pipeline/inputs/splunk.md
+++ b/pipeline/inputs/splunk.md
@@ -6,22 +6,23 @@ The _Splunk_ input plugin handles [Splunk HTTP HEC](https://docs.splunk.com/Docu
 
 This plugin uses the following configuration parameters:
 
-| Key                        | Description                                                                                                                                                        | Default         |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| `listen`                   | The address to listen on.                                                                                                                                          | `0.0.0.0`       |
-| `port`                     | The port for Fluent Bit to listen on.                                                                                                                              | `9880`          |
-| `tag_key`                  | Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.                                                                | _none_          |
-| `buffer_max_size`          | Specify the maximum buffer size in KB to receive a JSON message.                                                                                                   | `4M`            |
-| `buffer_chunk_size`        | This sets the chunk size for incoming JSON messages. These chunks are then stored and managed in the space available by `buffer_max_size`.                         | `512K`          |
-| `successful_response_code` | Set the successful response code. Allowed values: `200`, `201`, and `204`                                                                                          | `201`           |
-| `splunk_token`             | Specify a Splunk token for HTTP HEC authentication. If multiple tokens are specified (with commas and no spaces), usage will be divided across each of the tokens. | _none_          |
-| `store_token_in_metadata`  | Store Splunk HEC tokens in the Fluent Bit metadata. If set to `false`, tokens will be stored as normal key-value pairs in the record data.                         | `true`          |
-| `splunk_token_key`         | Use the specified key for storing the Splunk token for HTTP HEC. Use only when `store_token_in_metadata` is `false`.                                               | `@splunk_token` |
-| `Threaded`                 | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).                                                            | `false`         |
+| Key                       | Description                                                                                                                                                        | Default         |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `buffer_chunk_size`       | Set the chunk size for incoming JSON messages. These chunks are then stored and managed in the space available by `buffer_max_size`.                               | `512K`          |
+| `buffer_max_size`         | Set the maximum buffer size to receive a JSON message.                                                                                                             | `4M`            |
+| `http2`                   | Enable HTTP/2 support.                                                                                                                                             | `true`          |
+| `listen`                  | The address to listen on.                                                                                                                                          | `0.0.0.0`       |
+| `port`                    | The port for Fluent Bit to listen on.                                                                                                                              | `8088`          |
+| `splunk_token`            | Specify a Splunk token for HTTP HEC authentication. If multiple tokens are specified (with commas and no spaces), usage will be divided across each of the tokens. | _none_          |
+| `splunk_token_key`        | Set a record key for storing the Splunk token for HTTP HEC. Use only when `store_token_in_metadata` is `false`.                                                    | `@splunk_token` |
+| `store_token_in_metadata` | Store Splunk HEC tokens in the Fluent Bit metadata. If set to `false`, they will be stored as key-value pairs in the record data.                                  | `true`          |
+| `success_header`          | Add an HTTP header key/value pair on success. Multiple headers can be set.                                                                                         | _none_          |
+| `tag_key`                 | Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.                                                                | _none_          |
+| `threaded`                | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).                                                            | `false`         |
 
 ## Get started
 
-To start performing the checks, you can run the plugin from the command line or through the configuration file.
+To get started, you can run the plugin from the command line or through the configuration file.
 
 ### Set a tag
 
@@ -67,13 +68,85 @@ pipeline:
 
 ```text
 [INPUT]
-  name   splunk
-  listen 0.0.0.0
-  port   8088
+    Name   splunk
+    Listen 0.0.0.0
+    Port   8088
 
 [OUTPUT]
-  name  stdout
-  match *
+    Name  stdout
+    Match *
+```
+
+{% endtab %}
+{% endtabs %}
+
+### Authentication with `HEC` tokens
+
+To require authentication, specify one or more `Splunk` `HEC` tokens. Multiple tokens can be provided as a comma-separated list:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: splunk
+      port: 8088
+      splunk_token: "my-secret-token,another-token"
+
+  outputs:
+    - name: stdout
+      match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+    Name         splunk
+    Port         8088
+    Splunk_Token my-secret-token,another-token
+
+[OUTPUT]
+    Name  stdout
+    Match *
+```
+
+{% endtab %}
+{% endtabs %}
+
+### Custom success headers
+
+Use `success_header` to add custom HTTP headers to successful responses. Use this for CORS or other HTTP requirements:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: splunk
+      port: 8088
+      success_header: "X-Custom-Header myvalue"
+
+  outputs:
+    - name: stdout
+      match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+    Name           splunk
+    Port           8088
+    Success_Header X-Custom-Header myvalue
+
+[OUTPUT]
+    Name  stdout
+    Match *
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Fix port default: 9880 -> 8088 (matches source code)
  - Add missing http2 parameter (default: true)
  - Add missing success_header parameter
  - Remove non-existent successful_response_code parameter
  - Sort configuration table alphabetically
  - Fix "To start performing the checks" wording
  - Add authentication example with splunk_token
  - Add custom success headers example
  - Fix classic config examples to use capitalized keys

Fixes #2346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Splunk input docs with HTTP/2 support and guidance
  * Updated default port to 8088 and standardized example naming/casing
  * Clarified buffer parameter wording and max-buffer behavior per JSON message
  * Added authentication guidance (HEC tokens, token-key handling, storing token metadata)
  * Introduced success-header usage examples and multi-format templates (YAML/conf)
  * Refined "Get started" wording and reorganized examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->