### PR TITLE
update link checker test

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -20,7 +20,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept '100..=103,200..=299,401,403,429' --verbose --no-progress './**/*.mdx'
+          args: --accept '100..=103,200..=299,401,403,429' --verbose --no-progress .
           fail: false
           jobSummary: true
 


### PR DESCRIPTION
this updates the link checker test to ignore `401`, `403`, and `429` error codes. (the other values in that argument are part of the link checker's default value.)

`401` and `403` are ostensibly auth errors, but it seems like some non-auth pages return those statuses as an anti-scraper thing when the check runs--and even if they were genuine `401` or `403` errors, those don't indicate a broken link, just something that requires login. `429` also seems like an anti-scraper defense mechanism. in any case, they're _not_ `404` errors or other status that indicate a genuine broken link :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated link checker workflow to accept a broader range of HTTP status codes (including informational and additional success/error codes), enable verbose output, disable progress display, and run from the workflow root for clearer, more comprehensive link validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->