### PR TITLE
docs: outputs: null: add missing configuration parameters

### DIFF
--- a/pipeline/outputs/null.md
+++ b/pipeline/outputs/null.md
@@ -4,7 +4,14 @@ The _Null_ output plugin discards events.
 
 ## Configuration parameters
 
-This plugin doesn't have any configuration parameters.
+This plugin supports the following parameters:
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `format` | Specify the data format. Supported formats: `msgpack`, `json`, `json_lines`, `json_stream`. | `msgpack` |
+| `json_date_format` | Specify the format of the date. Supported formats: `double`, `epoch`, `epoch_ms`, `iso8601` (for example, `2018-05-30T09:39:52.000681Z`), and `java_sql_timestamp` (for example, `2018-05-30 09:39:52.000681`). | `double` |
+| `json_date_key` | Specify the name of the time key in the output record. To disable the time key, set the value to `false`. | `date` |
+| `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `1` |
 
 ## Get started
 


### PR DESCRIPTION
  - Replace incorrect "no configuration parameters" claim with a full table
  - Add format, json_date_format, json_date_key parameters
  - Add workers with correct default of 1

  Applies to #2412