### PR TITLE
docs: pipeline: outputs: gcs: correct Workload Identity Federation version to 5.1.2

### DIFF
--- a/pipeline/outputs/gcs.md
+++ b/pipeline/outputs/gcs.md
@@ -42,7 +42,7 @@ The metadata server isn't a fallback for a failed credentials file. It's used on
 
 {% hint style="info" %}
 
-Workload Identity Federation is available in Fluent Bit version 5.1.3 and greater.
+Workload Identity Federation is available in Fluent Bit version 5.1.2 and greater.
 
 {% endhint %}
 


### PR DESCRIPTION
  The v5.1.2 tag contains fluent-bit 9782dcb52, which added Workload
  Identity Federation support, so the feature shipped in 5.1.2 rather
  than 5.1.3.

Signed-off-by: Eric D. Schabell <eric@schabell.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documented minimum Fluent Bit version required for Workload Identity Federation from 5.1.3 to 5.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->