### PR TITLE
docs: outputs: chronicle: fix classic config key casing to Title_Case

### DIFF
--- a/pipeline/outputs/chronicle.md
+++ b/pipeline/outputs/chronicle.md
@@ -65,8 +65,8 @@ pipeline:
 [OUTPUT]
   Name         chronicle
   Match        *
-  Customer_id  my_customer_id
-  Log_type     my_super_awesome_type
+  Customer_Id  my_customer_id
+  Log_Type     my_super_awesome_type
 ```
 
 {% endtab %}


### PR DESCRIPTION
Trivial fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Chronicle output configuration key names to standardized casing (Customer_Id and Log_Type) in YAML and configuration file examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->