### PR TITLE
docs: outputs: s3: fix table sort, param name, add workers, fix classic key casing

### DIFF
--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -40,9 +40,9 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `authorization_endpoint_username` | Authorization endpoint basic authentication username. | _none_ |
 | `auto_retry_requests` | Immediately retry failed requests to AWS services once. This option doesn't affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which can help improve throughput during transient network issues. | `true` |
 | `blob_database_file` | Absolute path to a database file to be used to store blob files contexts. | _none_ |
-| `bucket` | S3 Bucket name | _none_ |
+| `bucket` | S3 bucket name. | _none_ |
 | `canned_acl` | [Predefined Canned ACL policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for S3 objects. | _none_ |
-| `compression` | Compression/format for S3 objects. Supported: `gzip` (always available) and `parquet` (requires Arrow build). For `gzip`, the `Content-Encoding` header is set to `gzip`. `parquet` is available **only when Fluent Bit is built with `-DFLB_ARROW=On`** and Arrow GLib/Parquet GLib are installed. Parquet is typically used with `use_put_object On`. | _none_ |
+| `compression` | Compression type for S3 objects. Supported values: `gzip` (always available), `arrow`, `parquet` (both require Arrow build), and `zstd`. For `gzip` and `zstd`, the `Content-Encoding` header is set accordingly. `arrow` and `parquet` are available **only when Fluent Bit is built with `-DFLB_ARROW=On`** and Arrow GLib/Parquet GLib are installed. `parquet` is typically used with `use_put_object On`. | _none_ |
 | `content_type` | A standard MIME type for the S3 object, set as the Content-Type HTTP header. | _none_ |
 | `endpoint` | Custom endpoint for the S3 API. Endpoints can contain scheme and port. | _none_ |
 | `external_id` | Specify an external ID for the STS API. Can be used with the `role_arn` parameter if your role requires an external ID. | _none_ |
@@ -50,25 +50,25 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `host` | IP address or hostname of the target HTTP server. | `127.0.0.1` |
 | `json_date_format` | Specify the format of the date. Accepted values: `double`, `epoch`, `epoch_ms`, `iso8601` (2018-05-30T09:39:52.000681Z), `_java_sql_timestamp_` (2018-05-30 09:39:52.000681). | _none_ |
 | `json_date_key` | Specify the name of the date key in the output record. To disable the time key, set the value to `false`. | `date` |
+| `log_key` | By default, the whole log record is sent to S3. When specifying a key name with this option, only the value of that key is sent to S3. For example, when using Docker you can specify `log_key log` and only the log message is sent to S3. | _none_ |
 | `log_level` | Specifies the log level for output plugin. If not set here, plugin uses global log level in `service` section. | `info` |
-| `log_supress_interval` | Suppresses log messages from output plugin that appear similar within a specified time interval. `0` no suppression. | `0` |
+| `log_suppress_interval` | Suppresses log messages from output plugin that appear similar within a specified time interval. `0` means no suppression. | `0` |
 | `match` | Set a tag pattern to match records that output should process. Exact matches or wildcards (for example `*`). | _none_ |
 | `match_regex` | Set a regular expression to match tags for output routing. This allows more flexible matching compared to wildcards. | _none_ |
 | `net.connect_timeout` | Set maximum time allowed to establish a connection, this time includes the TLS handshake. | `10s` |
 | `net.connect_timeout_log_error` | On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message. | `true` |
-| `net.keepalive_max_recycle` | Set maximum number of times a keepalive connection can be used before it retries. | `2000` |
 | `net.dns.mode` | Select the primary DNS connection type (TCP or UDP). | _none_ |
 | `net.dns.prefer_ipv4` | Select the primary DNS resolver type (LEGACY or ASYNC). | _none_ |
 | `net.dns.prefer_ipv6` | Prioritize IPv6 DNS results when trying to establish a connection. | _none_ |
 | `net.io_timeout` | Set maximum time a connection can stay idle while assigned. | `0s` |
+| `net.keepalive_max_recycle` | Set maximum number of times a keepalive connection can be used before it retries. | `2000` |
 | `net.max_worker_connections` | Set the maximum number of active TCP connections that can be used per worker thread. | `0` |
 | `net.proxy_env_ignore` | Ignore the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` when set. | `false` |
 | `net.source_address` | Specify network address to bind for data traffic. | _none_ |
 | `net.tcp_keepalive` | Enable or disable Keepalive support. | `off` |
-| `net.tcp_keepalive_time` | Interval between the last data packet sent and the first TCP keepalive probe. | `-1` |
 | `net.tcp_keepalive_interval` | Interval between TCP keepalive probes when no response is received on a `keepidle` probe. | `-1` |
 | `net.tcp_keepalive_probes` | Number of unacknowledged probes to consider a connection dead. | `-1` |
-| `log_key` | By default, the whole log record will be sent to S3. When specifying a key name with this option, only the value of that key sends to S3. For example, when using Docker you can specify `log_key log` and only the log message sends to S3. | _none_ |
+| `net.tcp_keepalive_time` | Interval between the last data packet sent and the first TCP keepalive probe. | `-1` |
 | `part_delivery_attempt_limit` | File part delivery attempt limit. | `1` |
 | `part_size` | Size of each part when uploading blob files. | `25M` |
 | `port` | TCP port of the target HTTP server. | `80` |
@@ -76,7 +76,7 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `profile` | Option to specify an AWS Profile for credentials. | _none_ |
 | `region` | The AWS region of your S3 bucket. | `us-east-1` |
 | `retry_limit` | Set retry limit for output plugin when delivery fails. Integer, `no_limits`, `false`, or `off` to disable, or `no_retries` to disable retries entirely. | `1` |
-| `role_arn` | ARN of an IAM role to assume (for example, for cross account access.) | _none_ |
+| `role_arn` | ARN of an IAM role to assume (for example, for cross account access). | _none_ |
 | `s3_key_format` | Format string for keys in S3. This option supports a UUID, strftime time formatters, a syntax for selecting parts of the Fluent log tag using a syntax inspired by the `rewrite_tag` filter. Add `$UUID` in the format string to insert a random string. Add `$INDEX` in the format string to insert an integer that increments each upload. The `$INDEX` value saves in the `store_dir`. Add `$TAG` in the format string to insert the full log tag. Add `$TAG[0]` to insert the first part of the tag in the S3 key. The tag is split into parts using the characters specified with the `s3_key_format_tag_delimiters` option. Add the extension directly after the last piece of the format string to insert a key suffix. To specify a key suffix in `use_put_object` mode, you must specify `$UUID`. See [S3 Key Format](#s3-key-format-and-tag-delimiters). Time in `s3_key` is the timestamp of the first record in the S3 file. | `/fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S` |
 | `s3_key_format_tag_delimiters` | A series of characters which will be used to split the tag into `parts` for use with the s3_key_format option. | `.` |
 | `send_content_md5` | Send the Content-MD5 header with `PutObject` and UploadPart requests, as is required when Object Lock is enabled. | `false` |
@@ -88,24 +88,25 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `tls` | Enable or disable TLS/SSL support. | `off` |
 | `tls.ca_file` | Absolute path to CA certificate file. | _none_ |
 | `tls.ca_path` | Absolute path to scan for certificate files. | _none_ |
-| `tls.crt_file` | Absolute path to Certificate file. | _none_ |
 | `tls.ciphers` | Specify TLS ciphers up to TLSv1.2. | _none_ |
-| `tls.debug` | Set TLS debug level. Accepts `0` (No debug), `1`(Error), `2` (State change), `3` (Informational) and `4` (Verbose). | `1` |
+| `tls.crt_file` | Absolute path to Certificate file. | _none_ |
+| `tls.debug` | Set TLS debug level. Accepts `0` (No debug), `1` (Error), `2` (State change), `3` (Informational) and `4` (Verbose). | `1` |
 | `tls.key_file` | Absolute path to private Key file. | _none_ |
 | `tls.key_passwd` | Optional password for tls.key_file file. | _none_ |
 | `tls.max_version` | Specify the maximum version of TLS. | _none_ |
 | `tls.min_version` | Specify the minimum version of TLS. | _none_ |
+| `tls.verify` | Force certificate validation. | `on` |
 | `tls.verify_hostname` | Enable or disable to verify hostname. | `off` |
 | `tls.vhost` | Hostname to be used for TLS SNI extension. | _none_ |
-| `tls.verify` | Force certificate validation. | `on` |
 | `tls.windows.certstore_name` | Sets the `certstore` name on an output (Windows). | _none_ |
 | `tls.windows.use_enterprise_store` | Sets whether using enterprise `certstore` or not on an output (Windows). | _none_ |
 | `total_file_size` | Specify file size in S3. Minimum size is `1M`. With `use_put_object On` the maximum size is `1G`. With multipart uploads, the maximum size is `50G`. | `100000000` |
 | `upload_chunk_size` | The size of each part for multipart uploads. Default: 5M, Max: 50M, Min: 5M. | `5242880` |
-| `upload_part_freshness_timeout` | Maximum lifespan of an uncommitted file part. | `6D` |
+| `upload_part_freshness_limit` | Maximum lifespan of an uncommitted file part. | `6D` |
 | `upload_parts_timeout` | Timeout to upload parts of a blob file. | `10m` |
 | `upload_timeout` | When this amount of time elapses, Fluent Bit uploads and creates a new file in S3. Set to `60m` to upload a new file every hour. | `10m` |
 | `use_put_object` | Use the S3 `PutObject` API instead of the multipart upload API. When enabled, the key extension is only available when `$UUID` is specified in `s3_key_format`. If `$UUID` isn't included, a random string appends format string and the key extension can't be customized. | `false` |
+| `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `1` |
 
 
 ## TLS / SSL
@@ -179,11 +180,11 @@ pipeline:
 [OUTPUT]
   Name                         s3
   Match                        *
-  bucket                       my-bucket
-  region                       us-west-2
-  total_file_size              250M
-  s3_key_format                /$TAG[2]/$TAG[0]/%Y/%m/%d/%H/%M/%S/$UUID.gz
-  s3_key_format_tag_delimiters .-
+  Bucket                       my-bucket
+  Region                       us-west-2
+  Total_file_size              250M
+  S3_key_format                /$TAG[2]/$TAG[0]/%Y/%m/%d/%H/%M/%S/$UUID.gz
+  S3_key_format_tag_delimiters .-
 ```
 
 {% endtab %}
@@ -237,12 +238,12 @@ pipeline:
 [OUTPUT]
   Name              s3
   Match             *
-  bucket            my-bucket
-  region            us-west-2
-  total_file_size   50M
-  use_put_object    Off
-  compression       gzip
-  s3_key_format     /$TAG/%Y/%m/%d/%H_%M_%S.gz
+  Bucket            my-bucket
+  Region            us-west-2
+  Total_file_size   50M
+  Use_put_object    Off
+  Compression       gzip
+  S3_key_format     /$TAG/%Y/%m/%d/%H_%M_%S.gz
 ```
 
 {% endtab %}
@@ -285,13 +286,13 @@ To disable this behavior, use one of the following methods:
   [OUTPUT]
     Name               s3
     Match              *
-    bucket             my-bucket
-    region             us-west-2
-    total_file_size    50M
-    use_put_object     Off
-    compression        gzip
-    s3_key_format      /$TAG/%Y/%m/%d/%H_%M_%S.gz
-    static_file_path   On
+    Bucket             my-bucket
+    Region             us-west-2
+    Total_file_size    50M
+    Use_put_object     Off
+    Compression        gzip
+    S3_key_format      /$TAG/%Y/%m/%d/%H_%M_%S.gz
+    Static_file_path   On
   ```
 
 {% endtab %}
@@ -323,12 +324,12 @@ To disable this behavior, use one of the following methods:
   [OUTPUT]
     Name                 s3
     Match                *
-    bucket               my-bucket
-    region               us-west-2
-    total_file_size      50M
-    use_put_object       Off
-    compression          gzip
-    s3_key_format        /$TAG/%Y/%m/%d/%H_%M_%S/$UUID.gz
+    Bucket               my-bucket
+    Region               us-west-2
+    Total_file_size      50M
+    Use_put_object       Off
+    Compression          gzip
+    S3_key_format        /$TAG/%Y/%m/%d/%H_%M_%S/$UUID.gz
   ```
 
 {% endtab %}
@@ -371,11 +372,11 @@ pipeline:
 [OUTPUT]
   Name               s3
   Match              *
-  bucket             your-bucket
-  region             us-east-1
-  total_file_size    1M
-  upload_timeout     1m
-  use_put_object     On
+  Bucket             your-bucket
+  Region             us-east-1
+  Total_file_size    1M
+  Upload_timeout     1m
+  Use_put_object     On
 ```
 
 {% endtab %}
@@ -446,8 +447,8 @@ pipeline:
 [OUTPUT]
   Name     s3
   Match    *
-  bucket   your-bucket
-  endpoint http://localhost:9000
+  Bucket   your-bucket
+  Endpoint http://localhost:9000
 ```
 
 {% endtab %}
@@ -481,8 +482,8 @@ pipeline:
 [OUTPUT]
   Name     s3
   Match    *
-  bucket   your-bucket
-  endpoint https://storage.googleapis.com
+  Bucket   your-bucket
+  Endpoint https://storage.googleapis.com
 ```
 
 {% endtab %}
@@ -527,11 +528,11 @@ pipeline:
 [OUTPUT]
   Name            s3
   Match           *
-  bucket          your-bucket
-  region          us-east-1
-  store_dir       /home/ec2-user/buffer
-  total_file_size 50M
-  upload_timeout  10m
+  Bucket          your-bucket
+  Region          us-east-1
+  Store_dir       /home/ec2-user/buffer
+  Total_file_size 50M
+  Upload_timeout  10m
 ```
 
 {% endtab %}
@@ -563,12 +564,12 @@ pipeline:
 [OUTPUT]
   Name            s3
   Match           *
-  bucket          your-bucket
-  region          us-east-1
-  store_dir       /home/ec2-user/buffer
-  use_put_object  On
-  total_file_size 10M
-  upload_timeout  10m
+  Bucket          your-bucket
+  Region          us-east-1
+  Store_dir       /home/ec2-user/buffer
+  Use_put_object  On
+  Total_file_size 10M
+  Upload_timeout  10m
 ```
 
 {% endtab %}
@@ -670,12 +671,12 @@ pipeline:
   Name cpu
 
 [OUTPUT]
-  Name s3
-  Bucket your-bucket-name
-  total_file_size 1M
-  use_put_object On
-  upload_timeout 60s
-  Compression arrow
+  Name            s3
+  Bucket          your-bucket-name
+  Total_file_size 1M
+  Use_put_object  On
+  Upload_timeout  60s
+  Compression     arrow
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Fix upload_part_freshness_timeout -> upload_part_freshness_limit
  - Add missing workers parameter with default of 1
  - Add missing zstd and arrow to compression description
  - Fix log_supress_interval typo -> log_suppress_interval
  - Sort config param table
  - Apply Title_Case to [OUTPUT] keys across all 9 classic config examples

  Applies to #2412