### PR TITLE
docs: outputs: standard-output: add otlp_json and otlp_json_pretty format values

### DIFF
--- a/pipeline/outputs/standard-output.md
+++ b/pipeline/outputs/standard-output.md
@@ -10,7 +10,7 @@ The _standard output_ plugin prints ingested data to standard output.
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `format` | Specify the data format to be printed. Supported formats are `msgpack`, `json`, `json_lines` and `json_stream`. | `msgpack` |
+| `format` | Specify the data format to be printed. Supported formats are `msgpack`, `json`, `json_lines`, `json_stream`, `otlp_json`, and `otlp_json_pretty`. | `msgpack` |
 | `json_date_format` | Specify the format of the date. Supported formats are `double`, `epoch`, `epoch_ms`, `iso8601` (for example, `2018-05-30T09:39:52.000681Z`) and `java_sql_timestamp` (for example, `2018-05-30 09:39:52.000681`). | `double` |
 | `json_date_key` | Specify the name of the time key in the output record. To disable the time key set the value to `false`. | `date` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `1` |


### PR DESCRIPTION
  - add `otlp_json` and `otlp_json_pretty` to the `format` parameter

  This is a code change with no corresponding doc PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for the standard-output plugin's `format` configuration parameter to reflect support for two new output formats: `otlp_json` and `otlp_json_pretty`. Default format remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->