### PR TITLE
ci: run link checker on PRs

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: ${{ env.LYCHEE_ARGS }}
-          fail: true
+          fail: false
           jobSummary: true
 
   linkchecker-scheduled:

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,6 +1,7 @@
 name: Link checks
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "00 18 1 * *"
   pull_request:
@@ -29,7 +30,7 @@ jobs:
           jobSummary: true
 
   linkchecker-scheduled:
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name != 'pull_request' }}
     name: Monthly Link Checker
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -5,8 +5,32 @@ on:
     - cron: "00 18 1 * *"
   pull_request:
 
+permissions: {}
+
+env:
+  # Single definition to simplify any future changes to the linkcheck configuration.
+  LYCHEE_ARGS: --accept '100..=103,200..=299,401,403,429,999' --verbose --no-progress .
+
 jobs:
-  linkChecker:
+  linkchecker-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: PR - Link Checker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: ${{ env.LYCHEE_ARGS }}
+          fail: true
+          jobSummary: true
+
+  linkchecker-scheduled:
+    if: ${{ github.event_name == 'schedule' }}
+    name: Monthly Link Checker
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,13 +43,13 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept '100..=103,200..=299,401,403,429,999' --verbose --no-progress .
-          # Fail if PR is opened with broken links, but don't fail on scheduled runs.
-          fail: ${{ github.event_name == 'pull_request' }}
+          args: ${{ env.LYCHEE_ARGS }}
+          # Do not fail scheduled runs; report by issue when links are broken.
+          fail: false
           jobSummary: true
 
       - name: Create Issue From File
-        if: ${{ github.event_name != 'pull_request' && steps.lychee.outputs.exit_code != 0 }}
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -21,6 +21,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
@@ -39,6 +41,8 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,18 +1,17 @@
-name: Links
+name: Link checks
 
 on:
   schedule:
     - cron: "00 18 1 * *"
-
-# Uncomment the following line while testing links in a single PR. Recomment when
-# done. Be sure to comment out the 'Create Issue from File' section while testing.
-# pull_request
+  pull_request:
 
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     permissions:
-      issues: write # required for peter-evans/create-issue-from-file
+      contents: read
+      # required for peter-evans/create-issue-from-file
+      issues: write
     steps:
       - uses: actions/checkout@v7
 
@@ -21,13 +20,12 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --accept '100..=103,200..=299,401,403,429,999' --verbose --no-progress .
-          fail: false
+          # Fail if PR is opened with broken links, but don't fail on scheduled runs.
+          fail: ${{ github.event_name == 'pull_request' }}
           jobSummary: true
 
-# If testing links on pull_request, comment these lines out!
-
       - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
+        if: ${{ github.event_name != 'pull_request' && steps.lychee.outputs.exit_code != 0 }}
         uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -19,10 +19,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: ${{ env.LYCHEE_ARGS }}
           fail: true
@@ -37,11 +37,11 @@ jobs:
       # required for peter-evans/create-issue-from-file
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: ${{ env.LYCHEE_ARGS }}
           # Do not fail scheduled runs; report by issue when links are broken.
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Issue From File
         if: ${{ steps.lychee.outputs.exit_code != 0 }}
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# Ignore certain landing pages for link checking, these may change redirects to internally
+https://console.treasuredata.com/users/sign_in
+https://app.datadoghq.com/logs/activation
+# Ignore the redirects for Github logins when creating custom issues
+^https:\/\/github\.com\/fluent\/fluent-bit\/issues\/new\?.*

--- a/administration/transport-security.md
+++ b/administration/transport-security.md
@@ -35,7 +35,7 @@ Both input and output plugins that perform Network I/O can optionally enable TLS
 
 {% hint style="info" %}
 
-When the connection target is an IP address (IPv4 or IPv6), Fluent Bit doesn't include the TLS Server Name Indication (SNI) extension, which is consistent with [RFC 6066](https://www.rfc-editor.org/rfc/rfc6066). Certificate validation still applies against the IP address. If the server requires SNI or uses a hostname-based certificate, use a hostname as the connection target and set `tls.vhost` if needed.
+When the connection target is an IP address (IPv4 or IPv6), Fluent Bit doesn't include the TLS Server Name Indication (SNI) extension, which is consistent with [RFC 6066](https://www.rfc-editor.org/info/rfc6066/). Certificate validation still applies against the IP address. If the server requires SNI or uses a hostname-based certificate, use a hostname as the connection target and set `tls.vhost` if needed.
 
 {% endhint %}
 

