### PR TITLE
docs: pipeline: inputs: ebpf: add trace_dns trace type and field docs

### DIFF
--- a/pipeline/inputs/ebpf.md
+++ b/pipeline/inputs/ebpf.md
@@ -20,7 +20,7 @@ The plugin supports the following configuration parameters:
 |:----|:------------|:--------|
 | `poll_ms` | Set the polling interval in milliseconds for collecting events from the ring buffer. | `1000` |
 | `ringbuf_map_name` | Set the name of the eBPF ring buffer map to read events from. | `events` |
-| `trace` | Set the eBPF trace to enable (for example, `trace_bind`, `trace_exec`, `trace_malloc`, `trace_signal`, `trace_tcp`, `trace_vfs`). This parameter can be set multiple times to enable multiple traces. | _none_ |
+| `trace` | Set the eBPF trace to enable (for example, `trace_bind`, `trace_dns`, `trace_exec`, `trace_malloc`, `trace_signal`, `trace_tcp`, `trace_vfs`). This parameter can be set multiple times to enable multiple traces. | _none_ |
 
 ## System dependencies
 
@@ -210,3 +210,17 @@ The `trace_exec` trace includes these additional fields:
 | `argv_last` | Final captured argument when more than three are present. |
 | `argc` | Total number of arguments. |
 | `error_raw` | Error code for the operation (`0` indicates success). |
+
+### DNS trace fields
+
+The `trace_dns` trace captures DNS query and response events and includes these additional fields:
+
+| Field | Description |
+|:------|:------------|
+| `error_raw` | Error code for the operation (`0` indicates success). |
+| `latency_ns` | Round-trip latency in nanoseconds between query and response. |
+| `query` | Resolved DNS query name (for example, `example.com`). |
+| `query_type` | Numeric DNS query type (for example, `1` for IPv4 address (A record), `28` for IPv6 address (AAAA record)). |
+| `rcode` | DNS response code (`0` indicates no error). |
+| `response` | Set to `1` if the record is a DNS response; `0` if it's a query. |
+| `txid` | DNS transaction ID. |


### PR DESCRIPTION
  - Add trace_dns to the trace parameter example list
  - Add DNS trace fields section documenting error_raw, latency_ns, query, query_type, rcode, response, and txid fields

  Note: this update is for code change without corresponding doc PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated eBPF input documentation with DNS trace configuration example
* Added DNS trace fields reference section with details on error codes, latency metrics, DNS query/response data, and transaction tracking information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->