### PR TITLE
docs: installation: downloads: macos: removed missing package link

### DIFF
--- a/installation/downloads/macos.md
+++ b/installation/downloads/macos.md
@@ -4,7 +4,7 @@ Fluent Bit is compatible with the latest Apple macOS software for x86_64 and App
 
 ## Installation packages
 
-Installation packages can be found [in the Fluent Bit repository](https://packages.fluentbit.io/macos/).
+Installation packages can be found [in the Fluent Bit repository](https://packages.fluentbit.io/).
 
 ## Requirements
 


### PR DESCRIPTION
  - no longer building macos package

  Applies to #2390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS installation documentation with revised package repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->