### PR TITLE
docs: env: bash-style default value operator :-

### DIFF
--- a/administration/configuring-fluent-bit/classic-mode/variables.md
+++ b/administration/configuring-fluent-bit/classic-mode/variables.md
@@ -6,9 +6,8 @@ Fluent Bit supports the usage of environment variables in any value associated t
 
 The variables are case sensitive and can be used in the following format:
 
-```text
-${MY_VARIABLE}
-```
+* **Standard:** `${MY_VARIABLE}`
+* **With Default Value:** `${MY_VARIABLE:-default_value}` (**v5.0.6+**) 
 
 When Fluent Bit starts, the configuration reader will detect any request for `${MY_VARIABLE}` and will try to resolve its value.
 
@@ -18,6 +17,18 @@ When Fluent Bit is running under [`systemd`](https://systemd.io/) (using the off
 - `/etc/sysconfig/fluent-bit` (Others)
 
 These files are ignored if they don't exist.
+
+### Fallback behavior
+
+{% hint style="info" %}
+Minimum Fluent Bit version 5.0.6
+{% endhint %}
+
+If the `${VARIABLE:-DEFAULT}` syntax is used, Fluent Bit will use the `DEFAULT` value if the variable meets either of the following conditions:
+1. The variable **isn't defined** (unset).
+2. The variable is defined but set to an **empty string** (`''`).
+
+Nesting **isn't supported**. You cannot use the `${}` syntax within another `${}` definition. `${MY_VAR:-${OTHER_VAR}}` would be invalid.
 
 ## Example
 

--- a/administration/configuring-fluent-bit/classic-mode/variables.md
+++ b/administration/configuring-fluent-bit/classic-mode/variables.md
@@ -28,7 +28,7 @@ If the `${VARIABLE:-DEFAULT}` syntax is used, Fluent Bit will use the `DEFAULT` 
 1. The variable **isn't defined** (unset).
 2. The variable is defined but set to an **empty string** (`''`).
 
-Nesting **isn't supported**. You cannot use the `${}` syntax within another `${}` definition. `${MY_VAR:-${OTHER_VAR}}` would be invalid.
+Nesting **isn't supported**. You can't use the `${}` syntax within another `${}` definition. `${MY_VAR:-${OTHER_VAR}}` would be invalid.
 
 ## Example
 

--- a/administration/configuring-fluent-bit/yaml/environment-variables-section.md
+++ b/administration/configuring-fluent-bit/yaml/environment-variables-section.md
@@ -65,6 +65,22 @@ pipeline:
 
 In this example, `${DB_PASSWORD}` is read from the file `/run/secrets/db_password` and refreshed every 60 seconds. `${REGION}` is set to the static value `us-east-1`.
 
+## Default values
+
+{% hint style="info" %}
+Minimum Fluent Bit version 5.0.6
+{% endhint %}
+
+Fluent Bit supports setting a default value for an environment variable if the variable isn't defined or is set to an empty string ('').
+
+The syntax for a default value is `${VARIABLE_NAME:-DEFAULT_VALUE}`.
+
+```yaml
+service:
+  flush: ${FLUSH_INTERVAL:-5}
+  log_level: info
+```
+
 ## Predefined variables
 
 Fluent Bit supports the following predefined environment variables. You can reference these variables in configuration files without defining them in the `env` section.


### PR DESCRIPTION
**Waiting on code merge:** https://github.com/fluent/fluent-bit/pull/11787

Updates documentation to mention the default value operator i.e `${ENV_VAR:-default}`. Feature applies to both legacy config and YAML config files. 

Has some examples, and details the expected behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified environment-variable substitution syntaxes, including the default-value form.
  * Added a “Fallback behavior” / “Default values” section explaining resolution when variables are unset or empty and that nesting is not supported.
  * Noted minimum Fluent Bit version for default-value support and updated example output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->