### PR TITLE
docs: document max inputs/outputs/filters plugin limits

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -111,7 +111,7 @@ The `OUTPUT` section specifies a destination that certain records should go to a
 | `Match_Regex` | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regular expression syntax. |
 | `Log_Level` | Set the plugin's logging verbosity level. Allowed values are: `off`, `error`, `warn`, `info`, `debug`, and `trace`. Defaults to the `SERVICE` section's `Log_Level`. |
 
-There is no hard-coded limit on the number of `OUTPUT` sections. The routing bitmask is dynamically sized at startup based on the number of configured output plugins. The practical maximum depends on available system resources such as memory and file descriptors.
+There is no hard-coded limit on the number of `OUTPUT` sections. The routing `bitmask` is dynamically sized at startup based on the number of configured output plugins. The practical maximum depends on available system resources such as memory and file descriptors.
 
 ### Output example
 

--- a/administration/configuring-fluent-bit/classic-mode/configuration-file.md
+++ b/administration/configuring-fluent-bit/classic-mode/configuration-file.md
@@ -62,6 +62,8 @@ The `INPUT` section defines a source (related to an input plugin). Each [input p
 
 `Name` is mandatory and tells Fluent Bit which input plugin to load. `Tag` is mandatory for all plugins except for the `input forward` plugin, which provides dynamic tags.
 
+There is no hard-coded limit on the number of `INPUT` sections. The practical maximum depends on available system resources such as memory and file descriptors.
+
 ### Example
 
 The following is an example of an `INPUT` section:
@@ -85,6 +87,8 @@ The `FILTER` section defines a filter (related to an filter plugin). Each filter
 
 `Name` is mandatory and lets Fluent Bit know which filter plugin should be loaded. `Match` or `Match_Regex` is mandatory for all plugins. If both are specified, `Match_Regex` takes precedence.
 
+There is no hard-coded limit on the number of `FILTER` sections. The practical maximum depends on available system resources such as memory.
+
 ### Filter example
 
 The following is an example of a `FILTER` section:
@@ -98,7 +102,7 @@ The following is an example of a `FILTER` section:
 
 ## Config output
 
-The `OUTPUT` section specifies a destination that certain records should go to after a `Tag` match. Fluent Bit can route up to 256 `OUTPUT` plugins. The configuration supports the following keys:
+The `OUTPUT` section specifies a destination that certain records should go to after a `Tag` match. The configuration supports the following keys:
 
 | Key         | Description    |
 | ----------- | -------------- |
@@ -106,6 +110,8 @@ The `OUTPUT` section specifies a destination that certain records should go to a
 | `Match`     | A pattern to match against the tags of incoming records. Case sensitive and supports the asterisk (`*`) character as a wildcard. |
 | `Match_Regex` | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regular expression syntax. |
 | `Log_Level` | Set the plugin's logging verbosity level. Allowed values are: `off`, `error`, `warn`, `info`, `debug`, and `trace`. Defaults to the `SERVICE` section's `Log_Level`. |
+
+There is no hard-coded limit on the number of `OUTPUT` sections. The routing bitmask is dynamically sized at startup based on the number of configured output plugins. The practical maximum depends on available system resources such as memory and file descriptors.
 
 ### Output example
 

--- a/administration/configuring-fluent-bit/yaml/pipeline-section.md
+++ b/administration/configuring-fluent-bit/yaml/pipeline-section.md
@@ -172,7 +172,7 @@ The `outputs` section defines one or more [output plugins](../../../pipeline/out
 | `match_regex` | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regular expression syntax. |
 | `log_level` | Set the plugin's logging verbosity level. Allowed values are: `off`, `error`, `warn`, `info`, `debug`, and `trace`. The output log level defaults to the `service` section's `log_level`. |
 
-Fluent Bit has no hard-coded limit on the number of output plugins. The routing bitmask is dynamically sized at startup based on the number of configured output plugins. The practical maximum depends on available system resources such as memory and file descriptors.
+Fluent Bit has no hard-coded limit on the number of output plugins. The routing `bitmask` is dynamically sized at startup based on the number of configured output plugins. The practical maximum depends on available system resources such as memory and file descriptors.
 
 ### Outgoing `OAuth 2.0` client credentials settings
 

--- a/administration/configuring-fluent-bit/yaml/pipeline-section.md
+++ b/administration/configuring-fluent-bit/yaml/pipeline-section.md
@@ -77,6 +77,8 @@ The `inputs` section defines one or more [input plugins](../../../pipeline/input
 
 The `name` parameter is required and defines for Fluent Bit which input plugin should be loaded. The `tag` parameter is required for all plugins except for the `forward` plugin, which provides dynamic tags.
 
+There is no hard-coded limit on the number of input plugins. The practical maximum depends on available system resources such as memory and file descriptors.
+
 ### Shared HTTP listener settings for inputs
 
 Some HTTP-based input plugins share the same listener implementation and support the following common settings in addition to their plugin-specific parameters:
@@ -144,6 +146,8 @@ The `filters` section defines one or more [filters](../../../pipeline/filters.md
 
 The `name` parameter is required and lets Fluent Bit know which filter should be loaded. One of either the `match` or `match_regex` parameters is required. If both are specified, `match_regex` takes precedence.
 
+There is no hard-coded limit on the number of filter plugins. The practical maximum depends on available system resources such as memory.
+
 ### Example filter configuration
 
 The following is an example of a `filters` section that contains a `grep` plugin:
@@ -168,7 +172,7 @@ The `outputs` section defines one or more [output plugins](../../../pipeline/out
 | `match_regex` | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regular expression syntax. |
 | `log_level` | Set the plugin's logging verbosity level. Allowed values are: `off`, `error`, `warn`, `info`, `debug`, and `trace`. The output log level defaults to the `service` section's `log_level`. |
 
-Fluent Bit can route up to 256 output plugins.
+Fluent Bit has no hard-coded limit on the number of output plugins. The routing bitmask is dynamically sized at startup based on the number of configured output plugins. The practical maximum depends on available system resources such as memory and file descriptors.
 
 ### Outgoing `OAuth 2.0` client credentials settings
 


### PR DESCRIPTION
## Summary

Remove the outdated "up to 256 OUTPUT plugins" hard limit and add
documentation for the maximum number of input, output, and filter plugins
in both the classic-mode and YAML configuration references.

### What changed

The routing bitmask was changed from a fixed-size array (`4 × uint64_t = 256`
bits) to a dynamically allocated bitmask sized at startup based on the number
of configured output plugins (`flb_routes_mask_set_size()` in
[`src/flb_engine.c`](https://github.com/fluent/fluent-bit/blob/master/src/flb_engine.c)).
This means the former 256-output cap no longer applies.

Input and filter plugin instances are stored in linked lists with no
compile-time size limit, so they were never capped either.

### Changes per file

| File | Change |
|------|--------|
| `administration/configuring-fluent-bit/classic-mode/configuration-file.md` | Remove "up to 256 OUTPUT plugins"; add no-hard-limit note to INPUT, FILTER, and OUTPUT sections |
| `administration/configuring-fluent-bit/yaml/pipeline-section.md` | Replace "up to 256 output plugins" with dynamic-limit note; add no-hard-limit note to inputs and filters sections |

Closes fluent/fluent-bit#4201

Signed-off-by: Pierluigi Lenoci <pierluigilenoci@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration docs: INPUT, FILTER, and OUTPUT plugins no longer have hard-coded count limits; practical limits depend on system resources (memory, file descriptors).
  * Added note that OUTPUT routing uses a dynamically sized bitmask computed at startup based on the configured output plugin count, constrained only by available system resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->