### PR TITLE
in_node_exporter_metrics: add timex collector description

### DIFF
--- a/pipeline/inputs/node-exporter-metrics.md
+++ b/pipeline/inputs/node-exporter-metrics.md
@@ -58,6 +58,7 @@ This helps with down-sampling when collecting metrics.
 | `collector.textfile.scrape_interval` | The rate in seconds at which `textfile` metrics are collected from the host operating system. | `0` |
 | `collector.thermalzone.scrape_interval` | The rate in seconds at which `thermal_zone` metrics are collected from the host operating system. | `0` |
 | `collector.time.scrape_interval` | The rate in seconds at which `time` metrics are collected from the host operating system. | `0` |
+| `collector.timex.scrape_interval` | The rate in seconds at which `timex` metrics are collected from the host operating system. | `0` |
 | `collector.uname.scrape_interval` | The rate in seconds at which `uname` metrics are collected from the host operating system. | `0` |
 | `collector.vmstat.scrape_interval` | The rate in seconds at which `vmstat` metrics are collected from the host operating system. | `0` |
 | `diskstats.ignore_device_regex` | Specify the regular expression for the` diskstats` to prevent collection of/ignore. | `^(ram\|loop\|fd\|(h\|s\|v\|xv)d[a-z]\|nvme\\d+n\\d+p)\\d+$` |
@@ -100,6 +101,7 @@ The Version column specifies the Fluent Bit version where the collector is avail
 | `textfile`          | Exposes custom metrics from text files. Requires `collector.textfile.path` to be set.            | Linux            | 2.2.0   |
 | `thermal_zone`      | Exposes thermal statistics from `/sys/class/thermal/thermal_zone/*`.                             | Linux            | 2.2.1   |
 | `time`              | Exposes the current system time.                                                                 | Linux            | 1.8     |
+| `timex`             | Exposes selected `adjtimex(2)` system call stats.                                                | Linux            | TBD     |
 | `uname`             | Exposes system information as provided by the `uname` system call.                               | Linux, macOS     | 1.8     |
 | `vmstat`            | Exposes statistics from `/proc/vmstat`.                                                          | Linux            | 1.8.2   |
 


### PR DESCRIPTION
Add documentation relative to [fluent-bit  PR #11718](https://github.com/fluent/fluent-bit/pull/11718).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support for the `timex` collector with a configurable scrape interval parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->