### PR TITLE
docs: outputs: prometheus-remote-write: general doc updates and cleanup

### DIFF
--- a/pipeline/outputs/prometheus-remote-write.md
+++ b/pipeline/outputs/prometheus-remote-write.md
@@ -14,23 +14,24 @@ This plugin supports the following parameters:
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `add_label` | This lets you add custom labels to all metrics sent by the `prometheus_remote_write` output. You can have multiple of these fields. | _none_ |
+| `aws_auth` | Enable AWS SigV4 authentication. | `false` |
+| `aws_external_id` | External ID for the AWS IAM Role specified with `aws_role_arn`, used by SigV4 authentication. | _none_ |
+| `aws_profile` | AWS profile name. AWS profiles can be configured with AWS CLI and are usually stored in `$HOME/.aws/`. | _none_ |
+| `aws_region` | Region of your Amazon Managed Service for Prometheus workspace. | _none_ |
+| `aws_role_arn` | AWS IAM Role to assume, used by SigV4 authentication. | _none_ |
+| `aws_service` | AWS destination service code, used by SigV4 authentication. For Amazon Managed Service for Prometheus, the service name is `aps`. | `aps` |
+| `aws_sts_endpoint` | Specify the custom STS endpoint to be used with STS API, used with the `aws_role_arn` option, used by SigV4 authentication. | _none_ |
+| `compression` | Payload compression algorithm. Supported options: `snappy`, `gzip`, `zstd`. | `snappy` |
+| `header` | Add a HTTP header key/value pair. Multiple headers can be set. | _none_ |
 | `host` | IP address or hostname of the target HTTP server. | `127.0.0.1` |
+| `http_passwd` | Basic Auth password. Requires `http_user` to be set. | _none_ |
 | `http_user` | Basic Auth username. | _none_ |
-| `http_passwd` | Basic Auth Password. Requires `HTTP_user` to be set. | _none_ |
-| `AWS_Auth` | Enable AWS SigV4 authentication. | `false` |
-| `AWS_Service` | For Amazon Managed Service for Prometheus, the service name is `aps`. | `aps` |
-| `AWS_Region` | Region of your Amazon Managed Service for Prometheus workspace. | _none_ |
-| `AWS_STS_Endpoint` | Specify the custom STS endpoint to be used with STS API, used with the `AWS_Role_ARN` option, used by SigV4 authentication. | _none_ |
-| `AWS_Role_ARN` | AWS IAM Role to assume, used by SigV4 authentication. | _none_ |
-| `AWS_External_ID` | External ID for the AWS IAM Role specified with `aws_role_arn`, used by SigV4 authentication. | _none_ |
+| `log_response_payload` | Log the response payload within the Fluent Bit log. | `true` |
 | `port` | TCP port of the target HTTP server. | `80` |
 | `proxy` | Specify an HTTP proxy. The expected format of this value is `http://HOST:PORT`. HTTPS isn't supported. Configure the [HTTP proxy environment variables](https://docs.fluentbit.io/manual/administration/http-proxy) instead as they support both HTTP and HTTPS. | _none_ |
-| `uri` | Specify an optional HTTP URI for the target web server. For example: `/someuri` | `/` |
-| `header` | Add a HTTP header key/value pair. Multiple headers can be set. | _none_ |
-| `log_response_payload` | Log the response payload within the Fluent Bit log. | `false` |
-| `add_label` | This lets you add custom labels to all metrics exposed through the Prometheus exporter. You can have multiple of these fields. | _none_ |
+| `uri` | Specify an optional HTTP URI for the target web server, for example `/someuri`. | _none_ |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `2` |
-| `compression` | Payload compression algorithm. Supported options: `snappy`, `gzip`, `zstd`. | `snappy` |
 
 ## Get started
 
@@ -84,12 +85,12 @@ pipeline:
 #
 [SERVICE]
   Flush                1
-  Log_level            info
+  Log_Level            info
 
 [INPUT]
   Name                 node_exporter_metrics
   Tag                  node_metrics
-  Scrape_interval      2
+  Scrape_Interval      2
 
 [OUTPUT]
   Name                 prometheus_remote_write
@@ -98,12 +99,12 @@ pipeline:
   Port                 443
   Uri                  /prometheus/v1/write?prometheus_server=YOUR_DATA_SOURCE_NAME
   Header               Authorization Bearer YOUR_LICENSE_KEY
-  Log_response_payload True
+  Log_Response_Payload True
   Tls                  On
   Tls.verify           On
   # add user-defined labels
-  add_label            app fluent-bit
-  add_label            color blue
+  Add_Label            app fluent-bit
+  Add_Label            color blue
 
 # Note : it would be necessary to replace both YOUR_DATA_SOURCE_NAME and YOUR_LICENSE_KEY
 # with real values for this example to work.
