### PR TITLE
fix links with bad paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,11 +117,11 @@ This repository runs linters as GitHub Actions for each pull request. If a linte
 <details>
 <summary>:mag: Examples: linter results</summary>
 
-![An example of a warning-level Vale result.](/.gitbook/assets/vale-example-warning.png)
+![An example of a warning-level Vale result.](./.gitbook/assets/vale-example-warning.png)
 
-![An example of an error-level Vale result.](/.gitbook/assets/vale-example-error.png)
+![An example of an error-level Vale result.](./.gitbook/assets/vale-example-error.png)
 
-![An example of a Markdownlint result.](/.gitbook/assets/markdownlint-example.png)
+![An example of a Markdownlint result.](./.gitbook/assets/markdownlint-example.png)
 
 </details>
 

--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -471,7 +471,7 @@ You can create Grafana dashboards and alerts using Fluent Bit exposed Prometheus
 
 The provided [example dashboard](https://github.com/fluent/fluent-bit-docs/blob/master/monitoring/dashboard.json) is heavily inspired by [Banzai Cloud](https://github.com/banzaicloud)'s [logging operator dashboard](https://grafana.com/grafana/dashboards/7752-logging-dashboard) with a few key differences, such as the use of the `instance` label, stacked graphs, and a focus on Fluent Bit metrics. See [this blog post](https://www.robustperception.io/controlling-the-instance-label/) for more information.
 
-![dashboard](/.gitbook/assets/dashboard.png)
+![dashboard](../.gitbook/assets/dashboard.png)
 
 ### Alerts
 

--- a/pipeline/processors/conditional-processing.md
+++ b/pipeline/processors/conditional-processing.md
@@ -76,7 +76,7 @@ This rule evaluates to `true` for a log that contains the string `'status':200`,
 
 #### Field access
 
-The `conditions.rules.field` parameter uses [record accessor syntax](/administration/configuring-fluent-bit/classic-mode/record-accessor.md) to reference fields inside logs.
+The `conditions.rules.field` parameter uses [record accessor syntax](../../administration/configuring-fluent-bit/classic-mode/record-accessor.md) to reference fields inside logs.
 
 You can use `$field` syntax to access a top-level field, and `$field['child']['subchild']` to access nested fields.
 

--- a/pipeline/router.md
+++ b/pipeline/router.md
@@ -259,7 +259,7 @@ Each rule in the `condition.rules` array must include:
 
 | Parameter | Description |
 | --- | --- |
-| `field` | The field within your logs to evaluate. Uses [record accessor syntax](/administration/configuring-fluent-bit/classic-mode/record-accessor.md). |
+| `field` | The field within your logs to evaluate. Uses [record accessor syntax](../administration/configuring-fluent-bit/classic-mode/record-accessor.md). |
 | `op` | The comparison operator. |
 | `value` | This is the value to compare against. It can be a single value or an array for `in` and `not_in` operators. |
 | `context` | Optional. Specifies where to look for the field. See the Context types section. Defaults to `body`. |
@@ -703,7 +703,7 @@ To get the most benefit from label-based matching:
 Fluent Bit provides comprehensive routing metrics to help you monitor routing performance and identify issues such as dropped records or unmatched logs. These metrics are available through the built-in HTTP server's `/metrics` endpoint.
 
 {% hint style="info" %}
-Routing metrics are available in Fluent Bit version 4.2 and greater. To access these metrics, enable the [HTTP server](/administration/monitoring.md) in your configuration.
+Routing metrics are available in Fluent Bit version 4.2 and greater. To access these metrics, enable the [HTTP server](../administration/monitoring.md) in your configuration.
 {% endhint %}
 
 ### Available metrics


### PR DESCRIPTION
the link checker reports throw a few errors for links that technically use invalid link syntax, even though they aren't broken in the live site (for whatever reason). I fixed those paths to be really truly correct :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Fixed image reference paths in CONTRIBUTING guide examples for linters
* Updated dashboard image link in monitoring documentation
* Corrected internal hyperlinks in pipeline processor and router guides to improve documentation consistency and portability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->