### PR TITLE
docs: outputs: firehose: fix profile default value

### DIFF
--- a/pipeline/outputs/firehose.md
+++ b/pipeline/outputs/firehose.md
@@ -22,7 +22,7 @@ This plugin uses the following configuration parameters:
 | `endpoint` | Specify a custom endpoint for the Firehose API. | _none_ |
 | `external_id` | Specify an external ID for the STS API. You can use this option with the `role_arn` parameter if your role requires an external ID. | _none_ |
 | `log_key` | By default, the whole log record will be sent to Firehose. If you specify a key name with this option, then only the value of that key will be sent to Firehose. For example, if you are using the Fluentd Docker log driver, you can specify `log_key log` and only the log message will be sent to Firehose. | _none_ |
-| `profile` | AWS profile name to use. | `default` |
+| `profile` | AWS profile name to use. | _none_ |
 | `region` | The AWS region. | _none_ |
 | `role_arn` | ARN of an IAM role to assume (for cross-account access). | _none_ |
 | `simple_aggregation` | Enable record aggregation to combine multiple records into single API calls. This reduces the number of requests and can improve throughput. | `false` |


### PR DESCRIPTION
Just one default value in config parameters table was changed to `_none`, source verifed.

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new configuration parameters: sts_endpoint, time_key, and time_key_format with defaults set to "none" unless specified
  * Updated profile default configuration from "default" to "none"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->