@@ -143,15 +144,15 @@ pipeline:
 
 ```text
 [OUTPUT]
-  name        prometheus_remote_write
-  match       *
-  host        prometheus-us-central1.grafana.net
-  uri         /api/prom/push
-  port        443
-  tls         on
-  tls.verify  on
-  http_user   <GRAFANA Username>
-  http_passwd <GRAFANA Password>
+  Name        prometheus_remote_write
+  Match       *
+  Host        prometheus-us-central1.grafana.net
+  Uri         /api/prom/push
+  Port        443
+  Tls         on
+  Tls.verify  on
+  Http_User   <GRAFANA Username>
+  Http_Passwd <GRAFANA Password>
 ```
 
 {% endtab %}
@@ -182,14 +183,14 @@ pipeline:
 
 ```text
 [OUTPUT]
-  name                  prometheus_remote_write
-  match                 *
-  host                  listener.logz.io
-  port                  8053
-  header                Authorization Bearer <LOGZIO Key>
-  tls                   on
-  tls.verify            on
-  log_response_payload true
+  Name                  prometheus_remote_write
+  Match                 *
+  Host                  listener.logz.io
+  Port                  8053
+  Header                Authorization Bearer <LOGZIO Key>
+  Tls                   on
+  Tls.verify            on
+  Log_Response_Payload  true
 ```
 
 {% endtab %}
@@ -209,7 +210,7 @@ pipeline:
     - name: prometheus_remote_write
       match: '*'
       host: metrics-api.coralogix.com
-      uri: prometheus/api/v1/write?appLabelName=path&subSystemLabelName=path&severityLabelName=severity
+      uri: /prometheus/api/v1/write?appLabelName=path&subSystemLabelName=path&severityLabelName=severity
       port: 443
       header: 'Authorization Bearer <CORALOGIX Key>'
       tls: on
@@ -221,14 +222,14 @@ pipeline:
 
 ```text
 [OUTPUT]
-  name                  prometheus_remote_write
-  match                 *
-  host                  metrics-api.coralogix.com
-  uri                   prometheus/api/v1/write?appLabelName=path&subSystemLabelName=path&severityLabelName=severity
-  port                  443
-  header                Authorization Bearer <CORALOGIX Key>
-  tls                   on
-  tls.verify            on
+  Name                  prometheus_remote_write
+  Match                 *
+  Host                  metrics-api.coralogix.com
+  Uri                   /prometheus/api/v1/write?appLabelName=path&subSystemLabelName=path&severityLabelName=severity
+  Port                  443
+  Header                Authorization Bearer <CORALOGIX Key>
+  Tls                   on
+  Tls.verify            on
 ```
 
 {% endtab %}
@@ -261,15 +262,15 @@ pipeline:
 
 ```text
 [OUTPUT]
-  name        prometheus_remote_write
-  match       *
-  host        app-tsdb.last9.io
-  uri         /v1/metrics/82xxxx/sender/org-slug/write
-  port        443
-  tls         on
-  tls.verify  on
-  http_user   <Levitate Cluster Username>
-  http_passwd <Levitate Cluster Password>
+  Name        prometheus_remote_write
+  Match       *
+  Host        app-tsdb.last9.io
+  Uri         /v1/metrics/82xxxx/sender/org-slug/write
+  Port        443
+  Tls         on
+  Tls.verify  on
+  Http_User   <Levitate Cluster Username>
+  Http_Passwd <Levitate Cluster Password>
 ```
 
 {% endtab %}
@@ -312,12 +313,12 @@ pipeline:
   Port                 443
   Uri                  /api/v1/write
   Header               Authorization Bearer YOUR_LICENSE_KEY
-  Log_response_payload True
+  Log_Response_Payload True
   Tls                  On
   Tls.verify           On
   # add user-defined labels
-  add_label instance ${HOSTNAME}
-  add_label job fluent-bit
+  Add_Label instance ${HOSTNAME}
+  Add_Label job fluent-bit
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Sort config parameter table alphabetically
  - Lowercase AWS table keys
  - Add missing aws_profile param
  - Fix uri default: / → _none_
  - Fix log_response_payload default: false → true
  - Fix http_passwd description: HTTP_user → http_user
  - Fix classic config keys to Title_Case across all 5 examples

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded Prometheus remote write output configuration documentation with new parameters for compression, proxy configuration, worker management, and enhanced AWS authentication capabilities
  * Updated all configuration examples and code blocks to use current parameter naming conventions and standardized formatting, improving consistency and clarity across documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->