### PR TITLE
docs: pipeline: fix classic config key casing to Title_Case

### DIFF
--- a/pipeline/filters/grep.md
+++ b/pipeline/filters/grep.md
@@ -79,7 +79,7 @@ pipeline:
 
 ```text
 [SERVICE]
-  parsers_file /path/to/parsers.conf
+  Parsers_File /path/to/parsers.conf
 
 [INPUT]
   Name   tail

--- a/pipeline/filters/kubernetes.md
+++ b/pipeline/filters/kubernetes.md
@@ -660,8 +660,8 @@ pipeline:
 [FILTER]
     Name                    kubernetes
     Match                   kube.*
-    aws_use_pod_association true
-    set_platform            eks
+    Aws_Use_Pod_Association true
+    Set_Platform            eks
 ```
 
 {% endtab %}

--- a/pipeline/inputs/elasticsearch.md
+++ b/pipeline/inputs/elasticsearch.md
@@ -91,13 +91,13 @@ pipeline:
 
 ```text
 [INPUT]
-  name   elasticsearch
-  listen 0.0.0.0
-  port   9200
+  Name   elasticsearch
+  Listen 0.0.0.0
+  Port   9200
 
 [OUTPUT]
-  name  stdout
-  match *
+  Name  stdout
+  Match *
 ```
 
 {% endtab %}
@@ -127,15 +127,15 @@ pipeline:
 
 ```text
 [INPUT]
-  name              elasticsearch
-  listen            0.0.0.0
-  port              9200
-  buffer_max_size   20M
-  buffer_chunk_size 5M
+  Name              elasticsearch
+  Listen            0.0.0.0
+  Port              9200
+  Buffer_Max_Size   20M
+  Buffer_Chunk_Size 5M
 
 [OUTPUT]
-  name  stdout
-  match *
+  Name  stdout
+  Match *
 ```
 
 {% endtab %}

--- a/pipeline/inputs/fluentbit-metrics.md
+++ b/pipeline/inputs/fluentbit-metrics.md
@@ -100,19 +100,19 @@ pipeline:
 # $ curl http://127.0.0.1:2021/metrics
 #
 [SERVICE]
-  flush           1
-  log_level       info
+  Flush           1
+  Log_Level       info
 
 [INPUT]
-  name            fluentbit_metrics
-  tag             internal_metrics
-  scrape_interval 2
+  Name            fluentbit_metrics
+  Tag             internal_metrics
+  Scrape_Interval 2
 
 [OUTPUT]
-  name            prometheus_exporter
-  match           internal_metrics
-  host            0.0.0.0
-  port            2021
+  Name            prometheus_exporter
+  Match           internal_metrics
+  Host            0.0.0.0
+  Port            2021
 ```
 
 {% endtab %}

--- a/pipeline/inputs/kubernetes-events.md
+++ b/pipeline/inputs/kubernetes-events.md
@@ -73,17 +73,17 @@ pipeline:
 
 ```text
 [SERVICE]
-  flush           1
-  log_level       info
+  Flush           1
+  Log_Level       info
 
 [INPUT]
-  name            kubernetes_events
-  tag             k8s_events
-  kube_url        https://kubernetes.default.svc
+  Name            kubernetes_events
+  Tag             k8s_events
+  Kube_URL        https://kubernetes.default.svc
 
 [OUTPUT]
-  name            stdout
-  match           *
+  Name            stdout
+  Match           *
 ```
 
 {% endtab %}

--- a/pipeline/inputs/node-exporter-metrics.md
+++ b/pipeline/inputs/node-exporter-metrics.md
@@ -158,19 +158,19 @@ pipeline:
 # $ curl http://127.0.0.1:2021/metrics
 #
 [SERVICE]
-  flush           1
-  log_level       info
+  Flush           1
+  Log_Level       info
 
 [INPUT]
-  name            node_exporter_metrics
-  tag             node_metrics
-  scrape_interval 2
+  Name            node_exporter_metrics
+  Tag             node_metrics
+  Scrape_Interval 2
 
 [OUTPUT]
-  name            prometheus_exporter
-  match           node_metrics
-  host            0.0.0.0
-  port            2021
+  Name            prometheus_exporter
+  Match           node_metrics
+  Host            0.0.0.0
+  Port            2021
 
 
 ```

