### PR TITLE
docs: fix preserve_data_ordering typo in s3.md

### DIFF
--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -155,7 +155,7 @@ The S3 output plugin conforms to the Fluent Bit output plugin specification. Bec
 
 S3 uploads primarily initiate using the S3 [`timer`](https://docs.aws.amazon.com/iotevents/latest/apireference/API_iotevents-data_Timer.html) callback function, which runs separately from its `flush`.
 
-S3 has its own buffering system and its own callback to upload data, so the normal sequential data ordering of chunks provided by the Fluent Bit engine can be compromised. S3 has the `presevere_data_ordering` option which ensures data is uploaded in the original order it was collected by Fluent Bit.
+S3 has its own buffering system and its own callback to upload data, so the normal sequential data ordering of chunks provided by the Fluent Bit engine can be compromised. S3 has the `preserve_data_ordering` option which ensures data is uploaded in the original order it was collected by Fluent Bit.
 
 ### Summary: uniqueness in the Amazon S3 plugin
 


### PR DESCRIPTION
This PR fixes a typo in the S3 output documentation.

`presevere_data_ordering` is corrected to `preserve_data_ordering`, matching the actual Fluent Bit S3 output plugin configuration option documented in the configuration parameters table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the description of the `preserve_data_ordering` option in S3 output settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->