### PR TITLE
docs: processors: content-modifier: add otel_log_attributes context

### DIFF
--- a/pipeline/processors/content-modifier.md
+++ b/pipeline/processors/content-modifier.md
@@ -30,16 +30,17 @@ The following contexts are available:
 
 ### OpenTelemetry contexts
 
-Additionally, Fluent Bit provides specific contexts for modifying data that follows the OpenTelemetry log schema. All of these contexts operate on shared data across a group of records.
+Additionally, Fluent Bit provides specific contexts for modifying data that follows the OpenTelemetry log schema.
 
 The following contexts are available:
 
 | Name | Telemetry type | Description |
 | ---- | -------------- | ----------- |
-| `otel_resource_attributes` | Logs | Modifies the attributes of the log resource. |
-| `otel_scope_name` | Logs | Modifies the name of a log scope. |
-| `otel_scope_version` | Logs | Modifies version of a log scope. |
-| `otel_scope_attributes` | Logs | Modifies the attributes of a log scope. |
+| `otel_resource_attributes` | Logs | Modifies the attributes of the log resource. Operates on shared data across a group of records. |
+| `otel_scope_name` | Logs | Modifies the name of a log scope. Operates on shared data across a group of records. |
+| `otel_scope_version` | Logs | Modifies the version of a log scope. Operates on shared data across a group of records. |
+| `otel_scope_attributes` | Logs | Modifies the attributes of a log scope. Operates on shared data across a group of records. |
+| `otel_log_attributes` | Logs | Modifies the attributes of an individual OpenTelemetry log record. Operates per record. |
 
 
 {% hint style="info" %}


### PR DESCRIPTION
  Add the missing otel_log_attributes context to the OpenTelemetry
  contexts table. Unlike the resource and scope contexts, this one
  operates per log record rather than on shared group data. Update
  the section intro text to reflect that distinction accurately.

  Fixes #2482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated content modifier processor documentation to clarify scope semantics for OpenTelemetry log-related contexts. Refined per-context descriptions to specify whether operations apply to individual records or shared data across record groups, including newly documented `otel_log_attributes` context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->