### PR TITLE
docs: inputs: opentelemetry: update metrics HTTP1/JSON support status and classic config examples

### DIFF
--- a/pipeline/inputs/opentelemetry.md
+++ b/pipeline/inputs/opentelemetry.md
@@ -98,7 +98,7 @@ The OpenTelemetry input plugin supports the following telemetry data types:
 | Type    | HTTP1/JSON    | HTTP1/Protobuf | HTTP2/gRPC |
 |---------|---------------|----------------|------------|
 | Logs    | Stable        | Stable         | Stable     |
-| Metrics | Unimplemented | Stable         | Stable     |
+| Metrics | Stable        | Stable         | Stable     |
 | Traces  | Stable        | Stable         | Stable     |
 
 A sample configuration file to get started will look something like the following:
@@ -123,13 +123,13 @@ pipeline:
 
 ```text
 [INPUT]
-  name opentelemetry
-  listen 127.0.0.1
-  port 4318
+  Name   opentelemetry
+  Listen 127.0.0.1
+  Port   4318
 
 [OUTPUT]
-  name stdout
-  match *
+  Name  stdout
+  Match *
 ```
 
 {% endtab %}


### PR DESCRIPTION
  - Update the transport protocol support matrix to reflect that HTTP/1.1 JSON is now Stable for metrics, added in commits 4a844c98b, f90bf0d7a, and e8ab3ab62
  - Fix classic .conf example to use Title_Case config parameter keys

  Fixes #2496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated OpenTelemetry support matrix: Metrics now marked as Stable for HTTP1/JSON transport
  * Fixed configuration example formatting with corrected field naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->