### PR TITLE
docs: administration: tls: document IP literal SNI behavior

### DIFF
--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -29,6 +29,12 @@ Both input and output plugins that perform Network I/O can optionally enable TLS
 | `tls.verify_hostname`     | Force TLS verification of host names.                                                                                                   | `off`   |
 | `tls.verify_client_cert`  | Require and verify the TLS certificate presented by a connecting client. Enables mutual TLS (mTLS) for input plugins. Only applies to input plugins. | `off`   |
 
+{% hint style="info" %}
+
+When the connection target is an IP address (IPv4 or IPv6), Fluent Bit doesn't include the TLS Server Name Indication (SNI) extension, which is consistent with [RFC 6066](https://www.rfc-editor.org/rfc/rfc6066). Certificate validation still applies against the IP address. If the server requires SNI or uses a hostname-based certificate, use a hostname as the connection target and set `tls.vhost` if needed.
+
+{% endhint %}
+
 To use TLS on input plugins, you must provide both a certificate and a private key.
 
 The listed properties can be enabled in the configuration file, specifically in each output plugin section or directly through the command line.


### PR DESCRIPTION
  - added an info callout explaining that connections to IPv4 or IPv6 addresses omit the SNI extension per RFC 6066, and that tls.vhost can be used when hostname-based SNI is required

  Note this update is for code changes without corresponding doc PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on TLS SNI extension handling for IP address connections and recommendations for using hostnames when required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluent/fluent-bit-docs/pull/2585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->