### PR TITLE
docs: administration: monitoring: correct filter metric name

### DIFF
--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -196,7 +196,7 @@ Some metrics are available only for specific plugins or runtime modes. For examp
 | Metric Name | Labels | Description | Type | Unit |
 | ----------- | ------ | ----------- | ---- | ---- |
 | `fluentbit_build_info` | hostname: the hostname, version: the version of Fluent Bit, os: OS type | Build version information. The value is the Unix epoch timestamp of the configuration context initialization. | gauge | seconds |
-| `fluentbit_filter_added_records_total` | name: the name or alias for the filter instance | The number of log records added by the filter into the data pipeline. | counter | records |
+| `fluentbit_filter_add_records_total` | name: the name or alias for the filter instance | The number of log records added by the filter into the data pipeline. | counter | records |
 | `fluentbit_filter_bytes_total` | name: the name or alias for the filter instance | The number of bytes of log records that this filter instance has ingested successfully. | counter | bytes |
 | `fluentbit_filter_drop_records_total` | name: the name or alias for the filter instance | The number of log records dropped by the filter and removed from the data pipeline. | counter | records |
 | `fluentbit_filter_records_total` | name: the name or alias for the filter instance | The number of log records this filter has ingested successfully. | counter | records |


### PR DESCRIPTION
## Summary

- Correct the filter metric name in `administration/monitoring.md`.
- Rename `fluentbit_filter_added_records_total` to `fluentbit_filter_add_records_total`.

## Evidence

The Fluent Bit source registers this counter with the namespace `fluentbit`, subsystem `filter`, and metric name `add_records_total`, producing `fluentbit_filter_add_records_total`.

See:
- https://github.com/fluent/fluent-bit/blob/3713988105fffaded9899d2914a42e04ed0e57e7/src/flb_filter.c#L626-L632
- https://github.com/fluent/fluent-bit/blob/3713988105fffaded9899d2914a42e04ed0e57e7/src/flb_filter.c#L274-L287

## Testing

- Documentation-only change.
- `git diff --check` passed.
- Configuration validation could not complete because Docker was unavailable to pull `fluent/fluent-bit:latest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v2 metrics documentation to reflect the corrected name for the filter records metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->