### PR TITLE
docs: administration: http-proxy: document tls.proxy.* options

### DIFF
--- a/administration/http-proxy.md
+++ b/administration/http-proxy.md
@@ -40,10 +40,10 @@ When `HTTP_PROXY`/`http_proxy` uses the `https` scheme, Fluent Bit establishes a
 
 | Key | Description | Default |
 | --- | ----------- | ------- |
-| `tls.proxy.ca_file` | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`, which verifies the destination's certificate. Only applies to output plugins. _Supported in v5.1 or later._ | _none_ |
-| `tls.proxy.ca_path` | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Only applies to output plugins. _Supported in v5.1 or later._ | _none_ |
-| `tls.proxy.verify` | Force certificate validation for the HTTPS proxy connection. Only applies to output plugins. _Supported in v5.1 or later._ | `on` |
-| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Only applies to output plugins. _Supported in v5.1 or later._ | `on` |
+| `tls.proxy.ca_file` | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`, which verifies the destination's certificate. Only applies to output plugins. Supported in v5.1 or later. | _none_ |
+| `tls.proxy.ca_path` | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Only applies to output plugins. Supported in v5.1 or later. | _none_ |
+| `tls.proxy.verify` | Force certificate validation for the HTTPS proxy connection. Only applies to output plugins. Supported in v5.1 or later. | `on` |
+| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Only applies to output plugins. Supported in v5.1 or later. | `on` |
 
 {% hint style="info" %}
 
@@ -84,12 +84,14 @@ pipeline:
   Match              *
   Host               backend.example.com
   Port               443
-  tls                on
+  Tls                on
   tls.proxy.ca_file  /etc/certs/proxy-ca.crt
 ```
 
 {% endtab %}
 {% endtabs %}
+
+Then set the proxy environment variable to the HTTPS proxy:
 
 ```text
 HTTP_PROXY='https://proxy.example.com:3129'

--- a/administration/http-proxy.md
+++ b/administration/http-proxy.md
@@ -6,8 +6,9 @@ description: Enable traffic through a proxy server using the HTTP_PROXY environm
 
 Fluent Bit supports configuring an HTTP proxy for all egress HTTP/HTTPS traffic using the `HTTP_PROXY` or `http_proxy` environment variable.
 
-The format for the HTTP proxy environment variable is `http://USER:PASS@HOST:PORT`, where:
+The format for the HTTP proxy environment variable is `SCHEME://USER:PASS@HOST:PORT`, where:
 
+- _`SCHEME`_ is either `http` or `https`. Use `https` when the connection to the proxy itself must be TLS-encrypted, for example when the proxy sits behind a corporate TLS-terminating gateway. There's no separate `HTTPS_PROXY` environment variable: the scheme lives inside the same `HTTP_PROXY`/`http_proxy` value. See [TLS to the proxy](#tls-to-the-proxy) to configure certificate verification for this connection.
 - _`USER`_ is the username when using basic authentication.
 - _`PASS`_ is the password when using basic authentication.
 - _`HOST`_ is the HTTP proxy hostname or IP address.
