### PR TITLE
docs: outputs: nats: add yaml/classic config examples, fix formatting

### DIFF
--- a/pipeline/outputs/nats.md
+++ b/pipeline/outputs/nats.md
@@ -4,8 +4,10 @@ The _NATS_ output plugin lets you flush your records into a [NATS Server](https:
 
 ## Configuration parameters
 
+This plugin supports the following parameters:
+
 | Key | Description | Default |
-| --- | ----------- | ------- |
+| :--- | :--- | :--- |
 | `host` | The IP address or hostname of the NATS server. | `127.0.0.1` |
 | `port` | The TCP port of the target NATS server. | `4222` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
@@ -18,25 +20,51 @@ To override the default configuration values, this plugin uses the optional Flue
 
 ## Get started
 
-You can get started with the NATS output plugin through the command line. If you use the following command without specifying parameter values, Fluent Bit uses the default values defined in the previous section.
+To flush records to a NATS server, you can run the plugin from the command line or through the configuration file.
+
+### Command line
+
+If you use the following command without specifying parameter values, Fluent Bit uses the default values defined in the previous section.
 
 ```shell
-$ fluent-bit -i cpu -o nats -V -f 5
-
-...
-[2016/03/04 10:17:33] [ info] Configuration
-flush time     : 5 seconds
-input plugins  : cpu
-collectors     :
-[2016/03/04 10:17:33] [ info] starting engine
-cpu[all] all=3.250000 user=2.500000 system=0.750000
-cpu[i=0] all=3.000000 user=1.000000 system=2.000000
-cpu[i=1] all=3.000000 user=2.000000 system=1.000000
-cpu[i=2] all=2.000000 user=2.000000 system=0.000000
-cpu[i=3] all=6.000000 user=5.000000 system=1.000000
-[2016/03/04 10:17:33] [debug] [in_cpu] CPU 3.25%
-...
+fluent-bit -i cpu -o nats -f 5
 ```
+
+### Configuration file
+
+In your main configuration file, append the following:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: cpu
+
+  outputs:
+    - name: nats
+      match: '*'
+      host: 127.0.0.1
+      port: 4222
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+  Name  cpu
+
+[OUTPUT]
+  Name   nats
+  Match  *
+  Host   127.0.0.1
+  Port   4222
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## Data format
 


### PR DESCRIPTION
  - Add "This plugin supports the following parameters:" intro before table
  - Fix table column alignment to use :--- (left-aligned)
  - Add ### Command line and ### Configuration file subsections
  - Add YAML and classic .conf config tabs with Title_Case keys
  - Remove outdated $ prefix and verbose CPU debug output from shell example

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded NATS output plugin documentation with improved configuration parameters section and detailed setup instructions.
  * Added streamlined examples and complete YAML/INI configuration blocks for easier plugin setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->