### PR TITLE
docs: outputs: parseable: general doc updates and cleanup

### DIFF
--- a/pipeline/outputs/parseable.md
+++ b/pipeline/outputs/parseable.md
@@ -10,17 +10,17 @@ Stream logs, metrics, and traces to [Parseable](https://www.parseable.com) by ut
 
 | Key                        | Description | Default |
 | -------------------------- | ----------- | ------- |
-| `host`                     | Your Parseable Ingestor hostname or IP address. | `parseable` |
-| `port`                     | TCP port of your Parseable Ingestor. | `8000` |
-| `http_user`                | Username for HTTP basic authentication. | `admin` |
-| `http_passwd`              | Password for HTTP basic authentication. | `admin` |
-| `header`                   | Required headers for Parseable integration. Must include `X-P-Stream` (stream name) and `X-P-Log-Source` (telemetry type: `otel-logs`, `otel-metrics`, or `otel-traces`). | _none_ |
 | `add_label`                | Add custom labels to the telemetry data. | _none_ |
-| `log_response_payload`     | Log the response payload from the server for debugging. | `False` |
-| `metrics_uri`              | Specify the HTTP URI for the target web server listening for metrics. | `/v1/metrics` |
+| `header`                   | Required headers for Parseable integration. Must include `X-P-Stream` (stream name) and `X-P-Log-Source` (telemetry type: `otel-logs`, `otel-metrics`, or `otel-traces`). | _none_ |
+| `host`                     | Your Parseable Ingestor hostname or IP address. | `parseable` |
+| `http_passwd`              | Password for HTTP basic authentication. | `admin` |
+| `http_user`                | Username for HTTP basic authentication. | `admin` |
+| `log_response_payload`     | Log the response payload from the server for debugging. | `false` |
 | `logs_uri`                 | Specify the HTTP URI for the target web server listening for logs. | `/v1/logs` |
+| `metrics_uri`              | Specify the HTTP URI for the target web server listening for metrics. | `/v1/metrics` |
+| `port`                     | TCP port of your Parseable Ingestor. | `8000` |
+| `tls`                      | Enable or disable TLS/SSL encryption. | `off` |
 | `traces_uri`               | Specify the HTTP URI for the target web server listening for traces. | `/v1/traces` |
-| `tls`                      | Enable or disable TLS/SSL encryption. | `Off` |
 
 ### TLS / SSL
 
@@ -93,14 +93,14 @@ pipeline:
     Match         v1_logs
     Host          parseable
     Port          8000
-    Logs_uri      /v1/logs
-    Log_response_payload True
+    Logs_Uri      /v1/logs
+    Log_Response_Payload True
     Tls           Off
     Http_User     admin
     Http_Passwd   admin
     Header        X-P-Stream otellogs
     Header        X-P-Log-Source otel-logs
-    Add_label     app fluent-bit
+    Add_Label     app fluent-bit
 
 # Send metrics to Parseable
 [OUTPUT]
@@ -108,14 +108,14 @@ pipeline:
     Match         v1_metrics
     Host          parseable
     Port          8000
-    Metrics_uri   /v1/metrics
-    Log_response_payload True
+    Metrics_Uri   /v1/metrics
+    Log_Response_Payload True
     Tls           Off
     Http_User     admin
     Http_Passwd   admin
     Header        X-P-Stream otelmetrics
     Header        X-P-Log-Source otel-metrics
-    Add_label     app fluent-bit
+    Add_Label     app fluent-bit
 
 # Send traces to Parseable
 [OUTPUT]
@@ -123,14 +123,14 @@ pipeline:
     Match         v1_traces
     Host          parseable
     Port          8000
-    Traces_uri    /v1/traces
-    Log_response_payload True
+    Traces_Uri    /v1/traces
+    Log_Response_Payload True
     Tls           Off
     Http_User     admin
     Http_Passwd   admin
     Header        X-P-Stream oteltraces
     Header        X-P-Log-Source otel-traces
-    Add_label     app fluent-bit
+    Add_Label     app fluent-bit
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Sort configuration parameters table alphabetically
  - Normalize boolean defaults to lowercase
  - Fix classic .conf keys to Title_Case

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized all configuration keys to CamelCase naming convention for consistency.
  * Added two new configuration options: `add_label` and `header`.
  * Updated all documentation examples and references to reflect the new standardized key names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->