### PR TITLE
pipeline: processors: sampling: fixed indentation of sample configs

### DIFF
--- a/pipeline/processors/sampling.md
+++ b/pipeline/processors/sampling.md
@@ -127,10 +127,10 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 5s
-              conditions:
-                - type: latency
-                  threshold_ms_low: 200
-                  threshold_ms_high: 3000
+            conditions:
+              - type: latency
+                threshold_ms_low: 200
+                threshold_ms_high: 3000
 
   outputs:
     - name: stdout
@@ -175,10 +175,10 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 5s
-              conditions:
-                - type: span_count
-                  min_spans: 3
-                  max_spans: 5
+            conditions:
+              - type: span_count
+                min_spans: 3
+                max_spans: 5
 
   outputs:
     - name: stdout
@@ -222,9 +222,9 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 5s
-              conditions:
-                - type: status_code
-                  status_codes: [ERROR]
+            conditions:
+              - type: status_code
+                status_codes: [ERROR]
 
   outputs:
     - name: stdout
@@ -275,29 +275,29 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 2s
-              conditions:
-                # Exact matching
-                - type: string_attribute
-                  match_type: strict
-                  key: "http.method"
-                  values: ["GET"]
+            conditions:
+              # Exact matching
+              - type: string_attribute
+                match_type: strict
+                key: "http.method"
+                values: ["GET"]
 
                 # Check if attribute exists
-                - type: string_attribute
-                  match_type: exists
-                  key: "service.name"
+              - type: string_attribute
+                match_type: exists
+                key: "service.name"
 
-                # Regex pattern matching
-                - type: string_attribute
-                  match_type: regex
-                  key: "http.url"
-                  values: ["^https://api\\..*", ".*\\/health$"]
+              # Regex pattern matching
+              - type: string_attribute
+                match_type: regex
+                key: "http.url"
+                values: ["^https://api\\..*", ".*\\/health$"]
 
-                # Multiple regex patterns for error conditions
-                - type: string_attribute
-                  match_type: regex
-                  key: "error.message"
-                  values: ["timeout.*", "connection.*failed", ".*rate.?limit.*"]
+              # Multiple regex patterns for error conditions
+              - type: string_attribute
+                match_type: regex
+                key: "error.message"
+                values: ["timeout.*", "connection.*failed", ".*rate.?limit.*"]
 
   outputs:
     - name: stdout
@@ -344,11 +344,11 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 5s
-              conditions:
-                - type: numeric_attribute
-                  key: "http.status_code"
-                  min_value: 400
-                  max_value: 504
+            conditions:
+              - type: numeric_attribute
+                key: "http.status_code"
+                min_value: 400
+                max_value: 504
 
   outputs:
     - name: stdout
@@ -393,10 +393,10 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 2s
-              conditions:
-                - type: boolean_attribute
-                  key: "user.logged"
-                  value: false
+            conditions:
+              - type: boolean_attribute
+                key: "user.logged"
+                value: false
 
   outputs:
     - name: stdout
@@ -440,9 +440,9 @@ pipeline:
             type: tail
             sampling_settings:
               decision_wait: 2s
-              conditions:
-                - type: trace_state
-                  values: [debug=false, priority=high]
+            conditions:
+              - type: trace_state
+                values: [debug=false, priority=high]
 
   outputs:
     - name: stdout


### PR DESCRIPTION
`conditions` is expected at the same level that `sampling_settings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and indentation consistency in sampling configuration documentation for enhanced readability and clearer presentation of configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->