--- a/installation/downloads/source.md
+++ b/installation/downloads/source.md
@@ -11,7 +11,7 @@ https://github.com/fluent/fluent-bit/archive/refs/tags/v&lt;release version&gt;.
 https://github.com/fluent/fluent-bit/archive/refs/tags/v&lt;release version&gt;.zip
 ```
 
-For example, for version 1.8.12 the link is: [https://github.com/fluent/fluent-bit/archive/refs/tags/v1.8.12.tar.gz](https://github.com/fluent/fluent-bit/archive/refs/tags/v1.8.12.tar.gz)
+For example, for version 1.8.12 the link is: [https://github.com/fluent/fluent-bit/archive/refs/tags/v1.8.12.tar.gz](https://codeload.github.com/fluent/fluent-bit/tar.gz/refs/tags/v1.8.12)
 
 ## Development
 

--- a/pipeline/outputs/dynatrace.md
+++ b/pipeline/outputs/dynatrace.md
@@ -83,7 +83,7 @@ pipeline:
 
 <!-- vale FluentBit.Simplicity = NO -->
 
-- [Dynatrace Fluent Bit documentation](https://docs.dynatrace.com/docs/shortlink/lma-stream-logs-with-fluent-bit)
+- [Dynatrace Fluent Bit documentation](https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-stream-logs-with-fluent-bit)
 - [Fluent Bit integration in Dynatrace Hub](https://www.dynatrace.com/hub/detail/fluent-bit/?filter=log-management-and-analytics)
 - [Video: Stream a Log File to Dynatrace using Fluent Bit](https://www.youtube.com/watch?v=JJJNxhtJ6R0)
 - [Blog: Easily stream logs from Fluent Bit to Dynatrace](https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-stream-logs-with-fluent-bit)

--- a/pipeline/outputs/kinesis.md
+++ b/pipeline/outputs/kinesis.md
@@ -132,7 +132,7 @@ You can use the Fluent Bit SSM Public Parameters to find the Amazon ECR image UR
 aws ssm get-parameters-by-path --path /aws/service/aws-for-fluent-bit/
 ```
 
-For more details, see the [Amazon ECR Public official doc](https://docs.aws.amazon.com/AmazonECR/latest/public/get-set-up-for-amazon-ecr.html).
+For more details, see the [Amazon ECR Public official doc](https://docs.aws.amazon.com/AmazonECR/latest/public/what-is-ecr.html).
 
 ### Docker Hub
 

--- a/pipeline/outputs/s3.md
+++ b/pipeline/outputs/s3.md
@@ -713,7 +713,7 @@ If you see errors for image pull limits, try signing in to public ECR with your 
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 ```
 
-See the [Amazon ECR Public official documentation](https://docs.aws.amazon.com/AmazonECR/latest/public/get-set-up-for-amazon-ecr.html) for more details.
+See the [Amazon ECR Public official documentation](https://docs.aws.amazon.com/AmazonECR/latest/public/what-is-ecr.html) for more details.
 
 ### Docker Hub
 

--- a/scripts/run-link-checker.sh
+++ b/scripts/run-link-checker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script is used to run the Lychee link checker in the same way that CI does in the GitHub Actions workflow.
+
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do
+  SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$SCRIPT_DIR/$SOURCE
+done
+SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+REPO_DIR=${REPO_DIR:-$SCRIPT_DIR/..}
+
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-"ghcr.io/lycheeverse/lychee:latest"}
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+
+# Always pull the latest Lychee image to ensure we are validating against the most recent version.
+if ! $CONTAINER_RUNTIME pull "$CONTAINER_IMAGE" &>/dev/null; then
+    echo "ERROR: Failed to pull container image $CONTAINER_IMAGE" >&2
+    exit 1
+fi
+
+# Matches the values in the GitHub Actions workflow for consistency.
+LYCHEE_ARGS=${LYCHEE_ARGS:-"--accept '100..=103,200..=299,401,403,429,999' --verbose --no-progress ."}
+
+# Run the Lychee link checker in a container with the same arguments as the GitHub Actions workflow.
+# Note we do want arguments to be expanded here, so we don't quote $LYCHEE_ARGS.
+# shellcheck disable=SC2086
+"$CONTAINER_RUNTIME" run --init -it -v "$REPO_DIR":/input:ro -e GITHUB_TOKEN="${GITHUB_TOKEN:-}" "$CONTAINER_IMAGE" $LYCHEE_ARGS

--- a/stream-processing/tutorial.md
+++ b/stream-processing/tutorial.md
@@ -7,7 +7,7 @@ Follow this tutorial to learn more about stream processing.
 This tutorial requires the following components:
 
 * Fluent Bit
-* [Docker Engine](https://www.docker.com/products/docker-engine)
+* Container runtime, e.g. [Docker Engine](https://www.docker.com/)
 * A stream processing [sample file](https://raw.githubusercontent.com/fluent/fluent-bit-docs/37b477786d6e28eb223e08611c26ec93671a34ac/stream-processing/samples/sp-samples-1k.log)
 
 ## Steps

--- a/stream-processing/tutorial.md
+++ b/stream-processing/tutorial.md
@@ -7,7 +7,7 @@ Follow this tutorial to learn more about stream processing.
 This tutorial requires the following components:
 
 * Fluent Bit
-* Container runtime, e.g. [Docker Engine](https://www.docker.com/)
+* [Docker Engine](https://docs.docker.com/engine/) and the `docker` CLI
 * A stream processing [sample file](https://raw.githubusercontent.com/fluent/fluent-bit-docs/37b477786d6e28eb223e08611c26ec93671a34ac/stream-processing/samples/sp-samples-1k.log)
 
 ## Steps


### PR DESCRIPTION
Set up CI to run link checker on PRs but also manually if required - manual runs will create an issue but PRs will only generate a report on the job when it is run.
Fixed a few redirects and excluded some others.
We do not fail on error as quite often these are timeout, bot detection and other errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated link checking for pull requests and scheduled runs.
  * Scheduled checks can create issues when broken links are detected.
  * Excluded known non-checkable pages from automated link validation.

* **Documentation**
  * Updated source download, Dynatrace, Amazon ECR Public, Docker, and RFC reference links to current destinations.
  * Clarified Docker as the container runtime requirement in the tutorial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->