### PR TITLE
docs: installation: ubuntu: add Ubuntu 26.04 as a supported platform

### DIFF
--- a/installation/downloads/linux/ubuntu.md
+++ b/installation/downloads/linux/ubuntu.md
@@ -1,6 +1,6 @@
 # Ubuntu
 
-Fluent Bit is distributed as the `fluent-bit` package and is available for long-term support releases of Ubuntu. The latest officially supported version is Noble Numbat (24.04).
+Fluent Bit is distributed as the `fluent-bit` package and is available for long-term support releases of Ubuntu. The latest officially supported version is Ubuntu 26.04. Long-term support releases are also available for Noble Numbat (24.04) and Jammy Jellyfish (22.04).
 
 The recommended secure deployment approach is to use the following instructions.
 


### PR DESCRIPTION
  - updated to list Ubuntu 26.04 as latest supported version

  Note this update is from code changes without corresponding docs PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ubuntu installation documentation to reflect support for Ubuntu 26.04 LTS as the latest officially supported long-term support version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->