### PR TITLE
pipeline: inputs: add AegisBPF input plugin

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -77,6 +77,7 @@
 ## Data pipeline
 
 * [Inputs](pipeline/inputs.md)
+  * [AegisBPF](pipeline/inputs/aegisbpf.md)
   * [Blob](pipeline/inputs/blob.md)
   * [Collectd](pipeline/inputs/collectd.md)
   * [CPU metrics](pipeline/inputs/cpu-metrics.md)

--- a/pipeline/inputs/aegisbpf.md
+++ b/pipeline/inputs/aegisbpf.md
@@ -4,30 +4,27 @@
 **Supported event types:** `logs`
 {% endhint %}
 
-The _AegisBPF_ input plugin streams runtime-security events from a co-located
-[AegisBPF](https://github.com/ErenAri/Aegis-BPF) agent into the Fluent Bit
-pipeline. AegisBPF is a BPF-LSM enforcement agent that exposes an opt-in,
-root-only Unix control socket; the plugin connects to it, requests the event
-stream, and forwards each newline-delimited JSON (OCSF) security event as a
-record. It reconnects automatically if the agent restarts.
+The _AegisBPF_ input plugin streams runtime-security events from a co-located [AegisBPF](https://github.com/ErenAri/Aegis-BPF) agent into the Fluent Bit pipeline. This plugin is available only for Linux.
+
+AegisBPF is a Berkeley Packet Filter (BPF) Linux Security Module (LSM) enforcement agent that exposes an opt-in, root-only Unix control socket. The plugin connects to that socket, requests the event stream, and forwards each newline-delimited JSON Open Cybersecurity Schema Framework (OCSF) security event as a record. It reconnects automatically if the agent restarts.
 
 ## Configuration parameters
 
 The plugin supports the following configuration parameters:
 
-| Key             | Description                                                                 | Default                            |
-|-----------------|-----------------------------------------------------------------------------|------------------------------------|
-| `socket_path`   | Path to the AegisBPF control socket (a root-only Unix stream socket).       | `/var/run/aegisbpf/aegisbpf.sock`  |
-| `reconnect_sec` | Interval in seconds between reconnection attempts while disconnected.       | `2`                                |
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `reconnect_sec` | Interval in seconds between reconnection attempts while disconnected. | `2` |
+| `socket_path` | Path to the AegisBPF control socket (a root-only Unix stream socket). | `/var/run/aegisbpf/aegisbpf.sock` |
 
 ## Prerequisites
 
-- The AegisBPF agent must run with its control socket enabled, for example
-  `AEGIS_API_SOCKET=/var/run/aegisbpf/aegisbpf.sock`.
-- The socket is created with `0600` permissions and owned by the agent (root),
-  so Fluent Bit must run as the same user (typically root) to connect.
+- The AegisBPF agent must run with its control socket enabled, for example `AEGIS_API_SOCKET=/var/run/aegisbpf/aegisbpf.sock`.
+- The socket is created with `0600` permissions and owned by the agent (root), so Fluent Bit must run as the same user (typically root) to connect.
 
 ## Get started
+
+You can run the plugin from the command line or through the configuration file:
 
 ### Command line
 
@@ -37,26 +34,36 @@ fluent-bit -i aegisbpf -p socket_path=/var/run/aegisbpf/aegisbpf.sock -o stdout
 
 ### Configuration file
 
+In your configuration file append the following:
+
+{% tabs %}
+{% tab title="fluent-bit.yaml" %}
+
 ```yaml
 pipeline:
   inputs:
     - name: aegisbpf
       socket_path: /var/run/aegisbpf/aegisbpf.sock
+
   outputs:
     - name: stdout
       match: '*'
 ```
 
-```ini
+{% endtab %}
+{% tab title="fluent-bit.conf" %}
+
+```text
 [INPUT]
-    name         aegisbpf
-    socket_path  /var/run/aegisbpf/aegisbpf.sock
+  Name        aegisbpf
+  Socket_Path /var/run/aegisbpf/aegisbpf.sock
 
 [OUTPUT]
-    name         stdout
-    match        *
+  Name  stdout
+  Match *
 ```
 
-Each security event is emitted as a single record whose body is the JSON object
-sent by the agent (AegisBPF emits OCSF-formatted events by default). The record
-timestamp is the time the event was received.
+{% endtab %}
+{% endtabs %}
+
+Each security event is emitted as a single record whose body is the JSON object sent by the agent (AegisBPF emits OCSF-formatted events by default). The record timestamp is the time the event was received.

--- a/pipeline/inputs/aegisbpf.md
+++ b/pipeline/inputs/aegisbpf.md
@@ -1,0 +1,62 @@
+# AegisBPF
+
+{% hint style="info" %}
+**Supported event types:** `logs`
+{% endhint %}
+
+The _AegisBPF_ input plugin streams runtime-security events from a co-located
+[AegisBPF](https://github.com/ErenAri/Aegis-BPF) agent into the Fluent Bit
+pipeline. AegisBPF is a BPF-LSM enforcement agent that exposes an opt-in,
+root-only Unix control socket; the plugin connects to it, requests the event
+stream, and forwards each newline-delimited JSON (OCSF) security event as a
+record. It reconnects automatically if the agent restarts.
+
+## Configuration parameters
+
+The plugin supports the following configuration parameters:
+
+| Key             | Description                                                                 | Default                            |
+|-----------------|-----------------------------------------------------------------------------|------------------------------------|
+| `socket_path`   | Path to the AegisBPF control socket (a root-only Unix stream socket).       | `/var/run/aegisbpf/aegisbpf.sock`  |
+| `reconnect_sec` | Interval in seconds between reconnection attempts while disconnected.       | `2`                                |
+
+## Prerequisites
+
+- The AegisBPF agent must run with its control socket enabled, for example
+  `AEGIS_API_SOCKET=/var/run/aegisbpf/aegisbpf.sock`.
+- The socket is created with `0600` permissions and owned by the agent (root),
+  so Fluent Bit must run as the same user (typically root) to connect.
+
+## Get started
+
+### Command line
+
+```shell
+fluent-bit -i aegisbpf -p socket_path=/var/run/aegisbpf/aegisbpf.sock -o stdout
+```
+
+### Configuration file
+
+```yaml
+pipeline:
+  inputs:
+    - name: aegisbpf
+      socket_path: /var/run/aegisbpf/aegisbpf.sock
+  outputs:
+    - name: stdout
+      match: '*'
+```
+
+```ini
+[INPUT]
+    name         aegisbpf
+    socket_path  /var/run/aegisbpf/aegisbpf.sock
+
+[OUTPUT]
+    name         stdout
+    match        *
+```
+
+Each security event is emitted as a single record whose body is the JSON object
+sent by the agent (AegisBPF emits OCSF-formatted events by default). The record
+timestamp is the time the event was received.

--- a/scripts/test-config.sh
+++ b/scripts/test-config.sh
@@ -44,6 +44,8 @@ SUPPRESSED_FILES=(
     # Not currently supported in the container image.
     "pipeline/filters/tensorflow.md"
     "pipeline/inputs/ebpf.md"
+    # Not yet present in the released validation image.
+    "pipeline/inputs/aegisbpf.md"
     # Windows plugins are not available in the Linux image.
     "installation/downloads/windows.md"
     "pipeline/inputs/windows-event-log-winevtlog.md"

--- a/vale-styles/FluentBit/Headings.yml
+++ b/vale-styles/FluentBit/Headings.yml
@@ -7,6 +7,7 @@ match: $sentence
 indicators:
   - ':'
 exceptions:
+  - AegisBPF
   - AlmaLinux
   - Amazon
   - Amazon CloudWatch

--- a/vale-styles/FluentBit/Spelling-exceptions.txt
+++ b/vale-styles/FluentBit/Spelling-exceptions.txt
@@ -42,6 +42,7 @@ coroutines
 cron
 Crowdstrike
 CRDs
+Cybersecurity
 DaemonSet
 Dash0
 Datadog


### PR DESCRIPTION
Documents the `aegisbpf` input plugin proposed in fluent/fluent-bit#12272.

Adds `pipeline/inputs/aegisbpf.md` (configuration parameters, prerequisites, CLI + YAML + classic config examples) and the nav entry in `SUMMARY.md`.

The plugin streams runtime-security events from a co-located [AegisBPF](https://github.com/ErenAri/Aegis-BPF) BPF-LSM agent over its Unix control socket (`GET /events` → newline-delimited OCSF JSON) into the pipeline.

> Companion to the code PR fluent/fluent-bit#12272 — happy to hold this until that merges, or adjust as the code is reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the AegisBPF input plugin, including supported events, configuration options, prerequisites, examples, reconnection behavior, and emitted records.
  * Added AegisBPF to the Data pipeline input plugin table of contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->