### PR TITLE
pipeline: podman metrics: document exclude_name_regex option

### DIFF
--- a/pipeline/inputs/podman-metrics.md
+++ b/pipeline/inputs/podman-metrics.md
@@ -12,6 +12,7 @@ The metrics can be exposed later as, for example, Prometheus counters and gauges
 
 | Key               | Description                                                                                             | Default                                                          |
 |-------------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| `exclude_name_regex` | Excludes containers whose name matches this regular expression, evaluated before metrics are collected. Use it to skip Podman pod infrastructure containers, for example `-(infra|service)$` to skip pause and `catatonit` containers. When unset, all containers are collected. | _none_ |
 | `path.config`     | Custom path to the Podman containers configuration file.                                                | `/var/lib/containers/storage/overlay-containers/containers.json` |
 | `path.procfs`     | Custom path to the `proc` subsystem directory.                                                          | `/proc`                                                          |
 | `path.sysfs`      | Custom path to the `sysfs` subsystem directory.                                                         | `/sys/fs/cgroup`                                                 |


### PR DESCRIPTION
## Summary

Documents the new `exclude_name_regex` configuration option for the
`in_podman_metrics` (Podman metrics) input plugin.

Companion to the code change in fluent/fluent-bit#11970.

The option skips containers whose name matches a user-supplied regular
expression before their metrics are collected, for example
`exclude_name_regex '-(infra|service)$'` to skip Podman pod infrastructure
(pause / `catatonit`) containers. It defaults to unset, so existing behaviour
(collect every container) is unchanged.

## Change

Adds an `exclude_name_regex` row to the Configuration parameters table in
`pipeline/inputs/podman-metrics.md`.

---

Signed-off-by: Stefano Tondo <stondo@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration parameter to exclude containers by name using regular expression patterns before metrics collection. When unset, all containers are included.

* **Documentation**
  * Updated Podman metrics input documentation with new container exclusion option details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->