### PR TITLE
docs: inputs: ebpf: document trace_vfs trace type

### DIFF
--- a/pipeline/inputs/ebpf.md
+++ b/pipeline/inputs/ebpf.md
@@ -20,7 +20,7 @@ The plugin supports the following configuration parameters:
 |:----|:------------|:--------|
 | `poll_ms` | Set the polling interval in milliseconds for collecting events from the ring buffer. | `1000` |
 | `ringbuf_map_name` | Set the name of the eBPF ring buffer map to read events from. | `events` |
-| `trace` | Set the eBPF trace to enable (for example, `trace_bind`, `trace_malloc`, `trace_signal`). This parameter can be set multiple times to enable multiple traces. | _none_ |
+| `trace` | Set the eBPF trace to enable (for example, `trace_bind`, `trace_malloc`, `trace_signal`, `trace_vfs`). This parameter can be set multiple times to enable multiple traces. | _none_ |
 
 ## System dependencies
 
@@ -130,7 +130,7 @@ All traces include the following fields:
 
 | Field | Description |
 |:------|:------------|
-| `event_type` | Type of event (`signal`, `malloc`, or `bind`). |
+| `event_type` | Type of event (`signal`, `malloc`, `bind`, or `vfs`). |
 | `pid` | Process ID that generated the event. |
 | `tid` | Thread ID that generated the event. |
 | `comm` | Command name (process name) that generated the event. |
@@ -165,3 +165,16 @@ The `trace_bind` trace includes these additional fields:
 | `port` | Port number the socket is binding to. |
 | `bound_dev_if` | Network device interface the socket is bound to. |
 | `error_raw` | Error code for the bind operation (`0` indicates success). |
+
+### `VFS` trace fields
+
+The `trace_vfs` trace includes these additional fields:
+
+| Field | Description |
+|:------|:------------|
+| `operation` | `VFS` operation type (integer). |
+| `path` | File path involved in the operation. |
+| `flags` | Flags passed to the `VFS` operation. |
+| `mode` | File mode bits for the operation. |
+| `fd` | File descriptor returned by the operation. |
+| `error_raw` | Error code for the operation (`0` indicates success). |


### PR DESCRIPTION
  - Update `trace` parameter description to list `trace_vfs` as an example
  - Update common `event_type` field to include `vfs` as a valid value
  - Add "`VFS` trace fields" section documenting operation, path, flags, mode, fd, and error_raw fields

  Fixes #2533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support documentation for `trace_vfs` eBPF trace type
  * Updated configuration examples to include the new trace type
  * Documented output fields and event type for VFS trace operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->