### PR TITLE
docs: outputs: document http_server.idle_timeout parameter

### DIFF
--- a/pipeline/outputs/prometheus-exporter.md
+++ b/pipeline/outputs/prometheus-exporter.md
@@ -22,6 +22,7 @@ This plugin supports the following parameters:
 | `add_label` | This lets you add custom labels to all metrics exposed through the Prometheus exporter. You can have multiple of these fields. | _none_ |
 | `add_timestamp` | Add timestamp to every metric honoring collection time. | `false` |
 | `host` | IP address or hostname Fluent Bit will bind to when hosting Prometheus metrics. The `listen` parameter is deprecated in 1.9.0 and later. | `0.0.0.0` |
+| `http_server.idle_timeout` | Maximum time an idle HTTP client connection is kept open. Connections that remain idle beyond this duration are closed. Accepts time values such as `10s` or `1m`. | `10s` |
 | `port` | TCP port Fluent Bit will bind to when hosting Prometheus metrics. | `2021` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `0` |
 

--- a/pipeline/outputs/vivo-exporter.md
+++ b/pipeline/outputs/vivo-exporter.md
@@ -15,6 +15,7 @@ This plugin supports the following configuration parameters:
 | `empty_stream_on_read` | If enabled, when an HTTP client consumes the data from a stream, the stream content will be removed. | `off` |
 | `host` | The network address for the HTTP server to listen on. | `0.0.0.0` |
 | `http_cors_allow_origin` | Specify the value for the HTTP `Access-Control-Allow-Origin` header (CORS). | _none_ |
+| `http_server.idle_timeout` | Maximum time an idle HTTP client connection is kept open. Connections that remain idle beyond this duration are closed. Accepts time values such as `10s` or `1m`. | `10s` |
 | `port` | The TCP port for the HTTP server to listen on. | `2025` |
 | `stream_queue_size`| Specify the maximum queue size per stream. Each specific stream for logs, metrics, and traces can hold up to `stream_queue_size` bytes. | `20M` |
 | `workers` | The number of [workers](../../administration/multithreading.md#outputs) to perform flush operations for this output. | `1` |


### PR DESCRIPTION
  - prometheus-exporter.md: add http_server.idle_timeout to configuration parameters table
  - vivo-exporter.md: add http_server.idle_timeout to configuration parameters table

  Note, for a code change without corresponding docs PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation for both Prometheus Exporter and Vivo Exporter. A new configuration parameter `http_server.idle_timeout` is now documented and available, allowing control over the maximum duration that idle HTTP client connections remain open. Default value is 10 seconds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->