### PR TITLE
docs: pipeline: parsers: configuring-parser: add time_zone parameter

### DIFF
--- a/pipeline/parsers/configuring-parser.md
+++ b/pipeline/parsers/configuring-parser.md
@@ -26,6 +26,7 @@ Custom parsers support the following configuration parameters:
 | `time_key` | If the log entry provides a field with a timestamp, this option specifies the name of that field. | _none_ |
 | `time_offset` | Specifies a fixed UTC time offset (such as `-0600` or `+0200`) for local dates. | _none_ |
 | `time_strict` | If `true`, the parser is strict with the expected time format. If `false`, the parser is permissive with the format of the time. Set to `false` when the format expects a time fraction but the time to be parsed doesn't include it. | `true` |
+| `time_zone` | Specifies an [Internet Assigned Numbers Authority (IANA) timezone](https://www.iana.org/time-zones) name (for example, `America/New_York`, `Europe/Berlin`) to apply when the parsed timestamp contains no timezone information. Takes precedence over `time_offset` when both are set. | _none_ |
 | `time_system_timezone` | If there is no time zone (`%z`) specified in the given `time_format`, enabling this option will make the parser detect and use the system's configured time zone. The configured time zone is detected from the [`TZ` environment variable](https://sourceware.org/glibc/manual/latest/html_node/TZ-Variable.html). | `false` |
 | `types` | Specifies the data type of a parsed field. The syntax is `types <field_name_1>:<type_name_1> <field_name_2>:<type_name_2> ...`. The supported types are `string` (default), `integer`, `bool`, `float`, `hex`. | _none_ |
 


### PR DESCRIPTION
  - Document the time_zone parser configuration parameter, which supports IANA timezone names (for example, America/New_York, Europe/Berlin) for applying a timezone to timestamps that contain no timezone information.

  Note: this update is for code change without corresponding doc PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parser configuration documentation to include the `time_zone` parameter, which provides support for IANA timezone names and takes precedence over the `time_offset` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->