### PR TITLE
docs: outputs: azure: fix table sort order, lowercase keys, fix a default

### DIFF
--- a/pipeline/outputs/azure.md
+++ b/pipeline/outputs/azure.md
@@ -12,13 +12,13 @@ For details about how to setup Azure Log Analytics, see the [Azure Log Analytics
 
 | Key | Description | Default |
 | :--- | :--- | :--- |
-| `Customer_ID` | Customer ID or WorkspaceID string. | _none_ |
-| `Shared_Key` | The primary or the secondary Connected Sources client authentication key. | _none_ |
-| `Log_Type` | The name of the event type. | `fluentbit` |
-| `Log_Type_Key` | If included, the value for this key checked in the record and if present, will overwrite the `log_type`. If not found then the `log_type` value will be used. | _none_ |
-| `Time_Key` | Optional. Specify the key name where the timestamp will be stored. | `@timestamp` |
-| `Time_Generated` | If enabled, the HTTP request header `time-generated-field` will be included so Azure can override the timestamp with the key specified by `time_key` option. | `off` |
-| `Workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
+| `customer_id` | Customer ID or WorkspaceID string. | _none_ |
+| `log_type` | The name of the event type. | `fluentbit` |
+| `log_type_key` | If included, the value for this key checked in the record and if present, will overwrite the `log_type`. If not found then the `log_type` value will be used. | _none_ |
+| `shared_key` | The primary or the secondary Connected Sources client authentication key. | _none_ |
+| `time_generated` | If enabled, the HTTP request header `time-generated-field` will be included so Azure can override the timestamp with the key specified by `time_key` option. | `false` |
+| `time_key` | Optional. Specify the key name where the timestamp will be stored. | `@timestamp` |
+| `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 
 ## Get started
 


### PR DESCRIPTION
  - Sort parameter table alphabetically
  - Lowercase all table keys to match source code
  - Fix time_generated default from off to false (matches source)

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure output configuration parameter naming convention to use lowercase with underscores format.
  * Adjusted corresponding default values for consistency with the new convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->