@@ -32,6 +33,67 @@ The `HTTP_PROXY` environment variable is a [standard way](https://docs.docker.co
 The [HTTP output plugin](../pipeline/outputs/http.md) also supports configuring an HTTP proxy. This configuration works, but shouldn't be used with the `HTTP_PROXY` or `http_proxy` environment variable. The environment variable-based proxy configuration is implemented by creating a TCP connection tunnel using [HTTP CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/CONNECT). Unlike the plugin's implementation, this supports both HTTP and HTTPS egress traffic.
 
 {% endhint %}
+
+## TLS to the proxy
+
+When `HTTP_PROXY`/`http_proxy` uses the `https` scheme, Fluent Bit establishes a TLS connection to the proxy itself before issuing the `HTTP CONNECT` request described previously. This proxy-side TLS connection is configured independently from the destination's own `tls.*` settings (see [TLS/SSL](transport-security.md)), using a dedicated set of properties:
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `tls.proxy.ca_file` | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`, which verifies the destination's certificate. Only applies to output plugins. _Supported in v5.1 or later._ | _none_ |
+| `tls.proxy.ca_path` | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Only applies to output plugins. _Supported in v5.1 or later._ | _none_ |
+| `tls.proxy.verify` | Force certificate validation for the HTTPS proxy connection. Only applies to output plugins. _Supported in v5.1 or later._ | `on` |
+| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Only applies to output plugins. _Supported in v5.1 or later._ | `on` |
+
+{% hint style="info" %}
+
+`tls.proxy.*` properties are set on the output plugin, the same way as `tls.*` properties. When `tls.proxy.ca_file` and `tls.proxy.ca_path` are both left unset, Fluent Bit falls back to the system's default trust store to verify the HTTPS proxy's certificate.
+
+{% endhint %}
+
+For example, to reach an HTTPS proxy signed by a private or corporate CA:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
+```yaml
+pipeline:
+  inputs:
+    - name: cpu
+      tag: cpu
+
+  outputs:
+    - name: http
+      match: '*'
+      host: backend.example.com
+      port: 443
+      tls: on
+      tls.proxy.ca_file: /etc/certs/proxy-ca.crt
+```
+
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
+[INPUT]
+  Name  cpu
+  Tag   cpu
+
+[OUTPUT]
+  Name               http
+  Match              *
+  Host               backend.example.com
+  Port               443
+  tls                on
+  tls.proxy.ca_file  /etc/certs/proxy-ca.crt
+```
+
+{% endtab %}
+{% endtabs %}
+
+```text
+HTTP_PROXY='https://proxy.example.com:3129'
+```
 
 ## `NO_PROXY`
 

--- a/administration/networking.md
+++ b/administration/networking.md
@@ -69,7 +69,7 @@ The following table describes the network configuration properties available and
 | `net.dns.resolver`              | Select the primary DNS resolver type (`LEGACY` or `ASYNC`).                                                        | _none_  |
 | `net.keepalive_max_recycle`     | Set maximum number of times a keepalive connection can be used before it's retired.                                | `2000`  |
 | `net.max_worker_connections`    | Set maximum number of TCP connections that can be established per worker.                                          | `0`     |
-| `net.proxy_env_ignore`          | Ignore the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` when set.                              | `false` |
+| `net.proxy_env_ignore`          | Ignore the `HTTP_PROXY`/`http_proxy` and `NO_PROXY`/`no_proxy` environment variables when set.                     | `false` |
 | `net.tcp_keepalive`             | Enable or disable Keepalive support.                                                                               | `off`   |
 | `net.tcp_keepalive_time`        | Interval between the last data packet sent and the first TCP keepalive probe.                                      | `-1`    |
 | `net.tcp_keepalive_interval`    | Interval between TCP keepalive probes when no response is received on a `keepidle` probe.                          | `-1`    |

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -24,6 +24,10 @@ Both input and output plugins that perform Network I/O can optionally enable TLS
 | `tls.key_passwd`      | Optional password for `tls.key_file` file.                                                                                              | _none_  |
 | `tls.max_version`     | Specify the maximum version of TLS.                                                                                                     | _none_  |
 | `tls.min_version`     | Specify the minimum version of TLS.                                                                                                     | _none_  |
+| `tls.proxy.ca_file`       | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`, which verifies the destination's certificate. Only applies to output plugins connecting through an HTTPS proxy. See [HTTP proxy](http-proxy.md). Supported in v5.1 or later. | _none_  |
+| `tls.proxy.ca_path`       | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | _none_  |
+| `tls.proxy.verify`        | Force certificate validation for the HTTPS proxy connection. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | `on`    |
+| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | `on`    |
 | `tls.verify`              | Force certificate validation.                                                                                                           | `on`    |
 | `tls.vhost`               | Hostname to be used for TLS SNI extension.                                                                                              | _none_  |
 | `tls.verify_hostname`     | Force TLS verification of host names.                                                                                                   | `off`   |

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -12,26 +12,26 @@ Both NPN and ALPN are used when client and server are establishing SSL/TLS conne
 
 Both input and output plugins that perform Network I/O can optionally enable TLS and configure the behavior. The following table describes the properties available:
 
-| Property              | Description                                                                                                                             | Default |
-|:----------------------|:----------------------------------------------------------------------------------------------------------------------------------------|:--------|
-| `tls`                 | Enable or disable TLS support.                                                                                                          | `off`   |
-| `tls.debug`           | Set TLS debug verbosity level. Accepted values: `0` (No debug), `1` (Error), `2` (State change), `3` (Informational) and `4` (Verbose). | `1`     |
-| `tls.ca_file`         | Absolute path to CA certificate file.                                                                                                   | _none_  |
-| `tls.ca_path`         | Absolute path to scan for certificate files.                                                                                            | _none_  |
-| `tls.ciphers`         | Specify TLS ciphers up to TLSv1.2.                                                                                                      | _none_  |
-| `tls.crt_file`        | Absolute path to Certificate file.                                                                                                      | _none_  |
-| `tls.key_file`        | Absolute path to private Key file.                                                                                                      | _none_  |
-| `tls.key_passwd`      | Optional password for `tls.key_file` file.                                                                                              | _none_  |
-| `tls.max_version`     | Specify the maximum version of TLS.                                                                                                     | _none_  |
-| `tls.min_version`     | Specify the minimum version of TLS.                                                                                                     | _none_  |
-| `tls.proxy.ca_file`       | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`, which verifies the destination's certificate. Only applies to output plugins connecting through an HTTPS proxy. See [HTTP proxy](http-proxy.md). Supported in v5.1 or later. | _none_  |
-| `tls.proxy.ca_path`       | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | _none_  |
-| `tls.proxy.verify`        | Force certificate validation for the HTTPS proxy connection. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | `on`    |
-| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | `on`    |
-| `tls.verify`              | Force certificate validation.                                                                                                           | `on`    |
-| `tls.vhost`               | Hostname to be used for TLS SNI extension.                                                                                              | _none_  |
-| `tls.verify_hostname`     | Force TLS verification of host names.                                                                                                   | `off`   |
-| `tls.verify_client_cert`  | Require and verify the TLS certificate presented by a connecting client. Enables mutual TLS (mTLS) for input plugins. Only applies to input plugins. | `off`   |
+| Property | Description | Default |
+| :--- | :--- | :--- |
+| `tls` | Enable or disable TLS support. | `off` |
+| `tls.debug` | Set TLS debug verbosity level. Accepted values: `0` (No debug), `1` (Error), `2` (State change), `3` (Informational) and `4` (Verbose). | `1` |
+| `tls.ca_file` | Absolute path to CA certificate file. | _none_ |
+| `tls.ca_path` | Absolute path to scan for certificate files. | _none_ |
+| `tls.ciphers` | Specify TLS ciphers up to TLSv1.2. | _none_ |
+| `tls.crt_file` | Absolute path to Certificate file. | _none_ |
+| `tls.key_file` | Absolute path to private Key file. | _none_ |
+| `tls.key_passwd` | Optional password for `tls.key_file` file. | _none_ |
+| `tls.max_version` | Specify the maximum version of TLS. | _none_ |
+| `tls.min_version` | Specify the minimum version of TLS. | _none_ |
+| `tls.proxy.ca_file` | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`, which verifies the destination's certificate. Only applies to output plugins connecting through an HTTPS proxy. See [HTTP proxy](http-proxy.md). Supported in v5.1 or later. | _none_ |
+| `tls.proxy.ca_path` | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | _none_ |
+| `tls.proxy.verify` | Force certificate validation for the HTTPS proxy connection. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | `on` |
+| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Only applies to output plugins connecting through an HTTPS proxy. Supported in v5.1 or later. | `on` |
+| `tls.verify` | Force certificate validation. | `on` |
+| `tls.vhost` | Hostname to be used for TLS SNI extension. | _none_ |
+| `tls.verify_hostname` | Force TLS verification of host names. | `off` |
+| `tls.verify_client_cert` | Require and verify the TLS certificate presented by a connecting client. Enables mutual TLS (mTLS) for input plugins. Only applies to input plugins. | `off` |
 
 {% hint style="info" %}
 

--- a/pipeline/outputs/azure_kusto.md
+++ b/pipeline/outputs/azure_kusto.md
@@ -120,7 +120,7 @@ By default, Kusto will insert incoming ingestion data into a table by inferring 
 | `net.keepalive_idle_timeout`           | Set maximum time allowed for an idle `Keepalive` connection..                | `false`                        |
 | `net.keepalive_max_recycle`            | Set maximum number of times a keepalive connection can be used before it's retried.                                                                  | `2000`                         |
 | `net.max_worker_connections`           | Set the maximum number of active TCP connections that can be used per worker thread.                                                                  | `0`                            |
-| `net.proxy_env_ignore`                 | Ignore the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` when set.                                                                 | `false`                        |
+| `net.proxy_env_ignore`                 | Ignore the `HTTP_PROXY`/`http_proxy` and `NO_PROXY`/`no_proxy` environment variables when set.                                                        | `false`                        |
 | `net.source_address`                   | Specify network address to bind for data traffic.                            | _none_                         |
 | `net.tcp_keepalive`                    | Enable or disable Keepalive support.                                         | `off`                          |
 | `net.tcp_keepalive_interval`           | Interval between TCP keepalive probes when no response is received on a `keepidle` probe.                                                               | `-1`                           |
@@ -144,6 +144,10 @@ By default, Kusto will insert incoming ingestion data into a table by inferring 
 | `tls.key_passwd`                       | Optional password for tls.key_file file.                                     | _none_                         |
 | `tls.max_version`                      | Specify the maximum version of TLS.                                          | _none_                         |
 | `tls.min_version`                      | Specify the minimum version of TLS.                                          | _none_                         |
+| `tls.proxy.ca_file`                    | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`. See [HTTP proxy](../../administration/http-proxy.md). Supported in v5.1 or later. | _none_                         |
+| `tls.proxy.ca_path`                    | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Supported in v5.1 or later. | _none_                         |
+| `tls.proxy.verify`                     | Force certificate validation for the HTTPS proxy connection. Supported in v5.1 or later. | `on`                           |
+| `tls.proxy.verify_hostname`            | Force hostname verification for the HTTPS proxy connection. Supported in v5.1 or later. | `on`                           |
 | `tls.verify`                           | Force certificate validation.                                                | `on`                           |
 | `tls.verify_hostname`                  | Enable or disable to verify hostname.                                        | `off`                          |
 | `tls.vhost`                            | Hostname to be used for TLS SNI extension.                                   | _none_                         |

--- a/pipeline/outputs/opentelemetry.md
+++ b/pipeline/outputs/opentelemetry.md
@@ -114,7 +114,7 @@ pipeline:
 | `net.io_timeout` | Set maximum time a connection can stay idle while assigned. | `0s` |
 | `net.keepalive_max_recycle` | Set maximum number of times a keepalive connection can be used before it retries. | `2000` |
 | `net.max_worker_connections` | Set the maximum number of active TCP connections that can be used per worker thread. | `0` |
-| `net.proxy_env_ignore` | Ignore the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` when set. | `false` |
+| `net.proxy_env_ignore` | Ignore the `HTTP_PROXY`/`http_proxy` and `NO_PROXY`/`no_proxy` environment variables when set. | `false` |
 | `net.source_address` | Specify network address to bind for data traffic. | _none_ |
 | `net.tcp_keepalive` | Enable or disable Keepalive support. | `off` |
 | `net.tcp_keepalive_interval` | Interval between TCP keepalive probes when no response is received on a `keepidle` probe. | `-1` |
@@ -151,6 +151,10 @@ pipeline:
 | `tls.key_passwd` | Optional password for tls.key_file. | _none_ |
 | `tls.max_version` | Specify the maximum version of TLS. | _none_ |
 | `tls.min_version` | Specify the minimum version of TLS. | _none_ |
+| `tls.proxy.ca_file` | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`. See [HTTP proxy](../../administration/http-proxy.md). Supported in v5.1 or later. | _none_ |
+| `tls.proxy.ca_path` | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Supported in v5.1 or later. | _none_ |
+| `tls.proxy.verify` | Force certificate validation for the HTTPS proxy connection. Supported in v5.1 or later. | `on` |
+| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Supported in v5.1 or later. | `on` |
 | `tls.verify` | Force certificate validation. | `on` |
 | `tls.verify_hostname` | Enable or disable to verify hostname. | `off` |
 | `tls.vhost` | Hostname to be used for TLS SNI extension. | _none_ |

--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -68,7 +68,7 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `net.io_timeout` | Set maximum time a connection can stay idle while assigned. | `0s` |
 | `net.keepalive_max_recycle` | Set maximum number of times a keepalive connection can be used before it retries. | `2000` |
 | `net.max_worker_connections` | Set the maximum number of active TCP connections that can be used per worker thread. | `0` |
-| `net.proxy_env_ignore` | Ignore the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` when set. | `false` |
+| `net.proxy_env_ignore` | Ignore the `HTTP_PROXY`/`http_proxy` and `NO_PROXY`/`no_proxy` environment variables when set. | `false` |
 | `net.source_address` | Specify network address to bind for data traffic. | _none_ |
 | `net.tcp_keepalive` | Enable or disable Keepalive support. | `off` |
 | `net.tcp_keepalive_interval` | Interval between TCP keepalive probes when no response is received on a `keepidle` probe. | `-1` |
@@ -102,6 +102,10 @@ The [Prometheus success/retry/error metrics values](../../administration/monitor
 | `tls.key_passwd` | Optional password for tls.key_file file. | _none_ |
 | `tls.max_version` | Specify the maximum version of TLS. | _none_ |
 | `tls.min_version` | Specify the minimum version of TLS. | _none_ |
+| `tls.proxy.ca_file` | Absolute path to the CA certificate file used to verify the HTTPS proxy's certificate. Independent from `tls.ca_file`. See [HTTP proxy](../../administration/http-proxy.md). Supported in v5.1 or later. | _none_ |
+| `tls.proxy.ca_path` | Absolute path to scan for CA certificate files used to verify the HTTPS proxy's certificate. Supported in v5.1 or later. | _none_ |
+| `tls.proxy.verify` | Force certificate validation for the HTTPS proxy connection. Supported in v5.1 or later. | `on` |
+| `tls.proxy.verify_hostname` | Force hostname verification for the HTTPS proxy connection. Supported in v5.1 or later. | `on` |
 | `tls.verify` | Force certificate validation. | `on` |
 | `tls.verify_hostname` | Enable or disable to verify hostname. | `off` |
 | `tls.vhost` | Hostname to be used for TLS SNI extension. | _none_ |


### PR DESCRIPTION
## Summary

Documents four new output-only config options landing in Fluent Bit 5.1 ([fluent/fluent-bit#11778](https://github.com/fluent/fluent-bit/pull/11778)): `tls.proxy.ca_file`, `tls.proxy.ca_path`, `tls.proxy.verify`, and `tls.proxy.verify_hostname`. These configure certificate verification for the *proxy* leg when an output plugin connects through an HTTPS proxy (`HTTP_PROXY=https://...`), independent from the destination's own `tls.*` settings.

## Changes

- **`administration/http-proxy.md`** (primary): clarifies that `HTTP_PROXY`/`http_proxy` can use either the `http` or `https` scheme — there's no separate `HTTPS_PROXY` variable — and adds a new **TLS to the proxy** section documenting the four new options plus a config example.
- **`administration/transport-security.md`**: adds the same four options to the shared `tls.*` properties table (alphabetically placed, annotated "Only applies to output plugins").
- **`pipeline/outputs/s3.md`, `opentelemetry.md`, `azure_kusto.md`**: add the same rows to each page's own inline `tls.*` table, matching their existing convention of repeating the full option list.
- **`administration/networking.md`** and the three plugin pages above: fixes `net.proxy_env_ignore`'s description, which referenced a non-existent `HTTPS_PROXY` environment variable — the scheme lives inside the same `HTTP_PROXY`/`http_proxy` value, not a separate variable. This was directly adjacent to (and would have contradicted) the new docs.

## Why these pages

Only pages that already carry TLS-relevant proxy content, or that duplicate the full `tls.*` table inline for a plugin where proxying is a realistic scenario (S3, OpenTelemetry, Azure Kusto — all HTTP(S)-API-style outputs), were touched. Most other output plugin pages just link out to `transport-security.md` for TLS docs and don't need a change.

## Notes for reviewers

- This PR should probably be merged in step with (or shortly after) [fluent/fluent-bit#11778](https://github.com/fluent/fluent-bit/pull/11778), which is currently milestoned for 5.1 and not yet merged. Happy to add the `waiting-on-code-merge` label if that's the right call.
- No `SUMMARY.md` changes — all edits are to existing pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified HTTP and HTTPS proxy URL formats and supported environment variables.
  * Added guidance for configuring TLS connections to HTTPS proxies, including custom CA certificates and certificate or hostname verification.
  * Documented HTTPS proxy settings for Azure Kusto, OpenTelemetry, and S3 outputs, including version support and configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->