### PR TITLE
docs: maintainers: Updated company references.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,11 +2,11 @@
 
 Fluent Bit is developed and supported by many individuals and companies. The following table list the names of maintainers per components and the company supporting their work.
 
-| Maintainer Name                                        | Documentation portion    | Company                                           |
-| :----------------------------------------------------  | ------------------------ | ------------------------------------------------- |
-| [Eduardo Silva](https://github.com/edsiper)            | All                      | [Chronosphere](https://chronosphere.io)           |
-| [Anurag Gupta](https://github.com/agup006)             | All                      | [Chronosphere](https://chronosphere.io)           |
-| [Jose Lecaros](https://github.com/lecaros)             | All                      | [Chronosphere](https://chronosphere.io)           |
-| [Paige Cruz](https://github.com/paigerduty)            | All                      | [Chronosphere](https://chronosphere.io/)          |
-| [Eric D. Schabell](https://github.com/eschabell)       | All                      | [Chronosphere](https://chronosphere.io/)          |
-| [Patrick Stephens](https://github.com/patrick-stephens)| All                      | [Telemetry Forge](https://telemetryforge.io)      |
+| Maintainer Name                                        | Documentation portion    | Company                                                 |
+| :----------------------------------------------------  | ------------------------ | ------------------------------------------------------- |
+| [Eduardo Silva](https://github.com/edsiper)            | All                      | [Palo Alto Networks](https://www.paloaltonetworks.com)  |
+| [Anurag Gupta](https://github.com/agup006)             | All                      | [Palo Alto Networks](https://www.paloaltonetworks.com)  |
+| [Jose Lecaros](https://github.com/lecaros)             | All                      | [Palo Alto Networks](https://www.paloaltonetworks.com)  |
+| [Paige Cruz](https://github.com/paigerduty)            | All                      | [Palo Alto Networks](https://www.paloaltonetworks.com)  |
+| [Eric D. Schabell](https://github.com/eschabell)       | All                      | [SUSE](https://www.suse.com/)                           |
+| [Patrick Stephens](https://github.com/patrick-stephens)| All                      | [Telemetry Forge](https://telemetryforge.io)            |


### PR DESCRIPTION
Bit overdue since the company does not exist anymore (acquisition).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated company links for five documentation maintainers to Palo Alto Networks.
  * Kept the SUSE maintainer entry unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->