### PR TITLE
docs: installation: downloads: docker: document Windows Server 2025 and Nano Server images

### DIFF
--- a/installation/downloads/docker.md
+++ b/installation/downloads/docker.md
@@ -221,7 +221,19 @@ The following table describes the Linux container tags that are available on Doc
 
 It's strongly suggested that you always use the latest image of Fluent Bit.
 
-Container images for Windows Server 2019 and Windows Server 2022 are provided for v2.0.6 and later. These can be found as tags on the same Docker Hub registry.
+Windows container images are provided on the same Docker Hub registry, tagged with a `windows-` prefix:
+
+| Tag pattern | Base image | Windows Server version |
+| --- | --- | --- |
+| `windows-2022-<version>` | Server Core | 2022 |
+| `windows-2025-<version>` | Server Core | 2025 |
+| `windows-nano-2025-<version>` | Nano Server | 2025 |
+
+Windows Server 2025 support, and the Nano Server image, are available in Fluent Bit version 5.1 and greater. Nano Server images are smaller than their Server Core counterparts, but don't include PowerShell and can't run plugins that shell out to external commands, such as `exec`. The Nano Server image ships with a default configuration that listens on the [Forward](../../pipeline/inputs/forward.md) input and writes to `stdout`, since there's no shell available to write one if needed.
+
+```shell
+docker pull cr.fluentbit.io/fluent/fluent-bit:windows-nano-2025-5.1.0
+```
 
 ## Multi-architecture images
 

--- a/vale-styles/FluentBit/Spelling-exceptions.txt
+++ b/vale-styles/FluentBit/Spelling-exceptions.txt
@@ -138,6 +138,7 @@ MTTx
 multiline
 multithreading
 Musl
+Nano
 namespace
 namespaces
 netcat


### PR DESCRIPTION
  - Replace stale Windows Server 2019/2022 claim with a tag table covering windows-2022, windows-2025, and windows-nano-2025 (new in 5.1)
  - Note Nano Server's PowerShell/exec-plugin limitations and its default Forward-to-stdout configuration
  - Drop the Windows Server 2019 claim, deprecated upstream well before this release and no longer built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows container documentation with tags for Server Core and Nano Server variants.
  * Added Windows Server 2025 and Nano Server availability details for Fluent Bit 5.1 and later.
  * Documented Nano Server limitations, default configuration, and an example image pull command.
* **Style**
  * Updated spelling rules to recognize “Nano” as a valid term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->