### PR TITLE
lua: fix return value documentation for record and code 2

### DIFF
--- a/pipeline/filters/lua.md
+++ b/pipeline/filters/lua.md
@@ -117,7 +117,7 @@ Each callback must return three values:
 | ---- | --------- | ----------- |
 | `code` | integer | The code return value represents the result and further actions that might follow. If `code` equals `-1`, this means that the record will be dropped. If `code` equals `0`, the record won't be modified. Otherwise, if `code` equals `1`, this means the original timestamp and record have been modified, so it must be replaced by the returned values from `timestamp` (second return value) and `record` (third return value). If `code` equals `2`, this means the original timestamp won't be modified and the record has been modified, so it must be replaced by the returned values from `record` (third return value). |
 | `timestamp` | double | If `code` equals `1`, the original record timestamp will be replaced with this new value. |
-| `record` | table | If `code` equals `1`, the original record information will be replaced with this new value. The `record` value must be a valid Lua table. This value can be an array of tables (for example, an array of objects in JSON format), and in that case the input record is effectively split into multiple records. |
+| `record` | table | If `code` equals `1` or `2`, the original record information will be replaced with this new value. The `record` value must be a valid Lua table. This value can be an array of tables (for example, an array of objects in JSON format), and in that case the input record is effectively split into multiple records. |
 
 ## Lua extended callback with groups and metadata support
 


### PR DESCRIPTION
Lua documentation state that the `record` field is only used when the `code` is equal to `1` but it's also used with `2` when we only change the record content if i am not mistaken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Lua callback docs: when returned codes indicate replacement (now applies to two specific codes) the original record is replaced; clarified timestamp handling and that a callback may emit multiple records if the returned value is an array.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->