### PR TITLE
docs: outputs: flowcounter: general doc updates and cleanup

### DIFF
--- a/pipeline/outputs/flowcounter.md
+++ b/pipeline/outputs/flowcounter.md
@@ -4,12 +4,11 @@ The _Flow counter_ output plugin lets you count up records and their size.
 
 ## Configuration parameters
 
-The plugin supports the following configuration parameters:
-
 | Key | Description | Default |
 | :--- | :--- | :--- |
-| `Unit` | The unit of duration. Allowed values: `second`, `minute`, `hour`, `day` | `minute` |
-| `Workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
+| `event_based` | When enabled, use the timestamp from the log event for time bucketing instead of the current wall-clock time. | `false` |
+| `unit` | The unit of duration. Allowed values: `second`, `minute`, `hour`, `day`. | `minute` |
+| `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 
 ## Get started
 


### PR DESCRIPTION
  - Lowercase Key column entries
  - Add missing event_based parameter
  - Sort config param table alphabetically
  - Remove redundant intro sentence
  - Add missing period to unit description

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated flowcounter configuration parameters: standardized Unit and Workers to lowercase (unit, workers) and introduced a new event_based parameter to enable time bucketing using event timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->