### PR TITLE
docs: outputs: skywalking: fix table header, sort order, host default, classic key casing

### DIFF
--- a/pipeline/outputs/skywalking.md
+++ b/pipeline/outputs/skywalking.md
@@ -4,15 +4,13 @@ The _Apache SkyWalking_ output plugin lets you flush your records to an [Apache 
 
 ## Configuration parameters
 
-This plugin supports the following parameters:
-
-| Parameter | Description | Default    |
-|:--------- |:----------- |:-----------|
-| `host` | Hostname of Apache SkyWalking OAP. |` 127.0.0.1` |
-| `port` | TCP port of the Apache SkyWalking OAP. | `12800` |
+| Key | Description | Default |
+| :--- | :--- | :--- |
 | `auth_token` | Authentication token if needed for Apache SkyWalking OAP. | _none_ |
-| `svc_name` | Service name that Fluent Bit belongs to. | `sw-service` |
+| `host` | Hostname of Apache SkyWalking OAP. | `127.0.0.1` |
+| `port` | TCP port of the Apache SkyWalking OAP. | `12800` |
 | `svc_inst_name` | Service instance name of Fluent Bit. | `fluent-bit` |
+| `svc_name` | Service name that Fluent Bit belongs to. | `sw-service` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 
 ### TLS / SSL
@@ -50,8 +48,8 @@ pipeline:
 
 [OUTPUT]
   Name          skywalking
-  svc_name      dummy-service
-  svc_inst_name dummy-service-fluentbit
+  Svc_Name      dummy-service
+  Svc_Inst_Name dummy-service-fluentbit
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Fix table column header: "Parameter" -> "Key" for consistency with other output plugin docs
  - Remove redundant "This plugin supports the following parameters:" intro sentence
  - Sort configuration parameters table alphabetically
  - Fix stray space in host default value
  - Apply Title_Case to classic config keys: Svc_name, Svc_inst_name

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changed parameter table header from "Parameter" to "Key" and clarified default value presentation.
  * Added a new auth_token option to the documented settings.
  * Reordered parameters so host and port appear before service name fields.
  * Updated sample configuration keys to CamelCase (Svc_Name, Svc_Inst_Name) and adjusted default values formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->