### PR TITLE
docs: fix broken links from generated May report

### DIFF
--- a/about/what-is-fluent-bit.md
+++ b/about/what-is-fluent-bit.md
@@ -14,6 +14,6 @@ Fluent Bit can be deployed as an edge agent for localized telemetry data handlin
 
 ## The history of Fluent Bit
 
-In 2014, the [Fluentd](https://www.fluentd.org/) team at [Treasure Data](https://www.treasuredata.com/) was forecasting the need for a lightweight log processor for constraint environments like embedded Linux and gateways. To meet this need, Eduardo Silva created Fluent Bit, a new open source solution and part of the Fluentd ecosystem.
+In 2014, the [Fluentd](https://www.fluentd.org/) team at [Treasure Data](https://www.treasure.ai/) was forecasting the need for a lightweight log processor for constraint environments like embedded Linux and gateways. To meet this need, Eduardo Silva created Fluent Bit, a new open source solution and part of the Fluentd ecosystem.
 
 After the project matured, it gained traction for normal Linux systems. With the new containerized world, the cloud native community asked to extend the project scope to support more sources, filters, and destinations. Not long after, Fluent Bit became one of the preferred solutions to solve the logging challenges in cloud environments.

--- a/pipeline/outputs/azure_kusto.md
+++ b/pipeline/outputs/azure_kusto.md
@@ -6,30 +6,30 @@ description: Send logs to Azure Data Explorer (Kusto)
 
 The _Kusto_ output plugin lets you ingest your logs into an [Azure Data Explorer](https://azure.microsoft.com/en-us/products/data-explorer/) cluster, using the [Queued Ingestion](https://learn.microsoft.com/en-us/kusto/api/netfx/about-kusto-ingest?view=azure-data-explorer&preserve-view=true&tabs=csharp#queued-ingestion) mechanism. This output plugin can also be used to ingest logs into an [Eventhouse](https://blog.fabric.microsoft.com/en-us/blog/eventhouse-overview-handling-real-time-data-with-microsoft-fabric/) cluster in Microsoft Fabric Real Time Analytics.
 
-## Authentication Methods
+## Authentication methods
 
-Fluent-Bit can use various authentication methods to connect to your Azure Data Explorer cluster:
+Fluent Bit can use various authentication methods to connect to your Azure Data Explorer cluster:
 
-### Service Principal Authentication (Default)
+### Service principal authentication (default)
 
 For service principal authentication, you'll need to create an Azure AD application:
 
 - [Register an Application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#register-an-application)
 - [Add a client secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret)
-- [Authorize the app in your database](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/access-control/principals-and-identity-providers#azure-ad-tenants)
+- [Authorize the app in your database](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/access-control/principals-and-identity-providers#azure-ad-tenants)
 
 Configure Fluent Bit with your application's `tenant_id`, `client_id`, and `client_secret`.
 
-### Managed Identity Authentication
+### Managed identity authentication
 
-When running on Azure services that support Managed Identities (such as Azure VMs, AKS, or App Service):
+When running on Azure services that support Managed Identities (such as Azure VMs, Azure Kubernetes Service (AKS), or App Service):
 
 1. [Assign the managed identity appropriate permissions to your Kusto database](https://learn.microsoft.com/en-us/azure/data-explorer/configure-managed-identities-cluster)
 2. Configure Fluent Bit with `auth_type` set to `managed_identity`
 3. For system-assigned identity, set `client_id` to `system`
-4. For user-assigned identity, set `client_id` to the managed identity's client ID (GUID)
+4. For user-assigned identity, set `client_id` to the managed identity's globally unique identifier (client ID)
 
-### Workload Identity Authentication
+### Workload identity authentication
 
 For Kubernetes environments using Azure Workload Identity:
 
@@ -38,9 +38,9 @@ For Kubernetes environments using Azure Workload Identity:
 3. Configure Fluent Bit with:
    - `auth_type` set to `workload_identity`
    - `tenant_id` and `client_id` of your Azure AD application
-   - `workload_identity_token_file` pointing to your token file path (typically `/var/run/secrets/azure/tokens/azure-identity-token`)
+   - `workload_identity_token_file` pointing to your token path (typically `/var/run/secrets/azure/tokens/azure-identity-token`)
 
-## For ingesting into Azure Data Explorer:  Creating a Kusto Cluster and Database
+## For ingesting into Azure Data Explorer: Creating a Kusto cluster and database
 
 Create an Azure Data Explorer cluster in one of the following ways:
 
@@ -231,7 +231,7 @@ pipeline:
   Io_Timeout                            60s
 ```
 
-#### Managed Identity Authentication
+#### Managed identity authentication
 
 ```
 [OUTPUT]
@@ -245,7 +245,7 @@ pipeline:
   # Additional parameters as needed
 ```
 
-#### Workload Identity Authentication
+#### Workload identity authentication
 
 ```
 [OUTPUT]

--- a/pipeline/outputs/bigquery.md
+++ b/pipeline/outputs/bigquery.md
@@ -25,7 +25,7 @@ Fluent Bit streams data into an existing BigQuery table using a service account 
    You must configure workload identity federation in GCP before using it with Fluent Bit.
 
    - [Configuring workload identity federation](https://cloud.google.com/iam/docs/configuring-workload-identity-federation#aws)
-   - [Obtaining short-lived credentials with identity federation](https://cloud.google.com/iam/docs/using-workload-identity-federation)
+   - [Obtaining short-lived credentials with identity federation](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-clouds)
 
 ## Configuration parameters
 

--- a/pipeline/outputs/dash0.md
+++ b/pipeline/outputs/dash0.md
@@ -25,7 +25,7 @@ The OpenTelemetry output plugin supports TLS/SSL. For more details about the pro
 
 To get started with sending logs to Dash0:
 
-1. Get an [Auth Token](https://www.dash0.com/documentation/dash0/key-concepts/auth-tokens) from **Settings** > **Auth Tokens**.
+1. Get an [Auth Token](https://www.dash0.com/docs/dash0/miscellaneous/glossary/auth-tokens) from **Settings** > **Auth Tokens**.
 1. In your main Fluent Bit configuration file append the following:
 
 {% tabs %}
@@ -65,4 +65,4 @@ pipeline:
 
 ## References
 
-- [Dash0 documentation](https://www.dash0.com/documentation/dash0)
+- [Dash0 documentation](https://www.dash0.com/docs/dash0)

--- a/pipeline/outputs/plot.md
+++ b/pipeline/outputs/plot.md
@@ -4,7 +4,7 @@ description: Generate data file for GNU Plot
 
 # Plot
 
-The _Plot_ output plugin generates data files in a format compatible with [GNU Plot](https://www.gnuplot.info/) (`gnuplot`), a command-line graphing tool. This plugin lets you export your telemetry data for visualization and analysis using `gnuplot`.
+The _Plot_ output plugin generates data files in a format compatible with GNU Plot (`gnuplot`), a command-line graphing tool. This plugin lets you export your telemetry data for visualization and analysis using `gnuplot`.
 
 ## Configuration parameters
 

--- a/pipeline/outputs/stackdriver.md
+++ b/pipeline/outputs/stackdriver.md
@@ -222,7 +222,7 @@ This will produce the following log:
 
 This makes the `resource_labels` API the recommended choice for supporting new or existing resource types that have all resource labels known before runtime or available on the payload during runtime.
 
-For instance, for a Kubernetes resource type, `resource_labels` can be used in tandem with the [Kubernetes filter](../filters/kubernetes) to pack all six resource labels. The following example shows what this could look like for a `k8s_container` resource:
+For instance, for a Kubernetes resource type, `resource_labels` can be used in tandem with the [Kubernetes filter](../filters/kubernetes.md) to pack all six resource labels. The following example shows what this could look like for a `k8s_container` resource:
 
 {% tabs %}
 {% tab title="fluent-bit.yaml" %}

--- a/pipeline/outputs/stackdriver_special_fields.md
+++ b/pipeline/outputs/stackdriver_special_fields.md
@@ -62,7 +62,7 @@ For the special fields that map to `LogEntry` prototypes, add them as objects wi
 }
 ```
 
-Adding special fields to logs is best done through the [`modify` filter](../filters/modify) for basic fields, or [a Lua script using the `lua` filter](../filters/lua) for more complex fields.
+Adding special fields to logs is best done through the [`modify` filter](../filters/modify.md) for basic fields, or [a Lua script using the `lua` filter](../filters/lua.md) for more complex fields.
 
 ## Basic type special fields
 

--- a/pipeline/outputs/tcp-and-tls.md
+++ b/pipeline/outputs/tcp-and-tls.md
@@ -34,7 +34,7 @@ The following parameters are available to configure a secure channel connection 
 
 #### JSON format
 
-This example specifies gathering [CPU](../inputs/cpu-metrics) usage metrics and send them in JSON lines mode to a remote endpoint using netcat service.
+This example specifies gathering [CPU](../inputs/cpu-metrics.md) usage metrics and send them in JSON lines mode to a remote endpoint using netcat service.
 
 ```shell
 fluent-bit -i cpu -o tcp://127.0.0.1:5170 -p format=json_lines -v

--- a/pipeline/outputs/treasure-data.md
+++ b/pipeline/outputs/treasure-data.md
@@ -1,6 +1,6 @@
 # Treasure Data
 
-The _Treasure Data_ (TD) output plugin lets you flush your records into the [Treasure Data](https://treasuredata.com) cloud service.
+The _Treasure Data_ (TD) output plugin lets you flush your records into the [Treasure Data](https://www.treasure.ai/) cloud service.
 
 ## Configuration parameters
 


### PR DESCRIPTION
  - Fix 4 internal links missing .md extension (stackdriver, stackdriver_special_fields, tcp-and-tls)
  - Update Microsoft docs URL from docs.microsoft.com to learn.microsoft.com (azure_kusto)
  - Remove broken gnuplot hyperlink (plot)
  - Update Treasure Data URLs to treasure.ai (what-is-fluent-bit, treasure-data)
  - Update Google IAM workload identity federation URL (bigquery)
  - Update Dash0 documentation URLs (dash0)

  Fixes #2593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vendor resource links and references across multiple output plugin documentation pages for accuracy
  * Enhanced Azure Data Explorer authentication section with improved formatting and explicit workload identity token configuration guidance
  * Corrected internal documentation cross-reference links to include proper markdown file extensions for consistency
  * Updated Dash0 documentation references to point to current endpoints and resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->