### PR TITLE
docs: pipeline: inputs: tcp: udp: forward: document workers option

### DIFF
--- a/pipeline/inputs/forward.md
+++ b/pipeline/inputs/forward.md
@@ -25,6 +25,7 @@ The plugin supports the following configuration parameters:
 | `threaded`          | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).                                                                                                                                                                                                                                    | `false`   |
 | `unix_path`         | Specify the path to Unix socket to receive a Forward message. If set, `listen` and `port` are ignored.                                                                                                                                                                                                                                     | _none_    |
 | `unix_perm`         | Set the permission of the Unix socket file. If `unix_path` isn't set, this parameter is ignored.                                                                                                                                                                                                                                           | _none_    |
+| `workers`           | The number of listener workers that accept and process incoming connections. Not supported with `unix_path`; a value greater than `1` while `unix_path` is set causes startup to fail.                                                                                                                                                     | `1`       |
 
 ### TLS / SSL
 

--- a/pipeline/inputs/tcp.md
+++ b/pipeline/inputs/tcp.md
@@ -21,6 +21,7 @@ The plugin supports the following configuration parameters:
 | `separator`          | When `format` is set to `none`, Fluent Bit needs a separator string to split the records.                                                                                                                                                                 | `LF` or `0x10` (break line) |
 | `source_address_key` | Specify the key to inject the source address.                                                                                                                                                                                                             | _none_                      |
 | `threaded`           | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).                                                                                                                                                   | `false`                     |
+| `workers`            | The number of listener workers that accept and process incoming connections on the port.                                                                                                                                                                  | `1`                         |
 
 ## Get started
 

--- a/pipeline/inputs/udp.md
+++ b/pipeline/inputs/udp.md
@@ -21,6 +21,7 @@ The plugin supports the following configuration parameters:
 | `separator`          | When `format` is set to `none`, Fluent Bit needs a separator string to split the records.                                                                                                            | `LF` or `0x10` (break line) |
 | `source_address_key` | Specify the key where the source address will be injected.                                                                                                                                           | _none_                      |
 | `threaded`           | Indicates whether to run this input in its own [thread](../../administration/multithreading.md#inputs).                                                                                              | `false`                     |
+| `workers`            | The number of listener workers that receive and process incoming datagrams on the port.                                                                                                              | `1`                         |
 
 ## Get started
 


### PR DESCRIPTION
Document the workers option (default 1) that sets the number of listener workers for the TCP, UDP, and Forward inputs. Note that Forward doesn't support workers > 1 together with unix_path.

Note this is from a code merge that did not submit a doc PR.