### PR TITLE
docs: outputs: http: general updates and fixes, added missing config parameters

### DIFF
--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -4,17 +4,15 @@ The _HTTP_ output plugin lets you flush your records into an HTTP endpoint. It i
 
 ## Configuration parameters
 
-The plugin supports the following configuration parameters:
-
 | Key | Description | Default |
-| --- | ----------- | -------- |
+| :--- | :--- | :--- |
 | `allow_duplicated_headers` | Specify if duplicated headers are allowed. If a duplicated header is found, the latest key/value set is preserved. | `true` |
 | `aws_auth` | Enable AWS SigV4 authentication. | `false` |
 | `aws_external_id` | External ID for the AWS IAM Role specified with `aws_role_arn`, used by SigV4 authentication. | _none_ |
 | `aws_profile` | AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in `$HOME/.aws/` directory. | _none_ |
 | `aws_region` | Specify the AWS region of your service, used by SigV4 authentication. | _none_ |
 | `aws_role_arn` | AWS IAM Role to assume, used by SigV4 authentication. | _none_ |
-| `aws_service` | Specify the AWS service code of your service, used by SigV4 authentication (for example, `es`, `xray`.) Usually found in the service endpoint's subdomains, `protocol://service-code.region-code.amazonaws.com`. | _none_ |
+| `aws_service` | Specify the AWS service code of your service, used by SigV4 authentication (for example, `es`, `xray`). Usually found in the service endpoint's subdomains, `protocol://service-code.region-code.amazonaws.com`. | _none_ |
 | `aws_sts_endpoint` | Specify the custom STS endpoint to be used by STS API. Used with the `aws_role_arn` option and by SigV4 authentication. | _none_ |
 | `body_key` | Specify the key to use as the body of the request (must prefix with `$`). The key must contain either a binary or raw string, and the content type can be specified using `headers_key`, which must be passed whenever `body_key` is present. When this option is present, each `msgpack` record will create a separate request. | _none_ |
 | `compress` | Set payload compression mechanism. Allowed values: `gzip`, `snappy`, `zstd`. | _none_ |
@@ -26,19 +24,35 @@ The plugin supports the following configuration parameters:
 | `gelf_timestamp_key` | Specify the key to use for `timestamp` in `gelf` format. | _none_ |
 | `header` | Add a HTTP header key/value pair. Multiple headers can be set. | _none_ |
 | `header_tag` | Specify an optional HTTP header field for the original message tag. | _none_ |
-| `headers_key` | Specify the key to use as the headers of the request (must prefix with `$`). The key must contain a map, which will have the contents merged on the request headers. This can be used for many purposes, such as specifying the content type of the data contained in `body_key`.| _none_ |
+| `headers_key` | Specify the key to use as the headers of the request (must prefix with `$`). The key must contain a map, which will have the contents merged on the request headers. This can be used for many purposes, such as specifying the content type of the data contained in `body_key`. | _none_ |
 | `host` | IP address or hostname of the target HTTP Server. | `127.0.0.1` |
 | `http.read_idle_timeout` | Set maximum allowed time between two consecutive reads. If set to `0s`, uses the `io_timeout` value from the network setup. | `0s` |
 | `http.response_timeout` | Set maximum time to wait for a server response. | `60s` |
-| `http_method` | Specify `POST` versus `PUT` HTTP Method. | `POST` |
+| `http_method` | Specify `POST` versus `PUT` HTTP method. | `POST` |
 | `http_passwd` | Basic Auth password. Requires `http_user` to be set. | _none_ |
 | `http_user` | Basic Auth username. | _none_ |
-| `json_date_format` | Specify the format of the date. Supported formats: `double`, `epoch`, `epoch_ms`, `iso8601`, `java_sql_timestamp`. | `double` |
+| `json_date_format` | Specify the format of the date. Supported formats: `double`, `epoch`, `epoch_ms`, `iso8601`, `java_sql_timestamp`. | _none_ |
 | `json_date_key` | Specify the name of the time key in the output record. To disable the time key, set the value to `false`. | `date` |
 | `log_response_payload` | Specify if the response payload should be logged or not. | `true` |
