### PR TITLE
docs: outputs: s3: document format parameter for OTLP JSON output

### DIFF
--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -51,6 +51,7 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `endpoint` | Custom endpoint for the S3 API. Endpoints can contain scheme and port. | _none_ |
 | `external_id` | Specify an external ID for the STS API. Can be used with the `role_arn` parameter if your role requires an external ID. | _none_ |
 | `file_delivery_attempt_limit` | File delivery attempt limit. | `1` |
+| `format` | Set the record output format. Supported values: `json_lines`, `otlp_json`. When set to `otlp_json`, the `log_key` option isn't supported and only `logs` event chunks are converted. | `json_lines` |
 | `host` | IP address or hostname of the target HTTP server. | `127.0.0.1` |
 | `json_date_format` | Specify the format of the date. Accepted values: `double`, `epoch`, `epoch_ms`, `iso8601` (2018-05-30T09:39:52.000681Z), `_java_sql_timestamp_` (2018-05-30 09:39:52.000681). | _none_ |
 | `json_date_key` | Specify the name of the date key in the output record. To disable the time key, set the value to `false`. | `date` |


### PR DESCRIPTION
  - add a `format` configuration parameter documenting `json_lines` (default) and `otlp_json` values, and noting that `log_key` isn't supported when `format` is `otlp_json`

  Note this is a fix for code changes without corresponding docs PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `format` configuration parameter for Amazon S3 output, including supported values (`json_lines`, `otlp_json`), default settings, and related constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2570)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->