### PR TITLE
Fixing intro docs (about), highlight profiles, OTLP, and fix vale suggestions

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,7 +4,7 @@
 
 ## About
 
-* [What is Fluent Bit?](about/what-is-fluent-bit.md)
+* [What's Fluent Bit?](about/what-is-fluent-bit.md)
 * [Fluentd and Fluent Bit](about/fluentd-and-fluent-bit.md)
 * [Lab resources](about/resources.md)
 

--- a/about/fluentd-and-fluent-bit.md
+++ b/about/fluentd-and-fluent-bit.md
@@ -26,6 +26,7 @@ The following table describes a comparison of different areas of the projects:
 | Performance  | Medium Performance    | High Performance                      |
 | Dependencies | Built as a Ruby Gem, depends on other gems. | Zero dependencies, unless required by a plugin. |
 | Plugins      | Over 1,000 external plugins available. | Over 100 built-in plugins available. |
+| OpenTelemetry | Available through plugins. | Native OTLP ingestion and delivery. |
 | License      | [Apache License v2.0](https://apache.org/licenses/LICENSE-2.0) | [Apache License v2.0](https://apache.org/licenses/LICENSE-2.0) |
 
 Both [Fluentd](https://www.fluentd.org) and [Fluent Bit](https://fluentbit.io) can work as Aggregators or Forwarders, and can complement each other or be used as standalone solutions.

--- a/about/what-is-fluent-bit.md
+++ b/about/what-is-fluent-bit.md
@@ -2,11 +2,11 @@
 description: Fluent Bit is a CNCF graduated project under the umbrella of Fluentd
 ---
 
-# What is Fluent Bit?
+# What's Fluent Bit?
 
-[Fluent Bit](https://fluentbit.io) is an open source telemetry agent specifically designed to efficiently handle the challenges of collecting and processing telemetry data across a wide range of environments, from constrained systems to complex cloud infrastructures. Managing telemetry data from various sources and formats can be a constant challenge, particularly when performance is a critical factor.
+[Fluent Bit](https://fluentbit.io) is an open source telemetry agent that processes logs, metrics, traces, and profiles. It's designed to efficiently handle the challenges of collecting and processing telemetry data across a wide range of environments, from constrained systems to complex cloud infrastructures. Managing telemetry data from various sources and formats can be a constant challenge, particularly when performance is a critical factor.
 
-Rather than serving as a drop-in replacement, Fluent Bit enhances the observability strategy for your infrastructure by adapting and optimizing your existing logging layer, and adding metrics and traces processing. Fluent Bit supports a vendor-neutral approach, seamlessly integrating with other ecosystems such as Prometheus and OpenTelemetry. Trusted by major cloud providers, banks, and companies in need of a ready-to-use telemetry agent solution, Fluent Bit effectively manages diverse data sources and formats while maintaining optimal performance and keeping resource consumption low.
+Rather than serving as a drop-in replacement, Fluent Bit enhances the observability strategy for your infrastructure. It adapts and optimizes your existing logging layer, and adds metrics and traces processing. Fluent Bit supports a vendor-neutral approach, with native OpenTelemetry (OTLP) ingestion and delivery and seamless integration with ecosystems such as Prometheus. Trusted by major cloud providers, banks, and companies that need a ready-to-use telemetry agent, Fluent Bit effectively manages diverse data sources and formats. It maintains optimal performance while keeping resource consumption low.
 
 Fluent Bit can be deployed as an edge agent for localized telemetry data handling or utilized as a central aggregator/collector for managing telemetry data across multiple sources and environments.
 
@@ -14,6 +14,6 @@ Fluent Bit can be deployed as an edge agent for localized telemetry data handlin
 
 ## The history of Fluent Bit
 
-In 2014, the [Fluentd](https://www.fluentd.org/) team at [Treasure Data](https://www.treasuredata.com/) was forecasting the need for a lightweight log processor for constraint environments like embedded Linux and gateways. To meet this need, Eduardo Silva created Fluent Bit, a new open-source solution and part of the Fluentd ecosystem.
+In 2014, the [Fluentd](https://www.fluentd.org/) team at [Treasure Data](https://www.treasuredata.com/) was forecasting the need for a lightweight log processor for constraint environments like embedded Linux and gateways. To meet this need, Eduardo Silva created Fluent Bit, a new open source solution and part of the Fluentd ecosystem.
 
 After the project matured, it gained traction for normal Linux systems. With the new containerized world, the cloud native community asked to extend the project scope to support more sources, filters, and destinations. Not long after, Fluent Bit became one of the preferred solutions to solve the logging challenges in cloud environments.


### PR DESCRIPTION
 - what-is-fluent-bit: explicitly list the telemetry signal types
    Fluent Bit processes (logs, metrics, traces, and profiles),
    aligning with concepts/key-concepts.md and fluentbit.io messaging.
  - what-is-fluent-bit: call out native OpenTelemetry (OTLP) ingestion
    and delivery rather than grouping it with ecosystem integrations.
  - what-is-fluent-bit: rename h1 to "What's Fluent Bit?", update
    SUMMARY.md, split long sentences, and use "open source".
  - fluentd-and-fluent-bit: add OpenTelemetry row to the comparison
    table to call out native OTLP support as a differentiator.

  Fixes #2539 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated navigation and heading wording for consistency
  * Expanded Fluent Bit description to explicitly list supported telemetry types: logs, metrics, traces, and profiles
  * Added OpenTelemetry comparison information highlighting native OTLP ingestion and delivery capabilities
  * Clarified vendor integrations with emphasis on native OpenTelemetry support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->