### PR TITLE
docs: installation: linux: redhat-centos: fix broken yum repo example

### DIFF
--- a/installation/downloads/linux/redhat-centos.md
+++ b/installation/downloads/linux/redhat-centos.md
@@ -42,12 +42,12 @@ The`fluent-bit` package is provided through a Yum repository. To add the reposit
 
    ```text
    [fluent-bit]
-     name = Fluent Bit
-     baseurl = https://packages.fluentbit.io/centos/$releasever/
-     gpgcheck=1
-     gpgkey=https://packages.fluentbit.io/fluentbit.key
-     repo_gpgcheck=1
-     enabled=1
+   name=Fluent Bit
+   baseurl=https://packages.fluentbit.io/centos/$releasever/$basearch/
+   gpgcheck=1
+   gpgkey=https://packages.fluentbit.io/fluentbit.key
+   repo_gpgcheck=1
+   enabled=1
    ```
 
 1. As a best practice, enable `gpgcheck` and `repo_gpgcheck` for security reasons. Fluent Bit signs its repository metadata and all Fluent Bit packages.
@@ -92,8 +92,8 @@ The `fluent-bit.repo` file for the latest installations of Fluent Bit uses a `$r
 
 ```text
 [fluent-bit]
-  name = Fluent Bit
-  baseurl = https://packages.fluentbit.io/centos/$releasever/$basearch/
+name=Fluent Bit
+baseurl=https://packages.fluentbit.io/centos/$releasever/$basearch/
 ```
 
 Depending on your Red Hat distribution version, this variable can return a value other than the OS major release version (for example, RHEL7 Server distributions return `7Server` instead of `7`). The Fluent Bit package URL uses the major OS release version, so any other value here will cause a 404.
@@ -102,12 +102,12 @@ To resolve this issue, replace the `$releasever` variable with your system's OS 
 
 ```text
 [fluent-bit]
-  name = Fluent Bit
-  baseurl = https://packages.fluentbit.io/centos/7/$basearch/
-  gpgcheck=1
-  gpgkey=https://packages.fluentbit.io/fluentbit.key
-  repo_gpgcheck=1
-  enabled=1
+name=Fluent Bit
+baseurl=https://packages.fluentbit.io/centos/7/$basearch/
+gpgcheck=1
+gpgkey=https://packages.fluentbit.io/fluentbit.key
+repo_gpgcheck=1
+enabled=1
 ```
 
 ### Yum install fails with incompatible dependencies using CentOS 9+


### PR DESCRIPTION
  The .repo file examples had two-space indentation on every key, which
  yum/dnf interprets as continuation lines, causing "failed loading
  /etc/yum.repos.d/fluent-bit.repo, skipping". Removed the indentation,
  added the missing $basearch to the primary baseurl, and normalized to
  key=value format across all three examples in the page.

  Fixes #2553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Yum repository configuration examples and guidance for Red Hat/CentOS installations to improve accuracy and clarity.
  * Enhanced troubleshooting section with corrected repository URL configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->