### PR TITLE
docs: admin: Storage backlog mem limit fixes

### DIFF
--- a/administration/backpressure.md
+++ b/administration/backpressure.md
@@ -58,19 +58,23 @@ In a few seconds, if the scheduler was able to flush the initial 700&nbsp;KB of 
 
 If one or more active input plugins use [filesystem buffering](../pipeline/buffering.md#filesystem-buffering-hybrid), use the following settings to manage backpressure.
 
-### Set `storage.max_chunks_up` and `storage.backlog.mem_limit` in global settings
+### Set `storage.max_chunks_up` in global settings
 
-In the [`service` section](../administration/configuring-fluent-bit/yaml/service-section.md) of your Fluent Bit configuration file, you can configure the `storage.max_chunks_up` and `storage.backlog.mem_limit` settings. Both settings dictate how much data can be buffered to memory by input plugins that use filesystem buffering, and are combined limits shared by all applicable input plugins.
+In the [`service` section](../administration/configuring-fluent-bit/yaml/service-section.md) of your Fluent Bit configuration file, you can configure the `storage.max_chunks_up` setting. This setting is a global cap on how many filesystem-backed chunks can be `up` (mapped into memory) at any time, and is shared across all input plugins that use filesystem buffering.
 
 {% hint style="info" %}
-These settings don't affect how much data can be buffered to memory by plugins that use memory-only buffering.
+This setting doesn't affect how much data can be buffered to memory by plugins that use memory-only buffering.
 {% endhint %}
 
-When either the specified `storage.max_chunks_up` or `storage.backlog.mem_limit` capacity is reached, all input plugins that use filesystem buffering will stop buffering data to memory until more memory becomes available. Whether these input plugins continue buffering data to the filesystem depends on each plugin's specified `storage.pause_on_chunks_overlimit` value.
+When the `storage.max_chunks_up` capacity is reached, input plugins that use filesystem buffering stop bringing new chunks up into memory. Whether these input plugins continue buffering data to the filesystem depends on each plugin's specified `storage.pause_on_chunks_overlimit` value.
+
+### Tune `storage.backlog.mem_limit` for the backlog plugin
+
+`storage.backlog.mem_limit` only governs the built-in `storage_backlog` input plugin, which promotes filesystem chunks left over from a previous Fluent Bit run back into memory so output plugins can flush them. While the up chunks owned by `storage_backlog` consume less memory than this limit, Fluent Bit continues to promote additional backlog chunks. Reaching this limit doesn't pause regular input plugins, and the limit doesn't cap memory used by inputs other than `storage_backlog`.
 
 ### Set `storage.pause_on_chunks_overlimit` for input plugins
 
-For input plugins that use filesystem buffering, you can configure the `storage.pause_on_chunks_overlimit` setting to specify how each plugin should behave after the global `storage.max_chunks_up` or `storage.backlog.mem_limit` capacity is reached.
+For input plugins that use filesystem buffering, you can configure the `storage.pause_on_chunks_overlimit` setting to specify how each plugin should behave after the global `storage.max_chunks_up` capacity is reached.
 
 If `storage.pause_on_chunks_overlimit` is set to `off` for an input plugin, the input plugin will stop buffering data to memory but continue buffering data to the filesystem.
 

--- a/administration/configuring-fluent-bit/yaml/service-section.md
+++ b/administration/configuring-fluent-bit/yaml/service-section.md
@@ -45,7 +45,7 @@ The following storage-related keys can be set as children to the `storage` key:
 | Key | Description | Default Value |
 | --- | ----------- | ------------- |
 | `storage.backlog.flush_on_shutdown` | If enabled, Fluent Bit attempts to flush all backlog filesystem chunks to their destination during the shutdown process. This can help ensure data delivery before Fluent Bit stops, but can also increase shutdown time. Possible values: `off` or `on`. | `off` |
-| `storage.backlog.mem_limit` | Sets the memory allocated for storing buffered data for input plugins that use filesystem storage. | `5M` |
+| `storage.backlog.mem_limit` | Sets the memory limit used by the `storage_backlog` input plugin when promoting backlog chunks (filesystem chunks left over from a previous Fluent Bit run) back into memory so they can be flushed by output plugins. While the up chunks owned by `storage_backlog` consume less memory than this limit, Fluent Bit continues to promote additional backlog chunks. This setting doesn't cap memory use for other input plugins that use filesystem storage. | `5M` |
 | `storage.checksum` | Enables data integrity check when writing and reading data from the filesystem. The storage layer uses the CRC32 algorithm. Possible values: `off` or `on`. | `off` |
 | `storage.delete_irrecoverable_chunks` | If enabled, deletes irrecoverable chunks during runtime and at startup. Possible values: `off` or `on`. | `off` |
 | `storage.inherit` | If enabled, input plugins that don't explicitly set `storage.type` will inherit the global `storage.type` value. Possible values: `off` or `on`. | `off` |


### PR DESCRIPTION
docs: administration: backpressure: separate storage.backlog.mem_limit from storage.max_chunks_up

      - Rename the heading to "Set storage.max_chunks_up in global settings"
        and rewrite the paragraph to describe only that setting
      - Add a new "Tune storage.backlog.mem_limit for the backlog plugin"
        subsection clarifying its actual scope
      - Update the storage.pause_on_chunks_overlimit subsection to reference
        storage.max_chunks_up only

docs: administration: yaml: service-section: fix storage.backlog.mem_limit description

      - Rewrite the description to scope the setting to the storage_backlog
        input plugin
      - Note explicitly that it doesn't cap memory used by other filesystem-
        buffering inputs

Fixes #2555.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified storage backpressure configuration guidance for better understanding of memory management behavior
  * Improved documentation of filesystem-buffering settings and how storage limits apply across different input plugins
  * Enhanced explanations of `storage.max_chunks_up` and `storage.backlog.mem_limit` configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->