### PR TITLE
docs: installation: linux: document service restart on package upgrade

### DIFF
--- a/installation/downloads/linux/debian.md
+++ b/installation/downloads/linux/debian.md
@@ -85,3 +85,17 @@ $ sudo service fluent-bit status
 The default Fluent Bit configuration collect metrics of CPU usage and sends the
 records to the standard output. You can see the outgoing data in your
 `/var/log/messages` file.
+
+## Upgrade Fluent Bit
+
+Upgrading the `fluent-bit` package reloads the `systemd` unit files and restarts the service, so the new version starts running as soon as the upgrade finishes.
+
+The restart applies only when the service is already running on a host that uses `systemd`. A stopped service stays stopped, and installing the package for the first time doesn't start it.
+
+If a restart isn't safe to take at that moment, stop the service before you upgrade the package and start it again when you're ready:
+
+```shell
+sudo systemctl stop fluent-bit
+sudo apt-get install --only-upgrade fluent-bit
+sudo systemctl start fluent-bit
+```

--- a/installation/downloads/linux/ubuntu.md
+++ b/installation/downloads/linux/ubuntu.md
@@ -85,3 +85,17 @@ $ systemctl status fluent-bit
 The default configuration of `fluent-bit` is collecting metrics of CPU usage and
 sending the records to the standard output. You can see the outgoing data in your
 `/var/log/syslog` file.
+
+## Upgrade Fluent Bit
+
+Upgrading the `fluent-bit` package reloads the `systemd` unit files and restarts the service, so the new version starts running as soon as the upgrade finishes.
+
+The restart applies only when the service is already running on a host that uses `systemd`. A stopped service stays stopped, and installing the package for the first time doesn't start it.
+
+If a restart isn't safe to take at that moment, stop the service before you upgrade the package and start it again when you're ready:
+
+```shell
+sudo systemctl stop fluent-bit
+sudo apt-get install --only-upgrade fluent-bit
+sudo systemctl start fluent-bit
+```


### PR DESCRIPTION
The deb postinst now runs systemctl daemon-reload and restarts the fluent-bit service when upgrading an existing installation.

Add an Upgrade Fluent Bit section to the Debian and Ubuntu pages noting that the restart applies only to upgrades, only on systemd hosts, and only when the service is already running, plus how to avoid an unplanned restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for Fluent Bit on Debian and Ubuntu.
  * Documented service restart behavior and commands for safely stopping, upgrading, and restarting the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->