+| `oauth2.audience` | Optional `OAuth 2.0` audience parameter. | _none_ |
+| `oauth2.auth_method` | `OAuth 2.0` client authentication method. Supported values: `basic`, `post`, `private_key_jwt`. | `basic` |
+| `oauth2.client_id` | `OAuth 2.0` client ID. | _none_ |
+| `oauth2.client_secret` | `OAuth 2.0` client secret. | _none_ |
+| `oauth2.connect_timeout` | Connect timeout for `OAuth 2.0` token requests. | `0s` |
+| `oauth2.enable` | Enable `OAuth 2.0` client credentials for outgoing requests. | `false` |
+| `oauth2.jwt_aud` | Audience for `private_key_jwt` JSON Web Token (JWT) assertion. Defaults to the value of `oauth2.token_url` when not set. | _none_ |
+| `oauth2.jwt_cert_file` | Path to certificate file used by `private_key_jwt`. | _none_ |
+| `oauth2.jwt_header` | JWT header claim name for `private_key_jwt` thumbprint. Accepted values: `kid`, `x5t`. | `kid` |
+| `oauth2.jwt_key_file` | Path to PEM private key file used by `private_key_jwt`. | _none_ |
+| `oauth2.jwt_ttl_seconds` | Lifetime in seconds for `private_key_jwt` JWT client assertions. | `300` |
+| `oauth2.refresh_skew_seconds` | Seconds before expiry at which to refresh the access token. | `60` |
+| `oauth2.resource` | Optional `OAuth 2.0` resource parameter. | _none_ |
+| `oauth2.scope` | Optional `OAuth 2.0` scope. | _none_ |
+| `oauth2.timeout` | Timeout for `OAuth 2.0` token requests. Defaults to `http.response_timeout` when unset. | `0s` |
+| `oauth2.token_url` | `OAuth 2.0` token endpoint URL. | _none_ |
 | `port` | TCP port of the target HTTP Server. | `80` |
 | `proxy` | Specify an HTTP Proxy. The expected format of this value is `http://HOST:PORT`. HTTPS isn't supported. It's recommended to configure the [HTTP proxy environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS. | _none_ |
-| `uri` | Specify an optional HTTP URI for the target web server. For example, `/somepath`. | `/` |
+| `uri` | Specify an optional HTTP URI for the target web server. For example, `/somepath`. | _none_ |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `2` |
 
 ### TLS / SSL
@@ -133,9 +147,9 @@ pipeline:
   Match *
   Host  192.168.2.3
   Port  80
-  URI   /something
-  Format json
-  header_tag  FLUENT-TAG
+  Uri        /something
+  Format     json
+  Header_tag FLUENT-TAG
 ```
 
 {% endtab %}
@@ -194,7 +208,7 @@ pipeline:
   Port           9000
   Header         X-Key-A Value_A
   Header         X-Key-B Value_B
-  URI            /something
+  Uri            /something
 ```
 
 {% endtab %}
@@ -230,7 +244,7 @@ pipeline:
   Match            *
   Host             collectors.au.sumologic.com
   Port             443
-  URI              /receiver/v1/http/[PrivateKey]
+  Uri              /receiver/v1/http/[PrivateKey]
   Format           json_lines
   Json_date_key    timestamp
   Json_date_format iso8601
@@ -277,7 +291,7 @@ pipeline:
   Match      *
   Host       192.168.2.3
   Port       80
-  URI        /api/endpoint
+  Uri        /api/endpoint
   Http_Method PUT
   Format     json
 ```


### PR DESCRIPTION
  - Add 16 missing oauth2.* parameters sourced from plugin config_map
  - Fix json_date_format default: "double" -> _none_
  - Fix uri default: "/" -> _none_
  - Fix config param table column alignment
  - Remove redundant intro sentence
  - Fix trailing space in aws_service description
  - Fix classic config example case issues
  - Use "OAuth 2.0" per style guide in all oauth2 parameter descriptions
  - Spell out JWT (JSON Web Token) on first use per style guide

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP output configuration documentation with improved table formatting and enhanced example clarity.
  * Expanded documentation to include OAuth 2.0 authentication configuration options and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->