### PR TITLE
docs: outputs: syslog: general doc updates and cleanup

### DIFF
--- a/pipeline/outputs/syslog.md
+++ b/pipeline/outputs/syslog.md
@@ -6,26 +6,26 @@ The _Syslog_ output plugin lets you deliver messages to Syslog servers. It suppo
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
+| `allow_longer_sd_id` | If `true`, Fluent Bit allows SD-ID values longer than 32 characters. SD-ID values that exceed 32 characters violate RFC5424 standards. | `false` |
 | `host` | Domain or IP address of the remote Syslog server. | `127.0.0.1` |
-| `port` | TCP or UDP port of the remote Syslog server. | `514` |
 | `mode` | Desired transport type. Available options are `tcp` and `udp`. | `udp` |
-| `syslog_format` | The Syslog protocol format to use. Available options are `rfc3164` and `rfc5424`. | `rfc5424` |
-| `syslog_maxsize` | The maximum size allowed per message. The value must be an integer representing the number of bytes allowed. If no value is provided, the default size is set depending of the protocol version specified by `syslog_format`. The value `rfc3164` sets max size to 1024 bytes, and `rfc5424` sets the size to 2048 bytes. | _none_ |
-| `syslog_severity_key` | Optional. The key name from the original record that contains the Syslog severity number. | _none_ |
-| `syslog_severity_preset` | Optional. The preset severity number. It will be overwritten if `syslog_severity_key` is set and a key of a record is matched. | `6` |
-| `syslog_facility_key` | Optional. The key name from the original record that contains the Syslog facility number. | _none_ |
-| `syslog_facility_preset` | Optional. The preset facility number. It will be overwritten if `syslog_facility_key` is set and a key of a record is matched. | `1` |
-| `syslog_hostname_key` | Optional. The key name from the original record that contains the hostname that generated the message. | _none_ |
-| `syslog_hostname_preset` | Optional. The preset hostname. It will be overwritten if `syslog_hostname_key` is set and a key of a record is matched. | _none_ |
+| `port` | TCP or UDP port of the remote Syslog server. | `514` |
 | `syslog_appname_key` | Optional. The key name from the original record that contains the application name that generated the message. | _none_ |
 | `syslog_appname_preset` | Optional. The preset application name. It will be overwritten if `syslog_appname_key` is set and a key of a record is matched. | _none_ |
-| `syslog_procid_key` | Optional. The key name from the original record that contains the Process ID that generated the message. | _none_ |
-| `syslog_procid_preset` | Optional. The preset process ID. It will be overwritten if `syslog_procid_key` is set and a key of a record is matched. | _none_ |
+| `syslog_facility_key` | Optional. The key name from the original record that contains the Syslog facility number. | _none_ |
+| `syslog_facility_preset` | Optional. The preset facility number. It will be overwritten if `syslog_facility_key` is set and a key of a record is matched. | `1` |
+| `syslog_format` | The Syslog protocol format to use. Available options are `rfc3164` and `rfc5424`. | `rfc5424` |
+| `syslog_hostname_key` | Optional. The key name from the original record that contains the hostname that generated the message. | _none_ |
+| `syslog_hostname_preset` | Optional. The preset hostname. It will be overwritten if `syslog_hostname_key` is set and a key of a record is matched. | _none_ |
+| `syslog_maxsize` | The maximum size allowed per message. The value must be an integer representing the number of bytes allowed. If no value is provided, the default size is set depending on the protocol version specified by `syslog_format`. The value `rfc3164` sets max size to 1024 bytes, and `rfc5424` sets the size to 2048 bytes. | `0` |
+| `syslog_message_key` | Required. The key name from the original record that contains the message to deliver. | _none_ |
 | `syslog_msgid_key` | Optional. The key name from the original record that contains the Message ID associated to the message. | _none_ |
 | `syslog_msgid_preset` | Optional. The preset message ID. It will be overwritten if `syslog_msgid_key` is set and a key of a record is matched. | _none_ |
+| `syslog_procid_key` | Optional. The key name from the original record that contains the Process ID that generated the message. | _none_ |
+| `syslog_procid_preset` | Optional. The preset process ID. It will be overwritten if `syslog_procid_key` is set and a key of a record is matched. | _none_ |
 | `syslog_sd_key` | Optional. The key name from the original record that contains a map of key/value pairs to use as Structured Data \(SD\) content. The key name is included in the resulting SD field as shown in the examples in this doc. | _none_ |
