### PR TITLE
monitoring: use v2 APIs in examples where they are equivalent

### DIFF
--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -382,7 +382,7 @@ The command prints a similar output like this:
 Query internal metrics in Prometheus Text 0.0.4 format:
 
 ```shell
-curl -s http://127.0.0.1:2020/api/v1/metrics/prometheus
+curl -s http://127.0.0.1:2020/api/v2/metrics/prometheus
 ```
 
 This command returns the same metrics in Prometheus format instead of JSON:
@@ -557,7 +557,7 @@ pipeline:
 Use the following command to call the health endpoint:
 
 ```shell
-curl -s http://127.0.0.1:2020/api/v1/health
+curl -s http://127.0.0.1:2020/api/v2/health
 ```
 
 With the example configuration, the health status is determined by the following equation:


### PR DESCRIPTION
The monitoring documentation used /api/v1/ routes in examples without it being clear why they were used instead of equivalent /api/v2/ routes. This commit changes that so that the new /api/v2/ routes are documented appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated monitoring documentation examples to reflect v2 API endpoints for Prometheus metrics collection and health endpoint monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->