### PR TITLE
docs: outputs: kafka: document otlp_logs_partition_by_resource parameter

### DIFF
--- a/pipeline/outputs/kafka.md
+++ b/pipeline/outputs/kafka.md
@@ -24,6 +24,7 @@ This plugin supports the following parameters:
 | `group_id` | Consumer group ID. | _none_ |
 | `message_key` | Optional key to store the message. | _none_ |
 | `message_key_field` | If set, the value of `message_key_field` in the record will indicate the message key. If not set or not found in the record, `message_key` is used if set. | _none_ |
+| `otlp_logs_partition_by_resource` | When using `otlp_json` or `otlp_proto` format for logs, send each OTLP resource's logs as a separate Kafka message. | `false` |
 | `queue_full_retries` | Number of local retries to enqueue data when the `rdkafka` queue is full. The interval between retries is 1 second. Set to `0` for unlimited retries. | `10` |
 | `raw_log_key` | When using the `raw` format, the value of `raw_log_key` in the record is sent to Kafka as the payload. | _none_ |
 | `rdkafka.{property}` | `{property}` can be any [librdkafka property](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md). | _none_ |


### PR DESCRIPTION
  - Add `otlp_logs_partition_by_resource` boolean parameter to the configuration parameters table

  Note, covers a code update without a doc update PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `otlp_logs_partition_by_resource` configuration parameter for Kafka output, which controls whether logs from each OTLP resource are sent as separate Kafka messages when using `otlp_json` or `otlp_proto` formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2573)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->