### PR TITLE
docs: outputs: plot: general doc update and cleanup

### DIFF
--- a/pipeline/outputs/plot.md
+++ b/pipeline/outputs/plot.md
@@ -12,8 +12,9 @@ This plugin supports the following parameters:
 
 | Key | Description | Default |
 |:--- |:----------- |:------- |
-| `File` | Set filename to store the records. If not set, the filename will be the `tag` associated with the records. If the file can't be opened, the plugin falls back to writing to STDOUT. | _none_ |
-| `Key` | Specify the key name from the record to extract as the value. The value must be a numeric type (integer or float). If not specified, the plugin uses the first field from the record. | _none_ |
+| `file` | Set filename to store the records. If not set, the filename will be the `tag` associated with the records. If the file can't be opened, the plugin falls back to writing to STDOUT. | _none_ |
+| `key` | Specify the key name from the record to extract as the value. The value must be a numeric type (integer or float). If not specified, the plugin uses the first field from the record. | _none_ |
+| `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 
 ## Output format
 


### PR DESCRIPTION
  - Lowercase table keys: File → file, Key → key
  - Add missing workers parameter with default 0

  Applies to #2412