### PR TITLE
docs: installation: downloads: docker: add 5.1.2 container image tags

### DIFF
--- a/installation/downloads/docker.md
+++ b/installation/downloads/docker.md
@@ -42,6 +42,8 @@ The following table describes the Linux container tags that are available on Doc
 
 | Tags | Manifest Architectures | Description |
 | ------------ | ------------------------- | -------------------------------------------------------------- |
+| 5.1.2-debug | amd64, arm64, arm/v7 | Debug images |
+| 5.1.2 | amd64, arm64, arm/v7 | Release [v5.1.2](https://fluentbit.io/announcements/v5.1.2/) |
 | 5.1.1-debug | amd64, arm64, arm/v7 | Debug images |
 | 5.1.1 | amd64, arm64, arm/v7 | Release [v5.1.1](https://fluentbit.io/announcements/v5.1.1/) |
 | 5.1.0-debug | amd64, arm64, arm/v7 | Debug images |


### PR DESCRIPTION
  The v5.1.2 release is published and the fluent/fluent-bit 5.1.2 and
  5.1.2-debug images are available on Docker Hub.

  - Add 5.1.2 and 5.1.2-debug rows to the Linux container tag table
  - Record the manifest architectures as amd64, arm64, and arm/v7,
    matching the published images
  - Link the release row to the v5.1.2 announcement

Signed-off-by: Eric D. Schabell <eric@schabell.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux container images for Fluent Bit 5.1.2, including standard and debug variants.
  * Both images support amd64, arm64, and arm/v7 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->