### PR TITLE
docs: yaml: add http_server.idle_timeout to shared HTTP listener settings

### DIFF
--- a/administration/configuring-fluent-bit/yaml/pipeline-section.md
+++ b/administration/configuring-fluent-bit/yaml/pipeline-section.md
@@ -100,6 +100,7 @@ plugin-specific behavior.
 | `http_server.workers` | Set the number of HTTP listener worker threads. | `1` |
 | `http_server.ingress_queue_event_limit` | Set the maximum number of deferred ingress queue entries. This setting applies only when `http_server.workers` is greater than `1`. | `8192` |
 | `http_server.ingress_queue_byte_limit` | Set the maximum size of the deferred ingress queue. This setting applies only when `http_server.workers` is greater than `1`. | `256M` |
+| `http_server.idle_timeout` | Maximum time an idle accepted HTTP connection is kept open. Connections that remain idle beyond this duration are closed. Set to `0` to disable. Accepts time values such as `10s` or `1m`. | `10s` |
 
 When `http_server.workers` is `1`, Fluent Bit does not use the deferred
 ingress queue, so the two `http_server.ingress_queue_*` settings have no

--- a/administration/configuring-fluent-bit/yaml/service-section.md
+++ b/administration/configuring-fluent-bit/yaml/service-section.md
@@ -36,7 +36,7 @@ The `service` section of YAML configuration files defines global properties of t
 | `streams_file` | Path for the [stream processor](../../../stream-processing/overview.md) configuration file. This file defines the rules and operations for stream processing in Fluent Bit. Stream processor configurations can also be defined directly in the `streams` section of YAML configuration files. | _none_ |
 | `windows.maxstdio` | If specified, adjusts the limit of `stdio`. Only provided for Windows. Values from `512` to `2048` are allowed. | `512` |
 
-The `service` section only controls the built-in monitoring and control HTTP server. Plugin-specific HTTP listener settings such as `http_server.http2`, `http_server.buffer_max_size`, `http_server.buffer_chunk_size`, `http_server.max_connections`, `http_server.workers`, `http_server.ingress_queue_event_limit`, and `http_server.ingress_queue_byte_limit` are configured on the relevant input plugin in the [`pipeline.inputs`](../yaml/pipeline-section.md#shared-http-listener-settings-for-inputs) section.
+The `service` section only controls the built-in monitoring and control HTTP server. Plugin-specific HTTP listener settings such as `http_server.http2`, `http_server.buffer_max_size`, `http_server.buffer_chunk_size`, `http_server.max_connections`, `http_server.workers`, `http_server.ingress_queue_event_limit`, `http_server.ingress_queue_byte_limit`, and `http_server.idle_timeout` are configured on the relevant input plugin in the [`pipeline.inputs`](../yaml/pipeline-section.md#shared-http-listener-settings-for-inputs) section.
 
 ## Storage configuration
 


### PR DESCRIPTION
  - pipeline-section.md: added http_server.idle_timeout row to the shared HTTP listener settings table with description and default of 10s
  - service-section.md: added http_server.idle_timeout to the inline list of plugin-specific HTTP listener settings in the note below the table

  Note these updates are from code changes without corresponding docs PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `http_server.idle_timeout` configuration setting for HTTP input listeners.
  * Clarified that the `service` section only controls the built-in monitoring and control HTTP server.
  * Updated list of plugin-specific HTTP listener settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->