### PR TITLE
docs: outputs: slack: fix classic config key casing

### DIFF
--- a/pipeline/outputs/slack.md
+++ b/pipeline/outputs/slack.md
@@ -40,9 +40,9 @@ pipeline:
 
 ```text
 [OUTPUT]
-    name                 slack
-    match                *
-    webhook              https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+    Name                 slack
+    Match                *
+    Webhook              https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 {% endtab %}


### PR DESCRIPTION
Small fix of case in examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Slack output connector configuration example to reflect current formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->