### PR TITLE
docs: outputs: kafka-rest-proxy: gemeral doc update and cleanup

### DIFF
--- a/pipeline/outputs/kafka-rest-proxy.md
+++ b/pipeline/outputs/kafka-rest-proxy.md
@@ -6,18 +6,20 @@ The _Kafka rest_ (`kafka-rest`) output plugin lets you flush your records into a
 
 This plugin supports the following parameters:
 
-| Key | Description | default |
+| Key | Description | Default |
 | :--- | :--- | :--- |
-| `Host` | IP address or hostname of the target Kafka REST Proxy server. | `127.0.0.1` |
-| `Port` | TCP port of the target Kafka REST Proxy server. | `8082` |
-| `Topic` | Set the Kafka topic. | `fluent-bit` |
-| `Partition` | Optional. Set the partition number. | _none_ |
-| `Message_Key` | Optional. Set a message key. | _none_ |
-| `Time_Key` | The `Time_Key` property defines the name of the field that holds the record timestamp. | `@timestamp` |
-| `Time_Key_Format` | Defines the format of the timestamp. | `%Y-%m-%dT%H:%M:%S` |
-| `Include_Tag_Key` | Append the Tag name to the final record. | `Off` |
-| `Tag_Key` | If `Include_Tag_Key` is enabled, this property defines the key name for the tag. | `_flb-key` |
-| `Workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
+| `avro_http_header` | Include Avro header in the HTTP request. | `false` |
+| `host` | IP address or hostname of the target Kafka REST Proxy server. | `127.0.0.1` |
+| `include_tag_key` | Append the tag name to the final record. | `false` |
+| `message_key` | Optional message key to set. | _none_ |
+| `partition` | Optional partition number. | `-1` |
+| `port` | TCP port of the target Kafka REST Proxy server. | `8082` |
+| `tag_key` | If `include_tag_key` is enabled, defines the key name for the tag. | `_flb-key` |
+| `time_key` | Name of the field that holds the record timestamp. | `@timestamp` |
+| `time_key_format` | Format of the timestamp. | `%Y-%m-%dT%H:%M:%S` |
+| `topic` | Set the Kafka topic. | `fluent-bit` |
+| `url_path` | Optional HTTP URL path for the target web server. For example, `/something`. | _none_ |
+| `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 
 ### TLS / SSL
 


### PR DESCRIPTION
  - Sort configuration parameters table alphabetically
  - Lowercase all Key column entries
  - Fix `default` column header capitalization
  - Fix `partition` default: `_none_` → `-1`
  - Fix `include_tag_key` default: `Off` → `false`
  - Add missing params: `url_path`, `avro_http_header`
  - Fix `time_key` description: remove `Time_Key` Title_Case reference

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Standardized Kafka REST Proxy configuration parameter documentation with consistent naming conventions
  - Added new configuration options including avro HTTP header support
  - Updated default values across parameters
  - Configuration parameter format has been updated for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->