### PR TITLE
docs: pipeline: outputs: forward: fix redirecting Fluentd installation link

### DIFF
--- a/pipeline/outputs/forward.md
+++ b/pipeline/outputs/forward.md
@@ -56,7 +56,7 @@ When using Secure Forward mode, the [TLS](../../administration/transport-securit
 
 ## Forward setup
 
-Before proceeding, ensure that [Fluentd](https://www.fluentd.org) is installed. If it's not, refer to the [Fluentd Installation](https://docs.fluentd.org/installation) document.
+Before proceeding, ensure that [Fluentd](https://www.fluentd.org) is installed. If it's not, refer to the [Fluentd Installation](https://docs.fluentd.org/installation/) document.
 
 After installing Fluentd, create the following configuration file example which lets you to stream data into it:
 


### PR DESCRIPTION
  - Update https://docs.fluentd.org/installation to the canonical
    trailing-slash URL to avoid a 301 redirect

  Fixes #2686

Signed-off-by: Eric D. Schabell <eric@schabell.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Fluentd Installation link in the Forward setup instructions to use the correct URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->