--- a/pipeline/inputs/process-exporter-metrics.md
+++ b/pipeline/inputs/process-exporter-metrics.md
@@ -130,19 +130,19 @@ pipeline:
 # $ curl http://127.0.0.1:2021/metrics
 #
 [SERVICE]
-  flush           1
-  log_level       info
+  Flush           1
+  Log_Level       info
 
 [INPUT]
-  name            process_exporter_metrics
-  tag             process_metrics
-  scrape_interval 2
+  Name            process_exporter_metrics
+  Tag             process_metrics
+  Scrape_Interval 2
 
 [OUTPUT]
-  name            prometheus_exporter
-  match           process_metrics
-  host            0.0.0.0
-  port            2021
+  Name            prometheus_exporter
+  Match           process_metrics
+  Host            0.0.0.0
+  Port            2021
 ```
 
 {% endtab %}

--- a/pipeline/inputs/prometheus-remote-write.md
+++ b/pipeline/inputs/prometheus-remote-write.md
@@ -65,14 +65,14 @@ pipeline:
 
 ```text
 [INPUT]
-  name prometheus_remote_write
-  listen 127.0.0.1
-  port 8080
-  uri /api/prom/push
+  Name prometheus_remote_write
+  Listen 127.0.0.1
+  Port 8080
+  Uri /api/prom/push
 
 [OUTPUT]
-  name stdout
-  match *
+  Name stdout
+  Match *
 ```
 
 {% endtab %}

--- a/pipeline/inputs/prometheus-scrape-metrics.md
+++ b/pipeline/inputs/prometheus-scrape-metrics.md
@@ -51,16 +51,16 @@ pipeline:
 
 ```text
 [INPUT]
-  name prometheus_scrape
-  host 0.0.0.0
-  port 8201
-  tag vault
-  metrics_path /v1/sys/metrics?format=prometheus
-  scrape_interval 10s
+  Name prometheus_scrape
+  Host 0.0.0.0
+  Port 8201
+  Tag vault
+  Metrics_Path /v1/sys/metrics?format=prometheus
+  Scrape_Interval 10s
 
 [OUTPUT]
-  name stdout
-  match *
+  Name stdout
+  Match *
 ```
 
 {% endtab %}

--- a/pipeline/inputs/tail.md
+++ b/pipeline/inputs/tail.md
@@ -217,8 +217,8 @@ pipeline:
 
 ```text
 [INPUT]