-| `syslog_message_key` | Required. The key name from the original record that contains the message to deliver. | _none_ |
-| `allow_longer_sd_id` | If `true`, Fluent Bit allows SD-ID values longer than 32 characters. SD-ID values that exceed 32 characters violate RFC5424 standards. | `false` |
+| `syslog_severity_key` | Optional. The key name from the original record that contains the Syslog severity number. | _none_ |
+| `syslog_severity_preset` | Optional. The preset severity number. It will be overwritten if `syslog_severity_key` is set and a key of a record is matched. | `6` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 
 ### TLS / SSL
@@ -67,21 +67,21 @@ pipeline:
 
 ```text
 [OUTPUT]
-  name                 syslog
-  match                *
-  host                 syslog.yourserver.com
-  port                 514
-  mode                 udp
-  syslog_format        rfc5424
-  syslog_maxsize       2048
-  syslog_severity_key  severity
-  syslog_facility_key  facility
-  syslog_hostname_key  hostname
-  syslog_appname_key   appname
-  syslog_procid_key    procid
-  syslog_msgid_key     msgid
-  syslog_sd_key        sd
-  syslog_message_key   message
+  Name                 syslog
+  Match                *
+  Host                 syslog.yourserver.com
+  Port                 514
+  Mode                 udp
+  Syslog_Format        rfc5424
+  Syslog_Maxsize       2048
+  Syslog_Severity_Key  severity
+  Syslog_Facility_Key  facility
+  Syslog_Hostname_Key  hostname
+  Syslog_Appname_Key   appname
+  Syslog_Procid_Key    procid
+  Syslog_Msgid_Key     msgid
+  Syslog_Sd_Key        sd
+  Syslog_Message_Key   message
 ```
 
 {% endtab %}
@@ -137,19 +137,19 @@ pipeline:
 
 ```text
 [OUTPUT]
-  name                 syslog
-  match                *
-  host                 syslog.yourserver.com
-  port                 514
-  mode                 udp
-  syslog_format        rfc5424
-  syslog_maxsize       2048
-  syslog_hostname_key  hostname
-  syslog_appname_key   appname
-  syslog_procid_key    procid
-  syslog_msgid_key     msgid
-  syslog_sd_key        uls@0
-  syslog_message_key   log
+  Name                 syslog
+  Match                *
+  Host                 syslog.yourserver.com
+  Port                 514
+  Mode                 udp
+  Syslog_Format        rfc5424
+  Syslog_Maxsize       2048
+  Syslog_Hostname_Key  hostname
+  Syslog_Appname_Key   appname
+  Syslog_Procid_Key    procid
+  Syslog_Msgid_Key     msgid
+  Syslog_Sd_Key        uls@0
+  Syslog_Message_Key   log
 ```
 
 {% endtab %}
@@ -206,25 +206,25 @@ pipeline:
 
 ```text
 [FILTER]
-  name  lua
-  match *
-  call  append_token
-  code  function append_token(tag, timestamp, record) record["${AUTH_TOKEN}"] = {} return 2, timestamp, record end
+  Name  lua
+  Match *
+  Call  append_token
+  Code  function append_token(tag, timestamp, record) record["${AUTH_TOKEN}"] = {} return 2, timestamp, record end
 
 [OUTPUT]
-  name                    syslog
-  match                   *
-  host                    syslog.yourserver.com
-  port                    514
-  mode                    tcp
-  syslog_format           rfc5424
-  syslog_hostname_preset  my-hostname
-  syslog_appname_preset   my-appname
-  syslog_message_key      log
-  allow_longer_sd_id      true
-  syslog_sd_key           ${AUTH_TOKEN}
-  tls                     on
-  tls.crt_file            /path/to/my.crt
+  Name                    syslog
+  Match                   *
+  Host                    syslog.yourserver.com
+  Port                    514
+  Mode                    tcp
+  Syslog_Format           rfc5424
+  Syslog_Hostname_Preset  my-hostname
+  Syslog_Appname_Preset   my-appname
+  Syslog_Message_Key      log
+  Allow_Longer_Sd_Id      true
+  Syslog_Sd_Key           ${AUTH_TOKEN}
+  Tls                     on
+  Tls.crt_file            /path/to/my.crt
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Sort config param table alphabetically
  - Fix syslog_maxsize default: _none_ → 0
  - Fix syslog_maxsize description: "depending of" → "depending on"
  - Fix classic config keys to Title_Case across all three examples

  Applies to #2412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Extended Syslog output configuration with new parameters: `syslog_appname_key`, `syslog_appname_preset`, `syslog_message_key` (required), `syslog_procid_key`, and `syslog_procid_preset`.
* Updated configuration documentation and examples with improved formatting and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->