### PR TITLE
docs: administration: monitoring: document filter drop_bytes metric

### DIFF
--- a/administration/monitoring.md
+++ b/administration/monitoring.md
@@ -198,6 +198,7 @@ Some metrics are available only for specific plugins or runtime modes. For examp
 | `fluentbit_build_info` | hostname: the hostname, version: the version of Fluent Bit, os: OS type | Build version information. The value is the Unix epoch timestamp of the configuration context initialization. | gauge | seconds |
 | `fluentbit_filter_added_records_total` | name: the name or alias for the filter instance | The number of log records added by the filter into the data pipeline. | counter | records |
 | `fluentbit_filter_bytes_total` | name: the name or alias for the filter instance | The number of bytes of log records that this filter instance has ingested successfully. | counter | bytes |
+| `fluentbit_filter_drop_bytes_total` | name: the name or alias for the filter instance | The number of bytes of log records dropped by the filter and removed from the data pipeline. | counter | bytes |
 | `fluentbit_filter_drop_records_total` | name: the name or alias for the filter instance | The number of log records dropped by the filter and removed from the data pipeline. | counter | records |
 | `fluentbit_filter_records_total` | name: the name or alias for the filter instance | The number of log records this filter has ingested successfully. | counter | records |
 | `fluentbit_hot_reloaded_times` | hostname: the hostname on running Fluent Bit | Collect the count of hot reloaded times. | counter | times |


### PR DESCRIPTION
  Add the missing fluentbit_filter_drop_bytes_total row to the v2 metrics
  table. The counter is registered in src/flb_filter.c but was absent from
  the documented filter metrics.

Signed-off-by: Eric D. Schabell <eric@schabell.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the `fluentbit_filter_drop_bytes_total` metric, which reports the number of log-record bytes dropped by filters and removed from the data pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->