### PR TITLE
docs: pipeline: inputs: standard-input: add Windows support note

### DIFF
--- a/pipeline/inputs/standard-input.md
+++ b/pipeline/inputs/standard-input.md
@@ -13,6 +13,10 @@ fluent-bit -i stdin -o stdout
 
 If the `stdin` stream is closed (`end-of-file`), the plugin instructs Fluent Bit to exit with success (`0`) after flushing any pending output.
 
+{% hint style="info" %}
+Windows support for the `stdin` plugin was added in Fluent Bit v5.0.7. On Windows, the plugin reads from the standard input handle using native Win32 APIs.
+{% endhint %}
+
 ## Configuration parameters
 
 The plugin supports the following configuration parameters:


### PR DESCRIPTION
  - Document that the stdin plugin supports Windows as of v5.0.7

  Note: this update is for code change without corresponding doc PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Standard input plugin documentation to clarify Windows support and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->