-  name              tail
-  path              /var/log/containers/*.log
+  Name              tail
+  Path              /var/log/containers/*.log
   multiline.parser  docker, cri
 ```
 
@@ -464,9 +464,9 @@ pipeline:
 
 ```text
 [INPUT]
-  name    tail
-  path    /var/log/containers/*.log
-  db      test.db
+  Name    tail
+  Path    /var/log/containers/*.log
+  DB      test.db
 ```
 
 {% endtab %}

--- a/pipeline/inputs/windows-exporter-metrics.md
+++ b/pipeline/inputs/windows-exporter-metrics.md
@@ -141,19 +141,19 @@ pipeline:
 # $ curl http://127.0.0.1:2021/metrics
 #
 [SERVICE]
-  flush           1
-  log_level       info
+  Flush           1
+  Log_Level       info
 
 [INPUT]
-  name            windows_exporter_metrics
-  tag             node_metrics
-  scrape_interval 2
+  Name            windows_exporter_metrics
+  Tag             node_metrics
+  Scrape_Interval 2
 
 [OUTPUT]
-  name            prometheus_exporter
-  match           node_metrics
-  host            0.0.0.0
-  port            2021
+  Name            prometheus_exporter
+  Match           node_metrics
+  Host            0.0.0.0
+  Port            2021
 ```
 
 {% endtab %}
@@ -191,8 +191,8 @@ pipeline:
 
 ```text
 [INPUT]
-  name                        windows_exporter_metrics
-  tag                         windows_metrics
+  Name                        windows_exporter_metrics
+  Tag                         windows_metrics
   we.logical_disk.allow_disk_regex ^(C|D):$
 ```
 
@@ -221,8 +221,8 @@ pipeline:
 
 ```text
 [INPUT]
-  name            windows_exporter_metrics
-  tag             windows_metrics
+  Name            windows_exporter_metrics
+  Tag             windows_metrics
   we.net.allow_nic_regex (Ethernet|Wi-Fi)
 ```
 
@@ -251,8 +251,8 @@ pipeline:
 
 ```text
 [INPUT]
-  name                      windows_exporter_metrics
-  tag                       windows_metrics
+  Name                      windows_exporter_metrics
+  Tag                       windows_metrics
   we.process.deny_process_regex (System|Idle|svchost)
 ```
 
@@ -380,10 +380,10 @@ pipeline:
 
 ```text
 [INPUT]
-  name            windows_exporter_metrics
-  tag             windows_metrics
-  metrics         cpu,memory,logical_disk
-  scrape_interval 5
+  Name            windows_exporter_metrics
+  Tag             windows_metrics
+  Metrics         cpu,memory,logical_disk
+  Scrape_Interval 5
 ```
 
 {% endtab %}
@@ -414,9 +414,9 @@ pipeline:
 
 ```text
 [INPUT]
-  name                        windows_exporter_metrics
-  tag                         windows_metrics
-  scrape_interval             10
+  Name                        windows_exporter_metrics
+  Tag                         windows_metrics
+  Scrape_Interval             10
   collector.cpu.scrape_interval 5
   collector.memory.scrape_interval 5
   collector.system.scrape_interval 60
@@ -443,16 +443,16 @@ Example configuration:
 
 ```text
 [SERVICE]
-    flush_interval 3
-    http_server    on
-    http_port      2020
-    log_level      debug
+    Flush_Interval 3
+    HTTP_Server    on
+    HTTP_Port      2020
+    Log_Level      debug
 
 [INPUT]
-    name             windows_exporter_metrics
-    tag              windows
-    scrape_interval  2
-    metrics          cpu,logical_disk,memory,performancecounter
+    Name             windows_exporter_metrics
+    Tag              windows
+    Scrape_Interval  2
+    Metrics          cpu,logical_disk,memory,performancecounter
 
     PerformanceCounter process_fluent_bit_thread_count=\Process(fluent-bit)\Thread Count
     PerformanceCounter gpu_3d_utilization=\GPU Engine(*engtype_3D)\Utilization Percentage
@@ -460,7 +460,7 @@ Example configuration:
     PerformanceCounter gpu_video_decode_utilization=\GPU Engine(*engtype_VideoDecode)\Utilization Percentage
 
 [OUTPUT]
-    name stdout
+    Name stdout
 ```
 
 This configuration creates metrics like:


### PR DESCRIPTION
Classic config examples for plugins should use Title_Case keys, but several were authored with lowercase keys copied from their YAML tabs. Fix plain keys while leaving dotted/namespaced keys lowercase per convention.

  - Input plugins updated: elasticsearch, fluentbit-metrics, kubernetes-events, node-exporter-metrics, process-exporter-metrics, prometheus-remote-write, prometheus-scrape-metrics, tail, windows-exporter-metrics
  - Filter plugins updated: grep (parsers_file), kubernetes (aws_use_pod_association, set_platform)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fluent Bit configuration examples across input and filter guides to use consistent capitalization and formatting for section headers and directives.
  * Improved clarity and consistency for service, input, and output configuration snippets without changing their example values or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->