### PR TITLE
oauth2: adding new `client_secret_file` parameter to http and opentelemetry

### DIFF
--- a/administration/configuring-fluent-bit/yaml/pipeline-section.md
+++ b/administration/configuring-fluent-bit/yaml/pipeline-section.md
@@ -185,6 +185,7 @@ Output plugins that support outgoing `OAuth 2.0` authentication can expose the f
 | `oauth2.token_url` | Token endpoint URL. | _none_ |
 | `oauth2.client_id` | Client ID. | _none_ |
 | `oauth2.client_secret` | Client secret. | _none_ |
+| `oauth2.client_secret_file` | Optional client_secret file path. | _none_ |
 | `oauth2.scope` | Optional scope parameter. | _none_ |
 | `oauth2.audience` | Optional audience parameter. | _none_ |
 | `oauth2.resource` | Optional resource parameter. | _none_ |

--- a/administration/configuring-fluent-bit/yaml/pipeline-section.md
+++ b/administration/configuring-fluent-bit/yaml/pipeline-section.md
@@ -185,7 +185,7 @@ Output plugins that support outgoing `OAuth 2.0` authentication can expose the f
 | `oauth2.token_url` | Token endpoint URL. | _none_ |
 | `oauth2.client_id` | Client ID. | _none_ |
 | `oauth2.client_secret` | Client secret. | _none_ |
-| `oauth2.client_secret_file` | Optional client_secret file path. | _none_ |
+| `oauth2.client_secret_file` | Optional path to a file containing the client secret. Overrides `oauth2.client_secret`. | _none_ |
 | `oauth2.scope` | Optional scope parameter. | _none_ |
 | `oauth2.audience` | Optional audience parameter. | _none_ |
 | `oauth2.resource` | Optional resource parameter. | _none_ |

--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -38,7 +38,7 @@ The _HTTP_ output plugin lets you flush your records into an HTTP endpoint. It i
 | `oauth2.auth_method` | `OAuth 2.0` client authentication method. Supported values: `basic`, `post`, `private_key_jwt`. | `basic` |
 | `oauth2.client_id` | `OAuth 2.0` client ID. | _none_ |
 | `oauth2.client_secret` | `OAuth 2.0` client secret. | _none_ |
-| `oauth2.client_secret_file` | Optional `OAuth 2.0` client_secret file path. | _none_ |
+| `oauth2.client_secret_file` | Optional path to a file containing the `OAuth 2.0` client secret. Overrides `oauth2.client_secret`. | _none_ |
 | `oauth2.connect_timeout` | Connect timeout for `OAuth 2.0` token requests. | `0s` |
 | `oauth2.enable` | Enable `OAuth 2.0` client credentials for outgoing requests. | `false` |
 | `oauth2.jwt_aud` | Audience for `private_key_jwt` JSON Web Token (JWT) assertion. Defaults to the value of `oauth2.token_url` when not set. | _none_ |

--- a/pipeline/outputs/http.md
+++ b/pipeline/outputs/http.md
@@ -38,6 +38,7 @@ The _HTTP_ output plugin lets you flush your records into an HTTP endpoint. It i
 | `oauth2.auth_method` | `OAuth 2.0` client authentication method. Supported values: `basic`, `post`, `private_key_jwt`. | `basic` |
 | `oauth2.client_id` | `OAuth 2.0` client ID. | _none_ |
 | `oauth2.client_secret` | `OAuth 2.0` client secret. | _none_ |
+| `oauth2.client_secret_file` | Optional `OAuth 2.0` client_secret file path. | _none_ |
 | `oauth2.connect_timeout` | Connect timeout for `OAuth 2.0` token requests. | `0s` |
 | `oauth2.enable` | Enable `OAuth 2.0` client credentials for outgoing requests. | `false` |
 | `oauth2.jwt_aud` | Audience for `private_key_jwt` JSON Web Token (JWT) assertion. Defaults to the value of `oauth2.token_url` when not set. | _none_ |

--- a/pipeline/outputs/opentelemetry.md
+++ b/pipeline/outputs/opentelemetry.md
@@ -124,7 +124,7 @@ pipeline:
 | `oauth2.auth_method` | `OAuth 2.0` client authentication method. Supported values: `basic`, `post`, `private_key_jwt`. | `basic` |
 | `oauth2.client_id` | `OAuth 2.0` client ID. | _none_ |
 | `oauth2.client_secret` | `OAuth 2.0` client secret. | _none_ |
-| `oauth2.client_secret_file` | Optional `OAuth 2.0` client_secret file path. | _none_ |
+| `oauth2.client_secret_file` | Optional path to a file containing the `OAuth 2.0` client secret. Overrides `oauth2.client_secret`. | _none_ |
 | `oauth2.connect_timeout` | Connect timeout for `OAuth 2.0` token requests. | `0s` |
 | `oauth2.enable` | Enable `OAuth 2.0` client credentials for outgoing requests. | `false` |
 | `oauth2.jwt_aud` | Audience for `private_key_jwt` JSON Web Token (JWT) assertion. Defaults to the value of `oauth2.token_url` when not set. | _none_ |

--- a/pipeline/outputs/opentelemetry.md
+++ b/pipeline/outputs/opentelemetry.md
@@ -124,6 +124,7 @@ pipeline:
 | `oauth2.auth_method` | `OAuth 2.0` client authentication method. Supported values: `basic`, `post`, `private_key_jwt`. | `basic` |
 | `oauth2.client_id` | `OAuth 2.0` client ID. | _none_ |
 | `oauth2.client_secret` | `OAuth 2.0` client secret. | _none_ |
+| `oauth2.client_secret_file` | Optional `OAuth 2.0` client_secret file path. | _none_ |
 | `oauth2.connect_timeout` | Connect timeout for `OAuth 2.0` token requests. | `0s` |
 | `oauth2.enable` | Enable `OAuth 2.0` client credentials for outgoing requests. | `false` |
 | `oauth2.jwt_aud` | Audience for `private_key_jwt` JSON Web Token (JWT) assertion. Defaults to the value of `oauth2.token_url` when not set. | _none_ |


### PR DESCRIPTION
Add `oauth2.client_secret_file` to http and opentelemetry property tables.

Related to: https://github.com/fluent/fluent-bit/pull/12118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the optional `oauth2.client_secret_file` setting for Fluent Bit pipeline outputs.
  * Clarified that `oauth2.client_secret_file` overrides `oauth2.client_secret` when provided.
  * Updated HTTP and OpenTelemetry output plugin configuration details to include this new OAuth 2.0 option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->