### PR TITLE
fix: update PA URLs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @fluent/fluent-bit-maintainers @eschabell
+* @fluent/fluent-bit-maintainers @eschabell @patrick-stephens

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ If you are upgrading from the Fluent Bit `4.2` series, start with [What's new in
 
 Fluent Bit is a [CNCF](https://www.cncf.io/) graduated sub-project under the umbrella of [Fluentd](https://www.fluentd.org).
 
-Fluent Bit was originally created by [Eduardo Silva](https://www.linkedin.com/in/edsiper) and is now sponsored by [Chronosphere](https://chronosphere.io/). As a CNCF-hosted project, it's a fully vendor-neutral and community-driven project.
+Fluent Bit was originally created by [Eduardo Silva](https://www.linkedin.com/in/edsiper) and is now sponsored by [Palo Alto Networks](https://www.paloaltonetworks.com).
+As a CNCF-hosted project, it's a fully vendor-neutral and community-driven project.
 
 ## License
 

--- a/about/resources.md
+++ b/about/resources.md
@@ -8,9 +8,9 @@ description: An overview of free public labs for learning how to successfully us
 
 To use these lab resources to their full extent, you'll need to [install](../installation/downloads.md) resources in your local environment to test and run Fluent Bit.
 
-## O11y workshops by Chronosphere
+## Observability (O11y) workshops
 
-Chronosphere provides several [open source observability workshops](https://o11y-workshops.gitlab.io/), including a Fluent Bit workshop:
+One of the maintainers, [Eric Schabell](https://www.schabell.org/), provides several [open source observability workshops](https://o11y-workshops.gitlab.io/), including a Fluent Bit workshop:
 
 {% embed url="https://o11y-workshops.gitlab.io/workshop-fluentbit/" %}
 Fluent Bit workshop for getting started with cloud native telemetry pipelines

--- a/installation/downloads.md
+++ b/installation/downloads.md
@@ -50,4 +50,4 @@ Fluent Bit can run on Berkeley Software Distribution (BSD) systems and IBM Z Lin
 
 ## Enterprise providers
 
-Fluent Bit packages are also provided by [enterprise providers](https://fluentbit.io/enterprise/) for older end-of-life versions, Unix systems, or for additional support and features including aspects (such as CVE backporting).
+Fluent Bit packages are also provided by [enterprise providers](https://fluentbit.io/enterprise/) for older end-of-life versions, Unix systems, or for additional support and features including aspects such as CVE backporting.


### PR DESCRIPTION
Minor changes to URLs to point at Palo Alto instead of Chronosphere to match maintainers.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sponsorship information in the Fluent Bit, Fluentd, and CNCF overview.
  * Renamed and refreshed the Observability workshop section, including updated attribution.
  * Clarified the enterprise provider description in the downloads documentation.
  * Added an additional maintainer to the project’s code ownership records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->