### PR TITLE
docs: inputs: http: add OAuth 2.0 JWT validation and remote_addr_key parameters

### DIFF
--- a/pipeline/inputs/http.md
+++ b/pipeline/inputs/http.md
@@ -13,7 +13,14 @@ The _HTTP_ input plugin lets Fluent Bit open an HTTP port that you can then rout
 | `http2`                    | Enable HTTP/2 support. Compatibility alias for `http_server.http2`.                                                                                 | `true`    |
 | `http_server.workers`      | Number of HTTP listener worker threads.                                                                                                             | `1`       |
 | `listen`                   | The address to listen on.                                                                                                                           | `0.0.0.0` |
+| `oauth2.allowed_audience`  | Audience claim to enforce when validating incoming `OAuth 2.0` `JWT` tokens.                                                                        | _none_    |
+| `oauth2.allowed_clients`   | Authorized `client_id` or `azp` claim values. Can be specified multiple times.                                                                      | _none_    |
+| `oauth2.issuer`            | Expected issuer (`iss`) claim. Required when `oauth2.validate` is `true`.                                                                           | _none_    |
+| `oauth2.jwks_refresh_interval` | How often in seconds to refresh the cached `JWKS` keys from `oauth2.jwks_url`.                                                                 | `300`     |
+| `oauth2.jwks_url`          | `JWKS` endpoint URL used to fetch public keys for `JWT` validation. Required when `oauth2.validate` is `true`.                                      | _none_    |
+| `oauth2.validate`          | Enable `OAuth 2.0` `JWT` validation for incoming requests.                                                                                          | `false`   |
 | `port`                     | The port for Fluent Bit to listen on.                                                                                                               | `9880`    |
+| `remote_addr_key`          | Key name for the remote address field added to the record when `add_remote_addr` is enabled.                                                        | `REMOTE_ADDR` |
 | `success_header`           | Add an HTTP header key/value pair on success. Multiple headers can be set. For example, `X-Custom custom-answer`.                                   | _none_    |
 | `successful_response_code` | Allows setting successful response code. Supported values: `200`, `201`, and `204`.                                                                 | `201`     |
 | `tag_key`                  | Specify the key name to overwrite a tag. If set, the tag will be overwritten by a value of the key.                                                 | _none_    |
@@ -26,6 +33,12 @@ HTTP input plugin supports TLS/SSL. For more details about the properties availa
 ### gzipped content
 
 The HTTP input plugin will accept and automatically handle gzipped content in version 2.2.1 or later if the header `Content-Encoding: gzip` is set on the received data.
+
+### `OAuth 2.0 JWT` validation
+
+When `oauth2.validate` is set to `true`, the HTTP input plugin validates the `Authorization: Bearer <token>` header on every incoming request. Requests with a missing, expired, or invalid token are rejected with a `401` response.
+
+`oauth2.issuer` and `oauth2.jwks_url` are both required when validation is enabled. `JWKS` keys are fetched lazily: the first request that requires validation triggers the initial retrieval from `oauth2.jwks_url`. Keys are then cached and refreshed every `oauth2.jwks_refresh_interval` seconds.
 
 ## Get started
 
@@ -230,7 +243,7 @@ pipeline:
 curl -d '{"key1":"value1"}' -XPOST -H 'Content-Type: application/json' -H 'X-Forwarded-For: host1, host2' http://localhost:8888
 ```
 
-#### Set multiple custom HTTP headers on success
+#### Set multiple custom `HTTP` headers on success
 
 The `success_header` parameter lets you set multiple HTTP headers on success. The format is:
 
@@ -290,6 +303,52 @@ pipeline:
   Name   http
   Listen 0.0.0.0
   Port   8888
+
+[OUTPUT]
+  Name  stdout
+  Match *
+```
+
+{% endtab %}
+{% endtabs %}
+
+### Enable `OAuth 2.0 JWT` validation
+
+The following example enables `JWT` validation using a `JWKS` endpoint. All incoming requests must include a valid bearer token issued by the specified issuer.
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: http
+      listen: 0.0.0.0
+      port: 8888
+      oauth2.validate: true
+      oauth2.issuer: https://auth.example.com
+      oauth2.jwks_url: https://auth.example.com/.well-known/jwks.json
+      oauth2.allowed_audience: my-service
+      oauth2.jwks_refresh_interval: 300
+
+  outputs:
+    - name: stdout
+      match: '*'
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+  Name                      http
+  Listen                    0.0.0.0
+  Port                      8888
+  Oauth2.validate           true
+  Oauth2.issuer             https://auth.example.com
+  Oauth2.jwks_url           https://auth.example.com/.well-known/jwks.json
+  Oauth2.allowed_audience   my-service
+  Oauth2.jwks_refresh_interval 300
 
 [OUTPUT]
   Name  stdout


### PR DESCRIPTION
  - Add oauth2.validate, oauth2.issuer, oauth2.jwks_url, oauth2.allowed_audience, oauth2.allowed_clients, and oauth2.jwks_refresh_interval config parameters to the table
  - Add remote_addr_key config parameter to the table
  - Add "OAuth 2.0 JWT validation" section explaining the feature and required parameters
  - Add configuration examples for OAuth 2.0 JWT validation in YAML and classic .conf format
  - Fix parameter table sort order

  Fixes #2500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented OAuth 2.0 JWT validation support for HTTP inputs with new configuration parameters
  * Added configuration examples for enabling JWT validation
  * Documented `remote_addr_key` parameter for controlling record field names
  * Updated HTTP headers documentation formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->