### PR TITLE
outputs: azure_logs_ingestion: Update time_generated description

### DIFF
--- a/pipeline/outputs/azure_logs_ingestion.md
+++ b/pipeline/outputs/azure_logs_ingestion.md
@@ -32,7 +32,7 @@ To get more details about how to set up these components, refer to the following
 | `dcr_id` | Data Collection Rule (DCR) [immutable ID](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/tutorial-logs-ingestion-portal#collect-information-from-the-dcr). | _none_ |
 | `table_name` | The name of the custom log table (include the `_CL` suffix as well if applicable). | _none_ |
 | `tenant_id` | The tenant ID of the Azure Active Directory (AAD) application. | _none_ |
-| `time_generated` | Optional. If enabled, will generate a timestamp and append it to JSON. The key name is set by the `time_key` parameter. | `false` |
+| `time_generated` | Optional. If enabled, the timestamp appended under `time_key` is formatted as an ISO 8601 string. If disabled, it's a floating-point number representing seconds since Unix epoch. | `false` |
 | `time_key` | Optional. Specify the key name where the timestamp will be stored. | `@timestamp` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 


### PR DESCRIPTION
The `time_generated` config setting influences the time format, not the addition of a timestamp field as previously documented.

Reference: https://github.com/fluent/fluent-bit/blob/a1d9c2a9a637bba1d8918c6c7a49b8279fd6df0a/plugins/out_azure_logs_ingestion/azure_logs_ingestion.c#L107-L131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the time_generated parameter: when enabled, timestamps under the configured key are ISO 8601 strings; when disabled, timestamps are floating-point seconds since the Unix epoch.
  * Reworded description to emphasize formatting behavior; default behavior and controls remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->