### PR TITLE
docs: outputs: forward: update retain_metadata_in_forward_mode default to true

### DIFF
--- a/pipeline/outputs/forward.md
+++ b/pipeline/outputs/forward.md
@@ -29,7 +29,7 @@ The following parameters are mandatory for both Forward and Secure Forward modes
 | `require_ack_response` | Send the `chunk` option and wait for an `ack` response from the server. This enables at-least-once delivery and lets the receiving server control traffic rate. Requires Fluentd `v0.14.0` or later. | `false` |
 | `compress` | Set to `gzip` to enable gzip compression. Incompatible with `time_as_integer true` and tags set dynamically using the [Rewrite Tag](../filters/rewrite-tag.md) filter. Requires Fluentd server `v0.14.7` or later. | _none_ |
 | `fluentd_compat` | Send metrics and traces using a Fluentd-compatible format. | `false` |
-| `retain_metadata_in_forward_mode` | Retain metadata when operating in forward mode. | `false` |
+| `retain_metadata_in_forward_mode` | Retain metadata when operating in forward mode. | `true` |
 | `add_option` | Add an extra Forward protocol option. This is an advanced setting and can be specified multiple times. Enabling it also enables `send_options`. | _none_ |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `2` |
 


### PR DESCRIPTION
  - flip the documented default parameter from `false` to `true` to match the upstream change in Fluent Bit commit 888db299e

  Note this is a fix for code changes without corresponding docs PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to reflect the default value change for metadata retention in Forward mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2569)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->